### PR TITLE
fix: enable vscode-file:// URI rewrite for Tauri WebView

### DIFF
--- a/src/vs/base/common/network.ts
+++ b/src/vs/base/common/network.ts
@@ -309,6 +309,8 @@ class FileAccessImpl {
 			(
 				// ...and we run in native environments
 				platform.isNative ||
+				// ...or in Tauri where file:// is blocked by WebView CSP
+				platform.isTauri ||
 				// ...or web worker extensions on desktop
 				(platform.webWorkerOrigin === `${Schemas.vscodeFileResource}://${FileAccessImpl.FALLBACK_AUTHORITY}`)
 			)

--- a/src/vs/base/test/common/network.test.ts
+++ b/src/vs/base/test/common/network.test.ts
@@ -5,7 +5,7 @@
 
 import assert from 'assert';
 import { FileAccess, Schemas } from '../../common/network.js';
-import { isWeb } from '../../common/platform.js';
+import { isTauri, isWeb } from '../../common/platform.js';
 import { isEqual } from '../../common/resources.js';
 import { URI } from '../../common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from './utils.js';
@@ -68,5 +68,36 @@ suite('network', () => {
 		const originalRemoteUri = URI.file('network.test.ts').with({ scheme: Schemas.vscodeRemote });
 		const browserUri = FileAccess.uriToBrowserUri(originalRemoteUri);
 		assert.notStrictEqual(originalRemoteUri.scheme, browserUri.scheme);
+	});
+
+	// Tauri tests: file:// → vscode-file:// URI conversion (issue #47)
+	// These tests verify that in a Tauri environment (isWeb=true, isTauri=true),
+	// file:// URIs are correctly rewritten to vscode-file:// URIs.
+	// Skipped in non-Tauri environments where file:// is handled natively.
+
+	(isTauri ? test : test.skip)('FileAccess: URI rewrite in Tauri (file → vscode-file)', () => {
+		const originalFileUri = URI.file('network.test.ts');
+		const browserUri = FileAccess.uriToBrowserUri(originalFileUri);
+		assert.strictEqual(browserUri.scheme, Schemas.vscodeFileResource);
+		assert.ok(browserUri.authority.length > 0);
+
+		const fileUri = FileAccess.uriToFileUri(browserUri);
+		assert.strictEqual(fileUri.authority.length, 0);
+		assert(isEqual(originalFileUri, fileUri));
+	});
+
+	(isTauri ? test : test.skip)('FileAccess: Tauri preserves existing authority', () => {
+		const originalFileUri = URI.file('network.test.ts').with({ authority: 'test-authority' });
+		const browserUri = FileAccess.uriToBrowserUri(originalFileUri);
+		assert.strictEqual(browserUri.scheme, Schemas.vscodeFileResource);
+		assert.strictEqual(browserUri.authority, originalFileUri.authority);
+	});
+
+	(isTauri ? test : test.skip)('FileAccess: Tauri drops query and fragment on rewrite', () => {
+		const originalFileUri = URI.file('network.test.ts').with({ query: 'foo=bar', fragment: 'something' });
+		const browserUri = FileAccess.uriToBrowserUri(originalFileUri);
+		assert.strictEqual(browserUri.scheme, Schemas.vscodeFileResource);
+		assert.strictEqual(browserUri.query, '');
+		assert.strictEqual(browserUri.fragment, '');
 	});
 });


### PR DESCRIPTION
## Summary

Closes #47

In Tauri environments (`isWeb=true`, `isTauri=true`), `file://` URIs are blocked by WebView CSP. This PR adds `platform.isTauri` to the condition in `FileAccess.uriToBrowserUri()` so that `file://` URIs are rewritten to `vscode-file://`, matching existing native environment behavior.

## Changes

- **`src/vs/base/common/network.ts`** — Add `platform.isTauri` condition to `uriToBrowserUri()` (+2 lines)
- **`src/vs/base/test/common/network.test.ts`** — Add 3 unit tests for Tauri URI rewrite path (+33 lines)

## Context

The `vscode-file://` custom protocol was already registered in `lib.rs` (PR #4), with the Rust handler in `src-tauri/src/protocol/` and CSP allowlisted in `tauri.conf.json`. The only missing piece was the frontend URI rewrite logic, which this PR addresses.

## Testing

- Verified `file://` load errors disappear after the fix (manual test with cache cleared)
- Unit tests conditional on `isTauri` runtime flag (`isTauri ? test : test.skip`)