### PR TITLE
fix: add vscode-file: to CSP connect-src and dynamic CORS origin for extension loading

### DIFF
--- a/src-tauri/src/protocol/headers.rs
+++ b/src-tauri/src/protocol/headers.rs
@@ -6,35 +6,70 @@
 //! Security headers for `vscode-file://` protocol responses.
 //!
 //! Mirrors the headers applied by Electron's `ProtocolMainService`:
-//! - **CORS**: Allow the Tauri origin to access resources.
+//! - **CORS**: Allow the requesting origin to access resources (validated against allow-list).
 //! - **COOP/COEP**: Cross-Origin Isolation for workbench HTML (SharedArrayBuffer).
 //! - **Cache-Control**: Disable caching in development builds.
 //! - **Document-Policy**: Enable JS callstack collection for crash reports.
 
 use std::path::Path;
 
-/// CORS origin for Tauri WebView requests.
+/// CORS origins allowed to access `vscode-file://` resources.
 ///
-/// Tauri uses `tauri://localhost` as the default origin on macOS/Linux and
-/// `https://tauri.localhost` on Windows. We allow both via a wildcard in
-/// development; in production this should be restricted.
-const TAURI_ORIGIN: &str = "tauri://localhost";
+/// - `tauri://localhost` — Default Tauri origin on macOS/Linux (production builds).
+/// - `https://tauri.localhost` — Default Tauri origin on Windows.
+/// - `http://127.0.0.1` — Dev server origin (port varies, checked by prefix).
+/// - `http://localhost` — Alternative dev server origin.
+const ALLOWED_ORIGIN_PREFIXES: &[&str] = &[
+    "tauri://localhost",
+    "https://tauri.localhost",
+    "http://127.0.0.1",
+    "http://localhost",
+];
 
-/// HTTP header key-value pair.
-pub type Header = (&'static str, &'static str);
+/// HTTP header key-value pair (owned strings to support dynamic CORS origins).
+pub type Header = (String, String);
+
+/// Check whether a request origin is allowed for CORS.
+///
+/// Returns the origin string to use in `Access-Control-Allow-Origin` if allowed,
+/// or the default `tauri://localhost` if the origin is absent or not recognized.
+fn resolve_cors_origin(request_origin: Option<&str>) -> &str {
+    match request_origin {
+        Some(origin) => {
+            for prefix in ALLOWED_ORIGIN_PREFIXES {
+                if origin == *prefix || origin.starts_with(&format!("{prefix}:")) {
+                    return origin;
+                }
+            }
+            // Unknown origin — fall back to default (won't match, effectively denying CORS)
+            "tauri://localhost"
+        }
+        // No Origin header — use default (same-origin requests from Tauri WebView)
+        None => "tauri://localhost",
+    }
+}
 
 /// Compute the security headers for a given file path.
 ///
 /// The returned headers vary based on:
+/// - The request's `Origin` header (determines CORS `Access-Control-Allow-Origin`)
 /// - Whether the file is a workbench HTML entry point (gets COOP/COEP + Document-Policy)
 /// - Whether this is a development build (gets Cache-Control: no-cache)
 ///
-/// All responses get CORS headers allowing the Tauri origin.
-pub fn headers_for_path(path: &Path, is_dev_build: bool) -> Vec<Header> {
+/// All responses get CORS headers allowing validated origins.
+pub fn headers_for_path(
+    path: &Path,
+    is_dev_build: bool,
+    request_origin: Option<&str>,
+) -> Vec<Header> {
     let mut headers = Vec::with_capacity(6);
 
-    // Always add CORS
-    headers.push(("Access-Control-Allow-Origin", TAURI_ORIGIN));
+    // Always add CORS with the resolved origin
+    let cors_origin = resolve_cors_origin(request_origin);
+    headers.push((
+        "Access-Control-Allow-Origin".to_string(),
+        cors_origin.to_string(),
+    ));
 
     let filename = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
 
@@ -44,18 +79,30 @@ pub fn headers_for_path(path: &Path, is_dev_build: bool) -> Vec<Header> {
 
     // COOP + COEP for workbench HTML (enables SharedArrayBuffer)
     if is_workbench_html {
-        headers.push(("Cross-Origin-Opener-Policy", "same-origin"));
-        headers.push(("Cross-Origin-Embedder-Policy", "require-corp"));
+        headers.push((
+            "Cross-Origin-Opener-Policy".to_string(),
+            "same-origin".to_string(),
+        ));
+        headers.push((
+            "Cross-Origin-Embedder-Policy".to_string(),
+            "require-corp".to_string(),
+        ));
     }
 
     // Document-Policy for workbench HTML (JS callstack collection)
     if is_workbench_html {
-        headers.push(("Document-Policy", "include-js-call-stacks-in-crash-reports"));
+        headers.push((
+            "Document-Policy".to_string(),
+            "include-js-call-stacks-in-crash-reports".to_string(),
+        ));
     }
 
     // Cache-Control for dev builds
     if is_dev_build {
-        headers.push(("Cache-Control", "no-cache, no-store"));
+        headers.push((
+            "Cache-Control".to_string(),
+            "no-cache, no-store".to_string(),
+        ));
     }
 
     headers
@@ -64,24 +111,76 @@ pub fn headers_for_path(path: &Path, is_dev_build: bool) -> Vec<Header> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
     use std::path::PathBuf;
 
-    fn header_map(headers: &[Header]) -> std::collections::HashMap<&str, &str> {
-        headers.iter().copied().collect()
+    fn header_map(headers: &[Header]) -> HashMap<&str, &str> {
+        headers
+            .iter()
+            .map(|(k, v)| (k.as_str(), v.as_str()))
+            .collect()
     }
 
     #[test]
     fn always_includes_cors() {
         let path = PathBuf::from("/app/out/vs/base/style.css");
-        let headers = headers_for_path(&path, false);
+        let headers = headers_for_path(&path, false, None);
         let map = header_map(&headers);
-        assert_eq!(map.get("Access-Control-Allow-Origin"), Some(&TAURI_ORIGIN));
+        assert_eq!(
+            map.get("Access-Control-Allow-Origin"),
+            Some(&"tauri://localhost")
+        );
+    }
+
+    #[test]
+    fn cors_echoes_allowed_dev_origin() {
+        let path = PathBuf::from("/app/out/vs/base/style.css");
+        let headers = headers_for_path(&path, false, Some("http://127.0.0.1:1430"));
+        let map = header_map(&headers);
+        assert_eq!(
+            map.get("Access-Control-Allow-Origin"),
+            Some(&"http://127.0.0.1:1430")
+        );
+    }
+
+    #[test]
+    fn cors_echoes_localhost_dev_origin() {
+        let path = PathBuf::from("/app/out/vs/base/style.css");
+        let headers = headers_for_path(&path, false, Some("http://localhost:5173"));
+        let map = header_map(&headers);
+        assert_eq!(
+            map.get("Access-Control-Allow-Origin"),
+            Some(&"http://localhost:5173")
+        );
+    }
+
+    #[test]
+    fn cors_rejects_unknown_origin() {
+        let path = PathBuf::from("/app/out/vs/base/style.css");
+        let headers = headers_for_path(&path, false, Some("https://evil.example.com"));
+        let map = header_map(&headers);
+        // Falls back to tauri://localhost (won't match the attacker's origin)
+        assert_eq!(
+            map.get("Access-Control-Allow-Origin"),
+            Some(&"tauri://localhost")
+        );
+    }
+
+    #[test]
+    fn cors_echoes_tauri_origin() {
+        let path = PathBuf::from("/app/out/vs/base/style.css");
+        let headers = headers_for_path(&path, false, Some("tauri://localhost"));
+        let map = header_map(&headers);
+        assert_eq!(
+            map.get("Access-Control-Allow-Origin"),
+            Some(&"tauri://localhost")
+        );
     }
 
     #[test]
     fn workbench_html_gets_coop_coep() {
         let path = PathBuf::from("/app/out/vs/workbench/workbench.html");
-        let headers = headers_for_path(&path, false);
+        let headers = headers_for_path(&path, false, None);
         let map = header_map(&headers);
 
         assert_eq!(map.get("Cross-Origin-Opener-Policy"), Some(&"same-origin"));
@@ -98,7 +197,7 @@ mod tests {
     #[test]
     fn non_workbench_file_no_coop_coep() {
         let path = PathBuf::from("/app/out/vs/editor/editor.main.js");
-        let headers = headers_for_path(&path, false);
+        let headers = headers_for_path(&path, false, None);
         let map = header_map(&headers);
 
         assert!(!map.contains_key("Cross-Origin-Opener-Policy"));
@@ -109,7 +208,7 @@ mod tests {
     #[test]
     fn dev_build_gets_cache_control() {
         let path = PathBuf::from("/app/out/vs/base/common/network.js");
-        let headers = headers_for_path(&path, true);
+        let headers = headers_for_path(&path, true, None);
         let map = header_map(&headers);
         assert_eq!(map.get("Cache-Control"), Some(&"no-cache, no-store"));
     }
@@ -117,7 +216,7 @@ mod tests {
     #[test]
     fn production_build_no_cache_control() {
         let path = PathBuf::from("/app/out/vs/base/common/network.js");
-        let headers = headers_for_path(&path, false);
+        let headers = headers_for_path(&path, false, None);
         let map = header_map(&headers);
         assert!(!map.contains_key("Cache-Control"));
     }
@@ -125,7 +224,7 @@ mod tests {
     #[test]
     fn index_html_treated_as_workbench() {
         let path = PathBuf::from("/app/workbench/index.html");
-        let headers = headers_for_path(&path, false);
+        let headers = headers_for_path(&path, false, None);
         let map = header_map(&headers);
         assert!(map.contains_key("Cross-Origin-Opener-Policy"));
     }

--- a/src-tauri/src/protocol/mod.rs
+++ b/src-tauri/src/protocol/mod.rs
@@ -106,12 +106,21 @@ pub fn handle_vscode_file_protocol<R: tauri::Runtime>(
 {
     move |_ctx: UriSchemeContext<'_, R>, request: Request<Vec<u8>>| {
         let raw_uri = request.uri().to_string();
+        let request_origin = request
+            .headers()
+            .get("Origin")
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_string());
 
-        match serve_file(&state, &raw_uri) {
+        match serve_file(&state, &raw_uri, request_origin.as_deref()) {
             Ok(response) => response,
             Err(e) => {
                 log::error!(target: "vscodeee::protocol", "{e}");
-                error_response(e.status_code(), e.reason().as_bytes())
+                error_response(
+                    e.status_code(),
+                    e.reason().as_bytes(),
+                    request_origin.as_deref(),
+                )
             }
         }
     }
@@ -123,7 +132,11 @@ pub fn handle_vscode_file_protocol<R: tauri::Runtime>(
 /// validation (step 2) and file read (step 3). A symlink could be swapped in after
 /// validation. Electron's `ProtocolMainService` has the same pattern. For production,
 /// consider using `O_NOFOLLOW` or re-validating the file descriptor after open.
-fn serve_file(state: &ProtocolState, raw_uri: &str) -> Result<Response<Vec<u8>>, ProtocolError> {
+fn serve_file(
+    state: &ProtocolState,
+    raw_uri: &str,
+    request_origin: Option<&str>,
+) -> Result<Response<Vec<u8>>, ProtocolError> {
     // 1. Parse URI → canonical path
     let canonical_path = uri::parse_vscode_file_uri(raw_uri)?;
 
@@ -139,9 +152,9 @@ fn serve_file(state: &ProtocolState, raw_uri: &str) -> Result<Response<Vec<u8>>,
     // TODO(Phase 1): Mitigate TOCTOU — open with O_NOFOLLOW, then read from fd
     let content = std::fs::read(&canonical_path)?;
 
-    // 4. Compute headers
+    // 4. Compute headers (pass request origin for dynamic CORS)
     let mime_type = mime::mime_from_path(&canonical_path);
-    let security_headers = headers::headers_for_path(&canonical_path, state.is_dev);
+    let security_headers = headers::headers_for_path(&canonical_path, state.is_dev, request_origin);
 
     // 5. Build response
     let mut builder = Response::builder()
@@ -149,7 +162,7 @@ fn serve_file(state: &ProtocolState, raw_uri: &str) -> Result<Response<Vec<u8>>,
         .header("Content-Type", mime_type);
 
     for (key, value) in &security_headers {
-        builder = builder.header(*key, *value);
+        builder = builder.header(key.as_str(), value.as_str());
     }
 
     builder
@@ -161,11 +174,20 @@ fn serve_file(state: &ProtocolState, raw_uri: &str) -> Result<Response<Vec<u8>>,
 ///
 /// CORS headers are required even on error responses, otherwise WKWebView's
 /// fetch() will report "Load failed" instead of the actual status code.
-fn error_response(status: u16, body: &[u8]) -> Response<Vec<u8>> {
+fn error_response(status: u16, body: &[u8], request_origin: Option<&str>) -> Response<Vec<u8>> {
+    // Use the same CORS origin resolution as success responses
+    let dummy_path = std::path::PathBuf::from("error");
+    let cors_headers = headers::headers_for_path(&dummy_path, false, request_origin);
+    let cors_origin = cors_headers
+        .iter()
+        .find(|(k, _)| k == "Access-Control-Allow-Origin")
+        .map(|(_, v)| v.as_str())
+        .unwrap_or("tauri://localhost");
+
     Response::builder()
         .status(status)
         .header("Content-Type", "text/plain; charset=utf-8")
-        .header("Access-Control-Allow-Origin", "tauri://localhost")
+        .header("Access-Control-Allow-Origin", cors_origin)
         .body(body.to_vec())
         .unwrap_or_else(|_| {
             Response::builder()
@@ -202,7 +224,7 @@ mod tests {
             file.canonicalize().unwrap().display()
         );
 
-        let result = serve_file(&state, &uri);
+        let result = serve_file(&state, &uri, None);
         assert!(result.is_ok());
 
         let resp = result.unwrap();
@@ -221,7 +243,7 @@ mod tests {
 
         // /usr/bin/env is definitely outside tmp
         let uri = "vscode-file://vscode-app/usr/bin/env";
-        let result = serve_file(&state, uri);
+        let result = serve_file(&state, uri, None);
 
         // Should be either Forbidden (if file exists) or NotFound
         assert!(result.is_err());
@@ -242,7 +264,7 @@ mod tests {
             css_file.canonicalize().unwrap().display()
         );
 
-        let resp = serve_file(&state, &uri).unwrap();
+        let resp = serve_file(&state, &uri, None).unwrap();
         let content_type = resp
             .headers()
             .get("Content-Type")
@@ -256,8 +278,34 @@ mod tests {
     }
 
     #[test]
+    fn serve_file_with_dev_origin_cors() {
+        let tmp = std::env::temp_dir().join("vscodee_proto_cors");
+        let _ = fs::create_dir_all(&tmp);
+        let file = tmp.join("app.js");
+        fs::write(&file, b"export {};").unwrap();
+
+        let state = test_state_with_root(&tmp);
+        let uri = format!(
+            "vscode-file://vscode-app{}",
+            file.canonicalize().unwrap().display()
+        );
+
+        let resp = serve_file(&state, &uri, Some("http://127.0.0.1:1430")).unwrap();
+        let cors = resp
+            .headers()
+            .get("Access-Control-Allow-Origin")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert_eq!(cors, "http://127.0.0.1:1430");
+
+        let _ = fs::remove_file(&file);
+        let _ = fs::remove_dir(&tmp);
+    }
+
+    #[test]
     fn error_response_includes_content_type() {
-        let resp = error_response(404, b"Not Found");
+        let resp = error_response(404, b"Not Found", None);
         assert_eq!(resp.status(), 404);
         let ct = resp
             .headers()
@@ -266,5 +314,17 @@ mod tests {
             .to_str()
             .unwrap();
         assert!(ct.contains("text/plain"));
+    }
+
+    #[test]
+    fn error_response_uses_request_origin_for_cors() {
+        let resp = error_response(403, b"Forbidden", Some("http://127.0.0.1:1430"));
+        let cors = resp
+            .headers()
+            .get("Access-Control-Allow-Origin")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert_eq!(cors, "http://127.0.0.1:1430");
     }
 }

--- a/src/vs/workbench/services/extensions/worker/webWorkerExtensionHostIframe.html
+++ b/src/vs/workbench/services/extensions/worker/webWorkerExtensionHostIframe.html
@@ -5,7 +5,7 @@
 			default-src 'none';
 			child-src 'self' data: blob:;
 			script-src 'self' 'unsafe-eval' 'sha256-cl8ijlOzEe+0GRCQNJQu2k6nUQ0fAYNYIuuKEm72JDs=' https: http://localhost:* blob:;
-			connect-src 'self' https: wss: http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:*;"/>
+			connect-src 'self' https: wss: http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:* vscode-file:;"/>
 	</head>
 	<body>
 	<script>


### PR DESCRIPTION
## Summary

- Add `vscode-file:` to `webWorkerExtensionHostIframe.html` CSP `connect-src` directive so the Web Worker Extension Host can fetch extension JS modules via the custom protocol
- Fix CORS by dynamically resolving `Access-Control-Allow-Origin` from the request `Origin` header against an allow-list (`tauri://localhost`, `https://tauri.localhost`, `http://127.0.0.1:*`, `http://localhost:*`)
- Unknown origins fall back to `tauri://localhost` (effectively denying CORS)

## Changes

| File | Change |
|------|--------|
| `src/vs/workbench/services/extensions/worker/webWorkerExtensionHostIframe.html` | Add `vscode-file:` to CSP `connect-src` (1-line change) |
| `src-tauri/src/protocol/headers.rs` | Replace fixed `TAURI_ORIGIN` with dynamic `resolve_cors_origin()` using allow-list; change `Header` type from `(&'static str, &'static str)` to `(String, String)` |
| `src-tauri/src/protocol/mod.rs` | Extract `Origin` header from requests and pass to `headers_for_path()` and `error_response()` |

## Testing

- All 51 Rust tests pass (`cargo test --lib`), including 6 new CORS tests
- Manual verification: CSP and CORS errors for extension loading are resolved (404 remains due to extension browser bundles not yet being built — separate issue, requires `transpile-extensions` from exthost-local branch)

Closes #53