### PR TITLE
chore: add vscodeee to cSpell words

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -215,6 +215,7 @@
 		".claude/skills/.local": true,
 	},
 	"cSpell.words": [
-		"Codeee"
+		"Codeee",
+		"vscodeee"
 	]
 }


### PR DESCRIPTION
## Summary
- Add `vscodeee` to cSpell custom words in `.vscode/settings.json`

## Test plan
- [ ] Verify cSpell no longer flags `vscodeee` as a misspelled word

🤖 Generated with [Claude Code](https://claude.com/claude-code)