### PR TITLE
fix: use fetch() for vscode-file:// scheme in extension resource loader

### DIFF
--- a/src/vs/platform/extensionResourceLoader/browser/extensionResourceLoaderService.ts
+++ b/src/vs/platform/extensionResourceLoader/browser/extensionResourceLoaderService.ts
@@ -34,7 +34,11 @@ class ExtensionResourceLoaderService extends AbstractExtensionResourceLoaderServ
 	async readExtensionResource(uri: URI): Promise<string> {
 		uri = FileAccess.uriToBrowserUri(uri);
 
-		if (uri.scheme !== Schemas.http && uri.scheme !== Schemas.https && uri.scheme !== Schemas.data) {
+		// In Tauri, file:// URIs are rewritten to vscode-file:// by uriToBrowserUri.
+		// The vscode-file:// scheme is served by Tauri's custom protocol handler, not
+		// by an IFileService provider, so we must use fetch() to load these resources.
+		// For http/https/data schemes, we also use fetch() (with optional gallery headers).
+		if (uri.scheme !== Schemas.http && uri.scheme !== Schemas.https && uri.scheme !== Schemas.data && uri.scheme !== Schemas.vscodeFileResource) {
 			const result = await this._fileService.readFile(uri);
 			return result.value.toString();
 		}


### PR DESCRIPTION
## Summary

- Add `Schemas.vscodeFileResource` to the scheme check in `readExtensionResource()` so that `vscode-file://` URIs are loaded via `fetch()` instead of `_fileService.readFile()`
- In Tauri, `file://` URIs are rewritten to `vscode-file://` by `uriToBrowserUri`, but no `FileSystemProvider` is registered for that scheme, causing ENOPRO errors
- This fixes icon theme font loading failures (e.g., `seti.woff`) and other extension resource loading errors in Tauri WebView

## Problem

When loading extension resources in Tauri:
1. `uriToBrowserUri()` rewrites `file://` to `vscode-file://`
2. `readExtensionResource()` tries to use `_fileService.readFile()` for `vscode-file://` URIs
3. No `FileSystemProvider` is registered for `vscode-file://` → **ENOPRO error**
4. Theme reload fails → cached CSS with stale `file://` paths persists → `seti.woff` load errors

## Fix

Add `Schemas.vscodeFileResource` to the condition in `readExtensionResource()` that determines whether to use `fetch()` or `_fileService.readFile()`. Since `vscode-file://` is served by Tauri's custom protocol handler (not by an IFileService provider), it must be fetched via HTTP like `http://` and `https://` schemes.

## Changed Files

- `src/vs/platform/extensionResourceLoader/browser/extensionResourceLoaderService.ts` (1 line change + comments)

## Testing

- Verified that icon theme fonts (seti.woff) load correctly after the fix
- Verified that `npm run transpile` succeeds
- Verified that Rust tests (51 tests) pass