### PR TITLE
docs: add Known Limitations section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,17 @@ The following features depend on Chrome DevTools Protocol (CDP), which has no pu
 > [!NOTE]
 > These features may be revisited if Tauri adds CDP support in the future, or if alternative approaches become viable.
 
+## Known Limitations
+
+Architectural differences between Electron (bundled Chromium) and Tauri (native system WebView) introduce permanent or platform-specific limitations.
+
+| Feature | Limitation | Platform Details |
+| --- | --- | --- |
+| `setBackgroundThrottling` | WebView internal JS timer/animation throttling cannot be controlled externally | All platforms — `NSProcessInfo.beginActivity()` (macOS) can prevent OS-level throttling, but WebView-internal behavior remains uncontrollable. |
+
+> [!NOTE]
+> This list covers inherent platform limitations. Features that are simply not yet implemented are tracked in individual GitHub Issues.
+
 ## Contributing
 
 Issues and PRs are welcome.<br>


### PR DESCRIPTION
## Summary

Add a new **Known Limitations** section to the README documenting inherent platform limitations from using Tauri's native system WebView instead of Electron's bundled Chromium.

## Changes

- New "Known Limitations" section placed after "MVP Excluded Features"
- Documents `setBackgroundThrottling` as the only permanent limitation (WebView-internal JS timer/animation throttling cannot be controlled externally)
- Includes a note clarifying that unimplemented features are tracked in individual GitHub Issues

## Context

This distinguishes between:
- **MVP Excluded Features** — CDP-dependent features that may become possible in the future
- **Known Limitations** — Inherent architectural constraints from the Electron → Tauri migration