### PR TITLE
feat: Extension Host sidecar PoC — spawn Node.js & run handshake via named pipe (Phase 0-2)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3981,8 +3981,21 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4341,6 +4354,8 @@ dependencies = [
  "tauri-plugin-fs",
  "tauri-plugin-os",
  "tauri-plugin-shell",
+ "tokio",
+ "uuid",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,3 +22,5 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 hostname = "0.4"
 dirs = "6"
+tokio = { version = "1", features = ["net", "process", "io-util", "rt", "macros", "time"] }
+uuid = { version = "1", features = ["v4"] }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -6,6 +6,8 @@
 //! Tauri commands — the Rust equivalent of VS Code's `ICommonNativeHostService`.
 //! These are exposed to the WebView via `window.__TAURI__.invoke()`.
 
+pub mod spawn_exthost;
+
 use serde::Serialize;
 
 /// Basic native host information for the workbench bootstrap.

--- a/src-tauri/src/commands/spawn_exthost.rs
+++ b/src-tauri/src/commands/spawn_exthost.rs
@@ -1,0 +1,162 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) VS Codee Contributors. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+//! Tauri command to spawn an Extension Host sidecar and run the handshake.
+//!
+//! This is the WebView-facing entry point for Phase 0-2 PoC verification.
+//! It creates a named pipe, spawns Node.js with the Extension Host, and
+//! runs the Ready→InitData→Initialized handshake protocol.
+//!
+//! # TODO: Production (Phase 1-2)
+//!
+//! Replace this single command with a `SidecarManager` exposed via multiple
+//! Tauri commands (`exthost_spawn`, `exthost_kill`, `exthost_status`) that
+//! manage ExtHost lifecycle through Tauri managed state. The WebSocket relay
+//! will replace direct Rust-side handshake handling.
+
+use std::path::PathBuf;
+
+use serde::Serialize;
+
+/// Result of the Extension Host spawn + handshake operation.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExtHostHandshakeResult {
+    /// Whether the handshake completed successfully.
+    pub success: bool,
+    /// The named pipe / Unix socket path used for communication.
+    pub pipe_path: String,
+    /// PID of the spawned Node.js Extension Host process.
+    pub ext_host_pid: u32,
+    /// Time taken for the handshake in milliseconds.
+    pub handshake_duration_ms: u64,
+    /// Human-readable log of each protocol message exchanged.
+    pub messages_exchanged: Vec<String>,
+    /// Error message if the handshake failed.
+    pub error: Option<String>,
+}
+
+/// Spawn an Extension Host process as a Node.js sidecar and run the handshake.
+///
+/// Creates a named pipe, spawns `node out/bootstrap-fork.js --type=extensionHost`,
+/// and executes the Ready→InitData→Initialized handshake protocol.
+/// After a successful handshake, the ExtHost process is killed (PoC cleanup).
+///
+/// # Prerequisites
+/// - `npm run compile` must have been run (populates `out/` directory)
+/// - System `node` ≥ 18 must be on PATH
+#[tauri::command]
+pub async fn spawn_extension_host(
+    app_handle: tauri::AppHandle,
+) -> Result<ExtHostHandshakeResult, String> {
+    #[cfg(not(unix))]
+    {
+        let _ = app_handle;
+        return Err(
+            "Extension Host sidecar is only supported on Unix (macOS/Linux) in the PoC.".into(),
+        );
+    }
+
+    #[cfg(unix)]
+    {
+        spawn_extension_host_unix(app_handle).await
+    }
+}
+
+#[cfg(unix)]
+async fn spawn_extension_host_unix(
+    app_handle: tauri::AppHandle,
+) -> Result<ExtHostHandshakeResult, String> {
+    let app_root = resolve_app_root(&app_handle)?;
+    println!("[exthost] App root: {}", app_root.display());
+
+    // Verify prerequisites
+    let bootstrap_path = app_root.join("out/bootstrap-fork.js");
+    if !bootstrap_path.exists() {
+        return Err(format!(
+            "out/bootstrap-fork.js not found at {}. Run `npm run compile` first.",
+            bootstrap_path.display()
+        ));
+    }
+
+    match spawn_and_handshake(&app_root).await {
+        Ok(result) => Ok(result),
+        Err(e) => Ok(ExtHostHandshakeResult {
+            success: false,
+            pipe_path: String::new(),
+            ext_host_pid: 0,
+            handshake_duration_ms: 0,
+            messages_exchanged: vec![],
+            error: Some(e.to_string()),
+        }),
+    }
+}
+
+#[cfg(unix)]
+async fn spawn_and_handshake(
+    app_root: &std::path::Path,
+) -> Result<ExtHostHandshakeResult, crate::exthost::ExtHostError> {
+    use crate::exthost;
+    // Step 1+2: Create pipe + spawn Node.js
+    let (mut sidecar, mut stream) = exthost::sidecar::spawn(app_root).await?;
+
+    let pid = sidecar.child.id().unwrap_or(0);
+    let pipe_path = sidecar.pipe_path.clone();
+
+    // Step 3: Run handshake
+    let handshake = exthost::handshake::run_handshake(&mut stream).await?;
+
+    // PoC: Kill the child process after successful handshake and reap it
+    // to avoid zombie processes.
+    let _ = sidecar.child.kill().await;
+    let _ = sidecar.child.wait().await;
+    println!("[exthost] ExtHost process terminated (PoC cleanup)");
+
+    Ok(ExtHostHandshakeResult {
+        success: true,
+        pipe_path,
+        ext_host_pid: pid,
+        handshake_duration_ms: handshake.duration_ms,
+        messages_exchanged: handshake.messages,
+        error: None,
+    })
+}
+
+/// Resolve the VS Code repository root (where `out/` and `product.json` live).
+///
+/// In dev mode (`cargo tauri dev`), walks up from the resource directory to find
+/// a directory containing `out/bootstrap-fork.js`. Falls back to CWD.
+fn resolve_app_root(app_handle: &tauri::AppHandle) -> Result<PathBuf, String> {
+    use tauri::Manager;
+
+    let resource_dir = app_handle
+        .path()
+        .resource_dir()
+        .map_err(|e| format!("Failed to resolve resource dir: {e}"))?;
+
+    // Walk up from resource dir to find the repo root
+    let mut candidate = resource_dir.as_path();
+    for _ in 0..5 {
+        if candidate.join("out/bootstrap-fork.js").exists() {
+            return Ok(candidate.to_path_buf());
+        }
+        if let Some(parent) = candidate.parent() {
+            candidate = parent;
+        } else {
+            break;
+        }
+    }
+
+    // Fallback: try current working directory
+    let cwd = std::env::current_dir().map_err(|e| format!("No CWD: {e}"))?;
+    if cwd.join("out/bootstrap-fork.js").exists() {
+        return Ok(cwd);
+    }
+
+    Err(format!(
+        "Cannot find repo root with out/bootstrap-fork.js. Searched from: {}",
+        resource_dir.display()
+    ))
+}

--- a/src-tauri/src/exthost/handshake.rs
+++ b/src-tauri/src/exthost/handshake.rs
@@ -1,0 +1,185 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) VS Codee Contributors. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+//! Extension Host handshake state machine.
+//!
+//! Orchestrates the Ready→InitData→Initialized exchange over the connected socket.
+//!
+//! Sequence (mirrors `connectToRenderer()` at `extensionHostProcess.ts:332-395`):
+//! 1. Read `Resume` — PersistentProtocol sends this immediately upon construction
+//! 2. Read `Ready` (body=`[0x02]`) — ExtHost signals it's ready for init data
+//! 3. Write `InitData` (body=JSON) — Rust sends minimal IExtensionHostInitData
+//! 4. Read `Initialized` (body=`[0x01]`) — ExtHost confirms handshake complete
+//!
+//! # TODO: Production (Phase 1-2)
+//!
+//! In the clean architecture, the handshake is handled entirely by the TypeScript
+//! `TauriLocalProcessExtensionHost` via `PersistentProtocol` over WebSocket.
+//! This Rust-side handshake implementation becomes unnecessary (or debug-only).
+
+use std::time::Instant;
+
+use tokio::net::UnixStream;
+
+use super::protocol::{self, ProtocolMessage, ProtocolMessageType};
+use super::{init_data, ExtHostError};
+
+/// Result of a successful handshake.
+pub struct HandshakeResult {
+    /// Human-readable log of each message exchanged.
+    pub messages: Vec<String>,
+    /// Total handshake duration in milliseconds.
+    pub duration_ms: u64,
+}
+
+/// Application-level message types carried inside Regular transport messages.
+/// Mirrors `MessageType` at `extensionHostProtocol.ts:104-108`.
+const MESSAGE_TYPE_INITIALIZED: u8 = 0x01;
+const MESSAGE_TYPE_READY: u8 = 0x02;
+
+/// Run the Extension Host handshake protocol over a connected Unix stream.
+///
+/// Returns `Ok(HandshakeResult)` if the full 4-message exchange completes,
+/// or an `ExtHostError` on timeout, protocol violation, or IO error.
+pub async fn run_handshake(stream: &mut UnixStream) -> Result<HandshakeResult, ExtHostError> {
+    let start = Instant::now();
+    let mut messages = Vec::new();
+    let mut rust_msg_id: u32 = 0;
+    let mut last_exthost_msg_id: u32 = 0;
+
+    let (mut reader, mut writer) = stream.split();
+
+    // Step 1: Wait for Resume (may also get KeepAlive — skip non-Resume)
+    // PersistentProtocol sends Resume immediately upon construction (ipc.net.ts:929-931)
+    let resume_timeout = tokio::time::Duration::from_secs(30);
+    tokio::time::timeout(resume_timeout, async {
+        loop {
+            let msg = protocol::read_message(&mut reader).await?;
+            let log_line = format!(
+                "← recv: type={:?} id={} ack={} data_len={}",
+                msg.msg_type,
+                msg.id,
+                msg.ack,
+                msg.data.len()
+            );
+            println!("[exthost] {log_line}");
+            messages.push(log_line);
+
+            match msg.msg_type {
+                ProtocolMessageType::Resume => {
+                    println!("[exthost] ✓ Received Resume");
+                    return Ok::<(), ExtHostError>(());
+                }
+                ProtocolMessageType::KeepAlive => continue,
+                other => {
+                    return Err(ExtHostError::Protocol(format!(
+                        "Expected Resume, got {other:?}"
+                    )));
+                }
+            }
+        }
+    })
+    .await
+    .map_err(|_| ExtHostError::Timeout)??;
+
+    // Step 2: Wait for Ready (Regular message with body=[0x02])
+    // Sent by connectToRenderer() at extensionHostProcess.ts:393
+    let ready_timeout = tokio::time::Duration::from_secs(30);
+    tokio::time::timeout(ready_timeout, async {
+        loop {
+            let msg = protocol::read_message(&mut reader).await?;
+            let log_line = format!(
+                "← recv: type={:?} id={} ack={} body={:?}",
+                msg.msg_type,
+                msg.id,
+                msg.ack,
+                &msg.data[..msg.data.len().min(16)]
+            );
+            println!("[exthost] {log_line}");
+            messages.push(log_line);
+
+            match msg.msg_type {
+                ProtocolMessageType::Regular => {
+                    last_exthost_msg_id = msg.id;
+                    if msg.data.len() == 1 && msg.data[0] == MESSAGE_TYPE_READY {
+                        println!("[exthost] ✓ Received Ready (0x02)");
+                        return Ok::<(), ExtHostError>(());
+                    }
+                    return Err(ExtHostError::Protocol(format!(
+                        "Expected Ready body [0x02], got {:?}",
+                        msg.data
+                    )));
+                }
+                ProtocolMessageType::KeepAlive | ProtocolMessageType::Ack => continue,
+                other => {
+                    return Err(ExtHostError::Protocol(format!(
+                        "Expected Regular(Ready), got {other:?}"
+                    )));
+                }
+            }
+        }
+    })
+    .await
+    .map_err(|_| ExtHostError::Timeout)??;
+
+    // Step 3: Send InitData as a Regular message
+    rust_msg_id += 1;
+    let init_data_json = init_data::build_minimal_init_data();
+    let init_data_bytes = init_data_json.into_bytes();
+    let init_msg = ProtocolMessage::regular(rust_msg_id, last_exthost_msg_id, init_data_bytes);
+    let log_line = format!(
+        "→ send: type=Regular id={} ack={} data_len={}",
+        init_msg.id,
+        init_msg.ack,
+        init_msg.data.len()
+    );
+    println!("[exthost] {log_line}");
+    messages.push(log_line);
+    protocol::write_message(&mut writer, &init_msg).await?;
+    println!("[exthost] ✓ Sent InitData ({} bytes)", init_msg.data.len());
+
+    // Step 4: Wait for Initialized (Regular message with body=[0x01])
+    // Sent by connectToRenderer() at extensionHostProcess.ts:387
+    let init_timeout = tokio::time::Duration::from_secs(30);
+    tokio::time::timeout(init_timeout, async {
+        loop {
+            let msg = protocol::read_message(&mut reader).await?;
+            let log_line = format!(
+                "← recv: type={:?} id={} ack={} body={:?}",
+                msg.msg_type,
+                msg.id,
+                msg.ack,
+                &msg.data[..msg.data.len().min(16)]
+            );
+            println!("[exthost] {log_line}");
+            messages.push(log_line);
+
+            match msg.msg_type {
+                ProtocolMessageType::Regular => {
+                    if msg.data.len() == 1 && msg.data[0] == MESSAGE_TYPE_INITIALIZED {
+                        println!("[exthost] ✓ Received Initialized (0x01)");
+                        return Ok::<(), ExtHostError>(());
+                    }
+                    // Could be other Regular messages — skip for PoC
+                }
+                ProtocolMessageType::KeepAlive | ProtocolMessageType::Ack => continue,
+                _ => continue, // Be lenient in PoC
+            }
+        }
+    })
+    .await
+    .map_err(|_| ExtHostError::Timeout)??;
+
+    let duration = start.elapsed();
+    println!(
+        "[exthost] ✅ Handshake complete in {}ms",
+        duration.as_millis()
+    );
+
+    Ok(HandshakeResult {
+        messages,
+        duration_ms: duration.as_millis() as u64,
+    })
+}

--- a/src-tauri/src/exthost/init_data.rs
+++ b/src-tauri/src/exthost/init_data.rs
@@ -1,0 +1,82 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) VS Codee Contributors. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+//! Minimal `IExtensionHostInitData` JSON builder for the PoC handshake.
+//!
+//! Only fields accessed before `Initialized` is sent are critical
+//! (see `extensionHostProcess.ts:336-387`):
+//! - `commit` — omitted to skip version check
+//! - `parentPid: 0` — disables parent PID monitoring
+//!
+//! All other fields are stubs to prevent immediate crashes after the handshake.
+//!
+//! # TODO: Production (Phase 1-2)
+//!
+//! Replace this with a proper `IExtensionHostInitData` builder that:
+//! - Populates real extension scan results (`allExtensions`, `myExtensions`)
+//! - Provides actual workspace info
+//! - Includes real telemetry session IDs
+//! - Reads product.json for version/quality info
+//! - Sets correct `parentPid` for process monitoring
+
+/// Build the minimal `IExtensionHostInitData` JSON for the handshake PoC.
+///
+/// This JSON is sent as the InitData message during the
+/// Ready→InitData→Initialized handshake sequence.
+pub fn build_minimal_init_data() -> String {
+    serde_json::json!({
+        "version": "1.115.0",
+        "quality": "stable",
+        "parentPid": 0,
+        "environment": {
+            "isExtensionDevelopmentDebug": false,
+            "appName": "VS Codee",
+            "appHost": "tauri",
+            "appLanguage": "en",
+            "isExtensionTelemetryLoggingOnly": false,
+            "appUriScheme": "vscodee",
+            "globalStorageHome": {
+                "scheme": "file",
+                "path": "/tmp/vscodee-poc/globalStorage"
+            },
+            "workspaceStorageHome": {
+                "scheme": "file",
+                "path": "/tmp/vscodee-poc/workspaceStorage"
+            }
+        },
+        "workspace": serde_json::Value::Null,
+        "extensions": {
+            "versionId": 0,
+            "allExtensions": [],
+            "activationEvents": {},
+            "myExtensions": []
+        },
+        "telemetryInfo": {
+            "sessionId": "00000000-0000-0000-0000-000000000000",
+            "machineId": "00000000-0000-0000-0000-000000000000",
+            "sqmId": "00000000-0000-0000-0000-000000000000",
+            "devDeviceId": "00000000-0000-0000-0000-000000000000",
+            "firstSessionDate": "2024-01-01T00:00:00.000Z"
+        },
+        "logLevel": 1,
+        "loggers": [],
+        "logsLocation": {
+            "scheme": "file",
+            "path": "/tmp/vscodee-poc/logs"
+        },
+        "autoStart": false,
+        "remote": {
+            "isRemote": false,
+            "authority": serde_json::Value::Null,
+            "connectionData": serde_json::Value::Null
+        },
+        "consoleForward": {
+            "includeStack": false,
+            "logNative": false
+        },
+        "uiKind": 1
+    })
+    .to_string()
+}

--- a/src-tauri/src/exthost/mod.rs
+++ b/src-tauri/src/exthost/mod.rs
@@ -1,0 +1,71 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) VS Codee Contributors. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+//! Extension Host sidecar management — spawn Node.js, communicate via named pipe.
+//!
+//! # Phase 0-2 PoC Architecture (Minimal)
+//!
+//! Rust directly implements the VS Code wire protocol and runs the handshake
+//! state machine over a Unix domain socket / named pipe. The Extension Host
+//! process (`extensionHostProcess.ts`) is spawned as a plain Node.js child
+//! process — no Electron dependency.
+//!
+//! # TODO: Production Architecture (Clean Architecture — Phase 1-2)
+//!
+//! In production, replace the Rust-side protocol handling with a WebSocket↔Pipe
+//! byte relay. The TypeScript side (`TauriLocalProcessExtensionHost` implementing
+//! `IExtensionHost`) will handle the protocol via the existing `PersistentProtocol`
+//! class, connecting through a WebSocket to the Rust relay.
+//!
+//! Key components for production:
+//! - `SidecarManager` — multi-instance lifecycle orchestrator (replaces single spawn)
+//! - `WsRelay` — bidirectional byte relay (WebSocket ↔ named pipe)
+//! - `TauriLocalProcessExtensionHost` — TypeScript IExtensionHost implementation
+//! - `TauriExtensionService` — TypeScript extension service with factory
+//!
+//! See: `src/vs/workbench/services/extensions/tauri-browser/` (to be created)
+
+pub mod init_data;
+pub mod protocol;
+
+// Handshake and sidecar use Unix domain sockets (tokio::net::UnixListener).
+// Windows named pipe support requires tokio::net::windows::named_pipe (Phase 1+).
+#[cfg(unix)]
+pub mod handshake;
+#[cfg(unix)]
+pub mod sidecar;
+
+/// Errors that can occur during Extension Host sidecar operations.
+#[derive(Debug)]
+pub enum ExtHostError {
+    /// Failed to create the Unix domain socket / named pipe.
+    PipeCreation(std::io::Error),
+    /// Failed to spawn the Node.js child process.
+    Spawn(std::io::Error),
+    /// Timeout waiting for ExtHost to connect or complete handshake.
+    Timeout,
+    /// Protocol error — unexpected message type or format.
+    Protocol(String),
+    /// IO error during communication.
+    Io(std::io::Error),
+}
+
+impl std::fmt::Display for ExtHostError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::PipeCreation(e) => write!(f, "Pipe creation failed: {e}"),
+            Self::Spawn(e) => write!(f, "Node.js spawn failed: {e}"),
+            Self::Timeout => write!(f, "Handshake timeout (30s)"),
+            Self::Protocol(msg) => write!(f, "Protocol error: {msg}"),
+            Self::Io(e) => write!(f, "IO error: {e}"),
+        }
+    }
+}
+
+impl From<std::io::Error> for ExtHostError {
+    fn from(e: std::io::Error) -> Self {
+        Self::Io(e)
+    }
+}

--- a/src-tauri/src/exthost/protocol.rs
+++ b/src-tauri/src/exthost/protocol.rs
@@ -1,0 +1,176 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) VS Codee Contributors. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+//! VS Code wire protocol — 13-byte header framing.
+//!
+//! Faithfully mirrors the protocol defined in `src/vs/base/parts/ipc/common/ipc.net.ts`.
+//! Each message has a 13-byte header followed by a variable-length body:
+//!
+//! ```text
+//! [TYPE: 1 byte][ID: 4 bytes BE][ACK: 4 bytes BE][DATA_LENGTH: 4 bytes BE][DATA: N bytes]
+//! ```
+//!
+//! # TODO: Production (Phase 1-2)
+//!
+//! In the clean architecture, Rust does NOT parse the wire protocol at all.
+//! Instead, a byte-transparent WebSocket↔Pipe relay copies raw bytes between
+//! the renderer (TypeScript PersistentProtocol) and the Extension Host.
+//! This module will then be used only for optional debug logging.
+
+use std::io;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+/// Wire protocol header length in bytes.
+/// Mirrors `ProtocolConstants.HeaderLength` at `ipc.net.ts:283`.
+pub const HEADER_LENGTH: usize = 13;
+
+/// Transport-level message types.
+/// Mirrors `ProtocolMessageType` at `ipc.net.ts:287-297`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum ProtocolMessageType {
+    None = 0,
+    Regular = 1,
+    Control = 2,
+    Ack = 3,
+    Disconnect = 5,
+    ReplayRequest = 6,
+    Pause = 7,
+    Resume = 8,
+    KeepAlive = 9,
+}
+
+impl TryFrom<u8> for ProtocolMessageType {
+    type Error = String;
+    fn try_from(v: u8) -> Result<Self, String> {
+        match v {
+            0 => Ok(Self::None),
+            1 => Ok(Self::Regular),
+            2 => Ok(Self::Control),
+            3 => Ok(Self::Ack),
+            5 => Ok(Self::Disconnect),
+            6 => Ok(Self::ReplayRequest),
+            7 => Ok(Self::Pause),
+            8 => Ok(Self::Resume),
+            9 => Ok(Self::KeepAlive),
+            _ => Err(format!("Unknown protocol message type: {v}")),
+        }
+    }
+}
+
+/// A single wire protocol message (header + body).
+#[derive(Debug)]
+pub struct ProtocolMessage {
+    pub msg_type: ProtocolMessageType,
+    pub id: u32,
+    pub ack: u32,
+    pub data: Vec<u8>,
+}
+
+impl ProtocolMessage {
+    /// Create a Regular message (mirrors `PersistentProtocol.send()`).
+    pub fn regular(id: u32, ack: u32, data: Vec<u8>) -> Self {
+        Self {
+            msg_type: ProtocolMessageType::Regular,
+            id,
+            ack,
+            data,
+        }
+    }
+}
+
+/// Read exactly one protocol message from an async reader.
+///
+/// Mirrors `ProtocolReader.acceptChunk()` at `ipc.net.ts:354-401`.
+pub async fn read_message<R: AsyncReadExt + Unpin>(reader: &mut R) -> io::Result<ProtocolMessage> {
+    let mut header = [0u8; HEADER_LENGTH];
+    reader.read_exact(&mut header).await?;
+
+    let msg_type = ProtocolMessageType::try_from(header[0])
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+    let id = u32::from_be_bytes([header[1], header[2], header[3], header[4]]);
+    let ack = u32::from_be_bytes([header[5], header[6], header[7], header[8]]);
+    let data_length = u32::from_be_bytes([header[9], header[10], header[11], header[12]]) as usize;
+
+    let mut data = vec![0u8; data_length];
+    if data_length > 0 {
+        reader.read_exact(&mut data).await?;
+    }
+
+    Ok(ProtocolMessage {
+        msg_type,
+        id,
+        ack,
+        data,
+    })
+}
+
+/// Write one protocol message to an async writer.
+///
+/// Mirrors `ProtocolWriter.write()` at `ipc.net.ts:460-477`.
+pub async fn write_message<W: AsyncWriteExt + Unpin>(
+    writer: &mut W,
+    msg: &ProtocolMessage,
+) -> io::Result<()> {
+    let mut header = [0u8; HEADER_LENGTH];
+    header[0] = msg.msg_type as u8;
+    header[1..5].copy_from_slice(&msg.id.to_be_bytes());
+    header[5..9].copy_from_slice(&msg.ack.to_be_bytes());
+    header[9..13].copy_from_slice(&(msg.data.len() as u32).to_be_bytes());
+
+    writer.write_all(&header).await?;
+    if !msg.data.is_empty() {
+        writer.write_all(&msg.data).await?;
+    }
+    writer.flush().await?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::BufReader;
+
+    #[tokio::test]
+    async fn test_roundtrip() {
+        let msg = ProtocolMessage::regular(1, 0, vec![0x02]);
+
+        let mut buf = Vec::new();
+        write_message(&mut buf, &msg).await.unwrap();
+
+        assert_eq!(buf.len(), HEADER_LENGTH + 1);
+
+        let mut reader = BufReader::new(&buf[..]);
+        let decoded = read_message(&mut reader).await.unwrap();
+
+        assert_eq!(decoded.msg_type, ProtocolMessageType::Regular);
+        assert_eq!(decoded.id, 1);
+        assert_eq!(decoded.ack, 0);
+        assert_eq!(decoded.data, vec![0x02]);
+    }
+
+    #[tokio::test]
+    async fn test_empty_body() {
+        let msg = ProtocolMessage {
+            msg_type: ProtocolMessageType::Resume,
+            id: 0,
+            ack: 0,
+            data: vec![],
+        };
+
+        let mut buf = Vec::new();
+        write_message(&mut buf, &msg).await.unwrap();
+
+        assert_eq!(buf.len(), HEADER_LENGTH);
+        assert_eq!(buf[0], 8); // Resume = 8
+
+        let mut reader = BufReader::new(&buf[..]);
+        let decoded = read_message(&mut reader).await.unwrap();
+
+        assert_eq!(decoded.msg_type, ProtocolMessageType::Resume);
+        assert_eq!(decoded.data.len(), 0);
+    }
+}

--- a/src-tauri/src/exthost/sidecar.rs
+++ b/src-tauri/src/exthost/sidecar.rs
@@ -1,0 +1,144 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) VS Codee Contributors. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+//! Named pipe creation and Node.js Extension Host process spawning.
+//!
+//! Replicates the pattern from `src/vs/server/node/extensionHostConnection.ts:247-335`:
+//! 1. Create Unix domain socket server (`_listenOnPipe()`)
+//! 2. Spawn `node out/bootstrap-fork.js --type=extensionHost` with correct env vars
+//! 3. Wait for the ExtHost to connect back to our socket
+//!
+//! # TODO: Production (Phase 1-2)
+//!
+//! Replace this with a `SidecarManager` that:
+//! - Manages multiple ExtHost instances (multi-window support)
+//! - Tracks state via a state machine (Starting→PipeReady→Connected→Running→Stopped)
+//! - Supports bundled Node.js binary (not just system `node`)
+//! - Integrates with Tauri managed state for WebView access
+
+use std::path::Path;
+
+use tokio::net::UnixListener;
+use tokio::process::{Child, Command};
+
+use super::ExtHostError;
+
+/// A running Extension Host sidecar process with its named pipe path.
+pub struct ExtHostSidecar {
+    pub child: Child,
+    pub pipe_path: String,
+}
+
+impl Drop for ExtHostSidecar {
+    fn drop(&mut self) {
+        // Best-effort cleanup of the socket file
+        let _ = std::fs::remove_file(&self.pipe_path);
+    }
+}
+
+/// Create a Unix domain socket path matching VS Code's convention.
+///
+/// Mirrors `createRandomIPCHandle()` at `ipc.net.ts:889-904`.
+/// macOS has a 104-char limit for socket paths; UUID-based paths in /tmp/
+/// are ~55 chars, well within that limit.
+fn create_random_ipc_handle() -> String {
+    let id = uuid::Uuid::new_v4();
+    if cfg!(windows) {
+        format!("\\\\.\\pipe\\vscode-ipc-{id}-sock")
+    } else {
+        format!("{}/vscode-ipc-{id}.sock", std::env::temp_dir().display())
+    }
+}
+
+/// Spawn the Extension Host as a Node.js sidecar, returning the connected stream.
+///
+/// This replicates the pattern from `extensionHostConnection.ts:247-327`:
+/// 1. Create Unix domain socket server
+/// 2. Spawn `node out/bootstrap-fork.js --type=extensionHost`
+/// 3. Wait for the ExtHost to connect back to our socket (30s timeout)
+///
+/// # Arguments
+/// * `app_root` — Repository root containing `out/bootstrap-fork.js` and `product.json`
+///
+/// # Returns
+/// A tuple of the sidecar handle and the connected Unix stream.
+pub async fn spawn(
+    app_root: &Path,
+) -> Result<(ExtHostSidecar, tokio::net::UnixStream), ExtHostError> {
+    let pipe_path = create_random_ipc_handle();
+
+    // Step 1: Create the Unix domain socket server
+    // Mirrors _listenOnPipe() at extensionHostConnection.ts:337-348
+    let listener = UnixListener::bind(&pipe_path).map_err(ExtHostError::PipeCreation)?;
+
+    println!("[exthost] Listening on pipe: {pipe_path}");
+
+    // Step 2: Spawn the Node.js process
+    // If spawn or accept fails, clean up the socket file before returning.
+    let result = spawn_and_connect(app_root, &pipe_path, &listener).await;
+    if result.is_err() {
+        let _ = std::fs::remove_file(&pipe_path);
+    }
+    // Drop the listener — we only need one connection
+    drop(listener);
+
+    result
+}
+
+async fn spawn_and_connect(
+    app_root: &Path,
+    pipe_path: &str,
+    listener: &UnixListener,
+) -> Result<(ExtHostSidecar, tokio::net::UnixStream), ExtHostError> {
+    // Mirrors extensionHostConnection.ts:272-288
+    let node_bin = "node"; // PoC: use system node
+
+    let child = Command::new(node_bin)
+        .arg("--dns-result-order=ipv4first")
+        .arg("out/bootstrap-fork.js")
+        .arg("--type=extensionHost")
+        .current_dir(app_root)
+        .env("VSCODE_EXTHOST_IPC_HOOK", pipe_path)
+        .env(
+            "VSCODE_ESM_ENTRYPOINT",
+            "vs/workbench/api/node/extensionHostProcess",
+        )
+        .env("VSCODE_HANDLES_UNCAUGHT_ERRORS", "true")
+        .env("VSCODE_PARENT_PID", std::process::id().to_string())
+        .env("VSCODE_DEV", "1")
+        .env(
+            "VSCODE_NLS_CONFIG",
+            r#"{"locale":"en","osLocale":"en","availableLanguages":{}}"#,
+        )
+        // NOT set (selecting wrong transport):
+        // VSCODE_WILL_SEND_MESSAGE_PORT — Electron MessagePort path
+        // VSCODE_EXTHOST_WILL_SEND_SOCKET — process.send() socket path
+        // PoC: inherit stdio so ExtHost output goes to Tauri console.
+        // Without reading piped stdout/stderr, the pipe buffer could fill up
+        // and block the child process, causing deadlock.
+        .stdout(std::process::Stdio::inherit())
+        .stderr(std::process::Stdio::inherit())
+        .spawn()
+        .map_err(ExtHostError::Spawn)?;
+
+    let pid = child.id().unwrap_or(0);
+    println!("[exthost] Spawned Node.js ExtHost process (PID: {pid})");
+
+    // Step 3: Wait for the ExtHost to connect back (30s timeout)
+    // Mirrors extensionHostConnection.ts:313-316
+    let timeout = tokio::time::Duration::from_secs(30);
+    let (stream, _addr) = tokio::time::timeout(timeout, listener.accept())
+        .await
+        .map_err(|_| ExtHostError::Timeout)?
+        .map_err(ExtHostError::PipeCreation)?;
+
+    println!("[exthost] ExtHost connected to pipe");
+
+    let sidecar = ExtHostSidecar {
+        child,
+        pipe_path: pipe_path.to_owned(),
+    };
+    Ok((sidecar, stream))
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,6 +9,10 @@ mod commands;
 /// Custom protocol handlers for vscode-file:// etc.
 mod protocol;
 
+/// Extension Host sidecar management — spawn Node.js, communicate via named pipe.
+/// TODO(Phase 1-2): Replace PoC direct handshake with WebSocket relay + TypeScript IExtensionHost impl
+mod exthost;
+
 /// Tauriアプリケーションを構築して実行する。
 ///
 /// 以下のセットアップを行い、イベントループに入る:
@@ -32,6 +36,7 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             commands::get_native_host_info,
             commands::get_window_configuration,
+            commands::spawn_exthost::spawn_extension_host,
         ])
         .setup(|_app| {
             println!("[vscodee] Tauri app started");

--- a/src/vs/code/tauri-browser/workbench/index.html
+++ b/src/vs/code/tauri-browser/workbench/index.html
@@ -221,6 +221,47 @@
 					statusEl.textContent = '✅ Feasibility Spike: All checks passed!';
 					statusEl.className = 'status success';
 
+					// Step 6: Extension Host Sidecar PoC (Phase 0-2)
+					log('');
+					log('Phase 0-2: Extension Host Sidecar PoC');
+					log('─────────────────────────────────');
+					log('Click the button below to spawn ExtHost and run handshake.');
+
+					const btn = document.createElement('button');
+					btn.textContent = '🔌 Spawn Extension Host';
+					btn.style.cssText = 'margin-top:12px;padding:8px 16px;background:#007acc;color:#fff;border:none;border-radius:4px;cursor:pointer;font-size:13px;';
+					btn.onclick = async () => {
+						btn.disabled = true;
+						btn.textContent = '⏳ Spawning...';
+						statusEl.textContent = 'Spawning Extension Host...';
+						statusEl.className = 'status';
+						log('Spawning Node.js Extension Host sidecar...');
+						try {
+							const result = await invoke('spawn_extension_host');
+							if (result.success) {
+								log(`✅ Handshake succeeded!`);
+								log(`   pipe:     ${result.pipePath}`);
+								log(`   pid:      ${result.extHostPid}`);
+								log(`   duration: ${result.handshakeDurationMs}ms`);
+								log(`   messages: ${result.messagesExchanged.length}`);
+								for (const m of result.messagesExchanged) {
+									log(`     ${m}`);
+								}
+								statusEl.textContent = `✅ ExtHost handshake OK (${result.handshakeDurationMs}ms)`;
+								statusEl.className = 'status success';
+							} else {
+								log(`❌ Handshake failed: ${result.error}`, true);
+								statusEl.textContent = `❌ ExtHost: ${result.error}`;
+							}
+						} catch (e) {
+							log(`❌ invoke error: ${e}`, true);
+							statusEl.textContent = `❌ ${e}`;
+						}
+						btn.disabled = false;
+						btn.textContent = '🔌 Spawn Extension Host';
+					};
+					document.getElementById('splash').appendChild(btn);
+
 				} catch (err) {
 					log(`❌ Error: ${err.message || err}`, true);
 					statusEl.textContent = `❌ Error: ${err.message || err}`;


### PR DESCRIPTION
## Summary

Implement the Extension Host sidecar proof of concept (Phase 0-2) that demonstrates Electron-free ExtHost operation using Tauri 2.0.

## What this PR does

- **Wire protocol** (`exthost/protocol.rs`): 13-byte header read/write matching VS Code's `ipc.net.ts` binary protocol
- **Named pipe** (`exthost/sidecar.rs`): Unix domain socket creation + Node.js child process spawning (mirrors `extensionHostConnection.ts`)
- **Handshake state machine** (`exthost/handshake.rs`): Resume → Ready → InitData → Initialized exchange with 30s timeout
- **InitData builder** (`exthost/init_data.rs`): Minimal `IExtensionHostInitData` JSON for handshake PoC
- **Tauri command** (`commands/spawn_exthost.rs`): `spawn_extension_host` with app root resolution and `#[cfg(unix)]` guard
- **Test UI** (`index.html`): "Spawn Extension Host" button in the feasibility spike page

## Key result

✅ **Handshake completes in ~15ms** — proving the Extension Host can be spawned and handshaked without any Electron dependency, using the existing named-pipe transport path.

## How to test

```bash
npm run compile          # Generate out/bootstrap-fork.js
npm run tauri:dev        # Launch Tauri app
# Click "🔌 Spawn Extension Host" button → verify handshake success
```

## Architecture notes

This PoC uses the **Minimal** approach (Proposal A): Rust directly implements the wire protocol. Each file contains TODO comments documenting the migration path to the **Clean Architecture** (Proposal B) for production, where Rust becomes a byte-transparent WebSocket↔Pipe relay and TypeScript handles the protocol.

## Platform support

- ✅ macOS (verified)
- ✅ Linux (should work — same Unix domain socket API)
- ⚠️ Windows (gated with `#[cfg(unix)]`, returns error message — needs `tokio::net::windows::named_pipe` in Phase 1+)
