### PR TITLE
fix: load product.json at bootstrap to enable marketplace search

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -185,6 +185,47 @@ fn collect_css_files(dir: &Path, root: &Path, result: &mut Vec<String>) {
     }
 }
 
+/// Read product.json and package.json from the project root.
+///
+/// Returns both files as raw JSON values so the bootstrap script can set
+/// `globalThis._VSCODE_PRODUCT_JSON` and `globalThis._VSCODE_PACKAGE_JSON`
+/// before any workbench modules are imported. This is critical because
+/// `product.ts` checks these globals to configure services like the
+/// Extension Gallery (marketplace).
+///
+/// The project root is resolved as `../` relative to `src-tauri/` (the
+/// Tauri process working directory during `cargo tauri dev`).
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProductPackageJson {
+    /// Contents of `product.json` as a raw JSON value.
+    pub product: serde_json::Value,
+    /// Contents of `package.json` as a raw JSON value.
+    pub package: serde_json::Value,
+}
+
+#[tauri::command]
+pub fn get_product_json() -> Result<ProductPackageJson, String> {
+    let project_root = std::env::current_dir()
+        .map_err(|e| format!("Failed to get cwd: {e}"))?
+        .join("..");
+
+    let product_path = project_root.join("product.json");
+    let package_path = project_root.join("package.json");
+
+    let product_str = std::fs::read_to_string(&product_path)
+        .map_err(|e| format!("Failed to read product.json at {}: {e}", product_path.display()))?;
+    let package_str = std::fs::read_to_string(&package_path)
+        .map_err(|e| format!("Failed to read package.json at {}: {e}", package_path.display()))?;
+
+    let product: serde_json::Value = serde_json::from_str(&product_str)
+        .map_err(|e| format!("Failed to parse product.json: {e}"))?;
+    let package: serde_json::Value = serde_json::from_str(&package_str)
+        .map_err(|e| format!("Failed to parse package.json: {e}"))?;
+
+    Ok(ProductPackageJson { product, package })
+}
+
 /// List all CSS module paths for the CSS import map.
 ///
 /// Scans the transpiled output directory (`out/`) for `.css` files and returns

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -91,6 +91,7 @@ pub fn run() {
             commands::get_native_host_info,
             commands::get_window_configuration,
             commands::list_css_modules,
+            commands::get_product_json,
             commands::extensions::list_builtin_extensions,
             commands::ipc_channel::ipc_message,
             commands::ipc_channel::ipc_handshake,

--- a/src/vs/code/tauri-browser/workbench/workbench-tauri.ts
+++ b/src/vs/code/tauri-browser/workbench/workbench-tauri.ts
@@ -244,6 +244,21 @@
 
 	//#endregion
 
+	//#region Product Configuration — must be set before importing workbench modules
+
+	// product.ts checks globalThis._VSCODE_PRODUCT_JSON and _VSCODE_PACKAGE_JSON
+	// to configure services like the Extension Gallery (marketplace).
+	// Without this, the fallback path provides a hardcoded default without extensionsGallery.
+	try {
+		const productPackage = await tauri.core.invoke<{ product: object; package: object }>('get_product_json');
+		(globalThis as any)._VSCODE_PRODUCT_JSON = productPackage.product;
+		(globalThis as any)._VSCODE_PACKAGE_JSON = productPackage.package;
+	} catch (err) {
+		console.warn('[Tauri Bootstrap] Failed to load product.json, using defaults:', err);
+	}
+
+	//#endregion
+
 	//#region Load Workbench
 
 	try {


### PR DESCRIPTION
## Summary

The Extension Marketplace search returned no results because `product.json` (containing the Open VSX `extensionsGallery` configuration added in PR #50) was never loaded at runtime.

## Root Cause

In the Tauri environment, `product.ts` follows the "Web/unknown" fallback path since neither `globalThis.vscode.context` (Electron sandbox) nor `globalThis._VSCODE_PRODUCT_JSON` are set. The fallback provides a hardcoded default object that does **not** include `extensionsGallery`, so `ExtensionGalleryService.isEnabled()` returns `false`.

## Fix

1. **Rust command** (`get_product_json`): Reads `product.json` and `package.json` from the project root and returns them as JSON values
2. **Bootstrap script** (`workbench-tauri.ts`): Calls `get_product_json` and sets `globalThis._VSCODE_PRODUCT_JSON` and `globalThis._VSCODE_PACKAGE_JSON` **before** any workbench modules are imported

This mirrors how the Electron bootstrap sets these globals via the preload script.

## Files Changed

| File | Change |
|------|--------|
| `src-tauri/src/commands/mod.rs` | Add `get_product_json` command + `ProductPackageJson` struct |
| `src-tauri/src/lib.rs` | Register `get_product_json` in invoke handler |
| `src/vs/code/tauri-browser/workbench/workbench-tauri.ts` | Call `get_product_json` and set globals before loading workbench |

## Testing

- Verified marketplace search works (Open VSX returns results for "Python", "Prettier", etc.)
- Desktop extensions correctly show "not available for Web" (expected until Phase 5 Extension Host)