### PR TITLE
feat: add Open VSX marketplace configuration

### DIFF
--- a/product.json
+++ b/product.json
@@ -32,6 +32,14 @@
 	"reportIssueUrl": "https://github.com/j4rviscmd/vscodeee/issues/new",
 	"nodejsRepository": "https://nodejs.org",
 	"urlProtocol": "code-oss",
+	"extensionsGallery": {
+		"serviceUrl": "https://open-vsx.org/vscode/gallery",
+		"itemUrl": "https://open-vsx.org/vscode/item",
+		"resourceUrlTemplate": "https://open-vsx.org/vscode/unpkg/{publisher}/{name}/{version}/{path}",
+		"controlUrl": "",
+		"nlsBaseUrl": "",
+		"publisherUrl": ""
+	},
 	"webviewContentExternalBaseUrlTemplate": "https://{{uuid}}.vscode-cdn.net/insider/ef65ac1ba57f57f2a3961bfe94aa20481caca4c6/out/vs/workbench/contrib/webview/browser/pre/",
 	"builtInExtensions": [
 		{


### PR DESCRIPTION
## Summary

Enable extension marketplace browsing and installation by adding Open VSX (Eclipse Foundation) gallery configuration to `product.json`.

## Problem

The Extensions view shows no search results because `product.json` lacks an `extensionsGallery` configuration. Without this, VS Code has no marketplace endpoint to query.

## Solution

Add Open VSX as the extension marketplace. Open VSX is the standard open-source marketplace for VS Code forks (used by VS Codium, Gitpod, Eclipse Theia, etc.) and is fully compatible with VS Code's gallery API.

```json
"extensionsGallery": {
    "serviceUrl": "https://open-vsx.org/vscode/gallery",
    "itemUrl": "https://open-vsx.org/vscode/item",
    "resourceUrlTemplate": "https://open-vsx.org/vscode/unpkg/{publisher}/{name}/{version}/{path}"
}
```

## Note

Extension **installation** will work, but extension **execution** still requires the Extension Host (Phase 5). Extensions installed via marketplace will appear in the sidebar but won't activate until Node.js sidecar integration is complete.