### PR TITLE
fix: enable SCM/git extension in Tauri desktop environment

### DIFF
--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -10,7 +10,8 @@ import * as cp from 'child_process';
 import { fileURLToPath } from 'url';
 import which from 'which';
 import { EventEmitter } from 'events';
-import { fileTypeFromBuffer } from 'file-type';
+// file-type is an ESM-only package; use dynamic import() for CJS compatibility
+// import { fileTypeFromBuffer } from 'file-type';
 import { assign, groupBy, IDisposable, toDisposable, dispose, mkdirp, readBytes, detectUnicodeEncoding, Encoding, onceEvent, splitInChunks, Limiter, Versions, isWindows, pathEquals, isMacintosh, isDescendant, relativePathWithNoFallback, Mutable } from './util';
 import { CancellationError, CancellationToken, ConfigurationChangeEvent, LogOutputChannel, Progress, Uri, workspace } from 'vscode';
 import type { Commit as ApiCommit, Ref, Branch, Remote, LogOptions, Change, CommitOptions, RefQuery as ApiRefQuery, InitOptions, DiffChange, Worktree as ApiWorktree } from './api/git';
@@ -1691,6 +1692,7 @@ export class Repository {
 		}
 
 		if (!isText) {
+			const { fileTypeFromBuffer } = await import('file-type');
 			const result = await fileTypeFromBuffer(buffer);
 
 			if (!result) {

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -3,7 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { cp } from '@vscode/fs-copyfile';
+// Dynamic import: @vscode/fs-copyfile is ESM-only ("type": "module")
+// and cannot be require()'d from CJS-transpiled output.
+// import { cp } from '@vscode/fs-copyfile';
 import TelemetryReporter from '@vscode/extension-telemetry';
 import { uniqueNamesGenerator, adjectives, animals, colors, NumberDictionary } from '@joaomoreno/unique-names-generator';
 import * as fs from 'fs';
@@ -2089,6 +2091,7 @@ export class Repository implements Disposable {
 				return limiter.queue(async () => {
 					const targetFile = path.join(worktreePath, relativePath(this.root, sourceFile));
 					await fsPromises.mkdir(path.dirname(targetFile), { recursive: true });
+						const { cp } = await import('@vscode/fs-copyfile');
 					await cp(sourceFile, targetFile, { force: true, recursive: true, verbatimSymlinks: true });
 				});
 			}));

--- a/src-tauri/src/exthost/sidecar.rs
+++ b/src-tauri/src/exthost/sidecar.rs
@@ -25,6 +25,50 @@ use tokio::process::{Child, Command};
 
 use super::ExtHostError;
 
+/// Build an enriched PATH for the Extension Host child process.
+///
+/// macOS app bundles inherit a minimal PATH (`/usr/bin:/bin:/usr/sbin:/sbin`)
+/// because launchd does not source shell profiles. Tools like `git` are
+/// commonly installed in `/opt/homebrew/bin` (Apple Silicon), `/usr/local/bin`
+/// (Intel Homebrew / manual install), or via Xcode CLT at `/usr/bin`.
+///
+/// This function takes the current process's PATH and prepends any
+/// well-known directories that are missing, so that child processes
+/// (in particular the `git` extension calling `which git`) can find them.
+fn build_exthost_path() -> String {
+    let current = std::env::var("PATH").unwrap_or_default();
+    let existing: std::collections::HashSet<&str> = current.split(':').collect();
+
+    // Well-known directories where git and other developer tools live.
+    // Order matters: higher-priority directories come first.
+    let extra_dirs: &[&str] = if cfg!(target_os = "macos") {
+        &[
+            "/opt/homebrew/bin",  // Apple Silicon Homebrew
+            "/opt/homebrew/sbin",
+            "/usr/local/bin",    // Intel Homebrew / manual installs
+            "/usr/local/sbin",
+        ]
+    } else {
+        // Linux: /usr/local/bin is the most common extra location
+        &["/usr/local/bin", "/usr/local/sbin"]
+    };
+
+    let mut parts: Vec<&str> = Vec::new();
+    for dir in extra_dirs {
+        if !existing.contains(dir) {
+            parts.push(dir);
+        }
+    }
+
+    if parts.is_empty() {
+        current
+    } else {
+        // Prepend extra dirs so they take priority
+        parts.push(&current);
+        parts.join(":")
+    }
+}
+
 /// A running Extension Host sidecar process with its named pipe path.
 ///
 /// Owns the child process handle and the socket path. When dropped,
@@ -114,6 +158,15 @@ async fn spawn_and_connect(
     // Mirrors extensionHostConnection.ts:272-288
     let node_bin = "node"; // PoC: use system node
 
+    // Enrich PATH so child processes (e.g., `git` extension calling `which git`)
+    // can find tools installed in non-default locations. This is critical on
+    // macOS where app bundles inherit a minimal PATH from launchd.
+    let enriched_path = build_exthost_path();
+    log::info!(
+        target: "vscodeee::exthost::sidecar",
+        "ExtHost PATH: {enriched_path}"
+    );
+
     let mut child = Command::new(node_bin)
         .arg("--dns-result-order=ipv4first")
         // Node.js 22+ enables require(esm) by default, which uses Atomics.wait()
@@ -124,6 +177,7 @@ async fn spawn_and_connect(
         .arg("out/bootstrap-fork.js")
         .arg("--type=extensionHost")
         .current_dir(app_root)
+        .env("PATH", &enriched_path)
         .env("VSCODE_EXTHOST_IPC_HOOK", pipe_path)
         .env(
             "VSCODE_ESM_ENTRYPOINT",

--- a/src/vs/workbench/services/extensionManagement/tauri-browser/tauriExtensionManagementServerService.ts
+++ b/src/vs/workbench/services/extensionManagement/tauri-browser/tauriExtensionManagementServerService.ts
@@ -1,0 +1,99 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) VS Codeee Contributors. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { localize } from '../../../../nls.js';
+import { ExtensionInstallLocation, IExtensionManagementServer, IExtensionManagementServerService } from '../common/extensionManagement.js';
+import { IRemoteAgentService } from '../../remote/common/remoteAgentService.js';
+import { Schemas } from '../../../../base/common/network.js';
+import { IChannel } from '../../../../base/parts/ipc/common/ipc.js';
+import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
+import { ILabelService } from '../../../../platform/label/common/label.js';
+import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
+import { WebExtensionManagementService } from '../common/webExtensionManagementService.js';
+import { IExtension } from '../../../../platform/extensions/common/extensions.js';
+import { RemoteExtensionManagementService } from '../common/remoteExtensionManagementService.js';
+
+/**
+ * Extension management server service for the Tauri desktop environment.
+ *
+ * Unlike the browser version, Tauri has a local Node.js process that can run
+ * workspace-type extensions (like `vscode.git`). This service sets up a
+ * `localExtensionManagementServer` backed by the web extension management
+ * service, which ensures that:
+ *
+ * 1. Built-in extensions with `extensionKind: ['workspace']` are NOT disabled
+ *    by `_isDisabledByExtensionKind()` in the enablement service.
+ *    (Without `localExtensionManagementServer`, all built-in extensions get
+ *    assigned to `webExtensionManagementServer`, causing workspace-type
+ *    extensions to be disabled as "not supported in the web".)
+ *
+ * 2. `getExtensionInstallLocation()` returns `Local` for built-in extensions,
+ *    matching the Desktop VS Code behavior.
+ *
+ * The key difference from the browser `ExtensionManagementServerService`:
+ * - Browser: `localExtensionManagementServer = null`, `webExtensionManagementServer = non-null`
+ * - Desktop: `localExtensionManagementServer = non-null`, `webExtensionManagementServer = null`
+ * - Tauri:   `localExtensionManagementServer = non-null`, `webExtensionManagementServer = null`
+ *
+ * By setting `webExtensionManagementServer = null`, the `_isDisabledByExtensionKind()`
+ * check in the enablement service skips entirely (the condition requires
+ * `remoteExtensionManagementServer || webExtensionManagementServer`), which
+ * means all extensions are enabled regardless of their extensionKind — matching
+ * the Desktop behavior.
+ */
+export class TauriExtensionManagementServerService implements IExtensionManagementServerService {
+
+	declare readonly _serviceBrand: undefined;
+
+	readonly localExtensionManagementServer: IExtensionManagementServer | null;
+	readonly remoteExtensionManagementServer: IExtensionManagementServer | null = null;
+	readonly webExtensionManagementServer: IExtensionManagementServer | null = null;
+
+	constructor(
+		@IRemoteAgentService remoteAgentService: IRemoteAgentService,
+		@ILabelService labelService: ILabelService,
+		@IInstantiationService instantiationService: IInstantiationService,
+	) {
+		const remoteAgentConnection = remoteAgentService.getConnection();
+		if (remoteAgentConnection) {
+			const extensionManagementService = instantiationService.createInstance(RemoteExtensionManagementService, remoteAgentConnection.getChannel<IChannel>('extensions'));
+			this.remoteExtensionManagementServer = {
+				id: 'remote',
+				extensionManagementService,
+				get label() { return labelService.getHostLabel(Schemas.vscodeRemote, remoteAgentConnection.remoteAuthority) || localize('remote', "Remote"); },
+			};
+		}
+
+		// In Tauri, we use WebExtensionManagementService as the backing service
+		// for the local server, since extensions are scanned via Rust and loaded
+		// through the web extension scanner pipeline. The key difference from
+		// the browser version is that we assign this to localExtensionManagementServer
+		// (not webExtensionManagementServer), which prevents workspace-type
+		// extensions from being disabled by the enablement service.
+		const extensionManagementService = instantiationService.createInstance(WebExtensionManagementService);
+		this.localExtensionManagementServer = {
+			id: 'local',
+			extensionManagementService,
+			label: localize('local', "Local"),
+		};
+	}
+
+	getExtensionManagementServer(extension: IExtension): IExtensionManagementServer {
+		if (extension.location.scheme === Schemas.vscodeRemote) {
+			return this.remoteExtensionManagementServer!;
+		}
+		return this.localExtensionManagementServer!;
+	}
+
+	getExtensionInstallLocation(extension: IExtension): ExtensionInstallLocation | null {
+		const server = this.getExtensionManagementServer(extension);
+		if (server === this.remoteExtensionManagementServer) {
+			return ExtensionInstallLocation.Remote;
+		}
+		return ExtensionInstallLocation.Local;
+	}
+}
+
+registerSingleton(IExtensionManagementServerService, TauriExtensionManagementServerService, InstantiationType.Delayed);

--- a/src/vs/workbench/services/extensions/tauri-browser/tauriExtensionService.ts
+++ b/src/vs/workbench/services/extensions/tauri-browser/tauriExtensionService.ts
@@ -7,7 +7,7 @@ import { mainWindow } from '../../../../base/browser/window.js';
 import { Schemas } from '../../../../base/common/network.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IDialogService } from '../../../../platform/dialogs/common/dialogs.js';
-import { IExtensionDescription } from '../../../../platform/extensions/common/extensions.js';
+import { IBuiltinExtensionsScannerService, IExtensionDescription } from '../../../../platform/extensions/common/extensions.js';
 import { IFileService } from '../../../../platform/files/common/files.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
@@ -70,6 +70,7 @@ export class TauriExtensionService extends AbstractExtensionService implements I
 		@IWorkspaceTrustManagementService private readonly _workspaceTrustManagementService: IWorkspaceTrustManagementService,
 		@IRemoteExplorerService private readonly _remoteExplorerService: IRemoteExplorerService,
 		@IDialogService dialogService: IDialogService,
+		@IBuiltinExtensionsScannerService private readonly _builtinExtensionsScannerService: IBuiltinExtensionsScannerService,
 	) {
 		const extensionsProposedApi = instantiationService.createInstance(ExtensionsProposedApi);
 		const extensionHostFactory = new TauriExtensionHostFactory(
@@ -130,8 +131,14 @@ export class TauriExtensionService extends AbstractExtensionService implements I
 	}
 
 	/**
-	 * Scan all web extensions (system, user, and under-development) and return
+	 * Scan all extensions (system, user, and under-development) and return
 	 * a deduplicated list. Results are cached after the first call.
+	 *
+	 * Unlike the browser version, this uses IBuiltinExtensionsScannerService
+	 * directly for system extensions to ensure Node.js-only extensions
+	 * (those with only a `main` field, no `browser` field) like `vscode.git`
+	 * are included. The WebExtensionsScannerService would filter these out
+	 * because they cannot execute on the web.
 	 */
 	private _scanWebExtensionsPromise: Promise<IExtensionDescription[]> | undefined;
 	private async _scanWebExtensions(): Promise<IExtensionDescription[]> {
@@ -140,7 +147,12 @@ export class TauriExtensionService extends AbstractExtensionService implements I
 				const system: IExtensionDescription[] = [], user: IExtensionDescription[] = [], development: IExtensionDescription[] = [];
 				try {
 					await Promise.all([
-						this._webExtensionsScannerService.scanSystemExtensions().then(extensions => system.push(...extensions.map(e => toExtensionDescription(e)))),
+						// Use IBuiltinExtensionsScannerService directly instead of
+						// _webExtensionsScannerService.scanSystemExtensions() to include
+						// Node.js-only extensions (main-only, no browser field) like git.
+						this._builtinExtensionsScannerService.scanBuiltinExtensions().then(extensions => {
+							system.push(...extensions.map(e => toExtensionDescription(e)));
+						}),
 						this._webExtensionsScannerService.scanUserExtensions(this._userDataProfileService.currentProfile.extensionsResource, { skipInvalidExtensions: true }).then(extensions => user.push(...extensions.map(e => toExtensionDescription(e)))),
 						this._webExtensionsScannerService.scanExtensionsUnderDevelopment().then(extensions => development.push(...extensions.map(e => toExtensionDescription(e, true)))),
 					]);

--- a/src/vs/workbench/workbench.tauri.main.ts
+++ b/src/vs/workbench/workbench.tauri.main.ts
@@ -54,7 +54,7 @@ import './services/extensions/tauri-browser/tauriExtensionService.js';
 import './services/extensionManagement/browser/extensionsProfileScannerService.js';
 import './services/extensions/browser/extensionsScannerService.js';
 import './services/extensionManagement/browser/webExtensionsScannerService.js';
-import './services/extensionManagement/common/extensionManagementServerService.js';
+import './services/extensionManagement/tauri-browser/tauriExtensionManagementServerService.js';
 import './services/mcp/browser/mcpWorkbenchManagementService.js';
 import './services/extensionManagement/browser/extensionGalleryManifestService.js';
 import './services/telemetry/browser/telemetryService.js';


### PR DESCRIPTION
## Summary

Fixes #61 — SCM panel showing "No source control providers registered" after ESM fix.

## Root Causes & Fixes

### 1. Extension Scanning (Node.js-only extensions excluded)
- **Problem**: `_scanWebExtensions()` used `WebExtensionsScannerService.scanSystemExtensions()` which filters out extensions without a `browser` field (94 → 80 extensions)
- **Fix**: Use `IBuiltinExtensionsScannerService.scanBuiltinExtensions()` directly in `tauriExtensionService.ts` to include all built-in extensions

### 2. Extension Enablement (workspace-type extensions disabled)
- **Problem**: `ExtensionManagementServerService` set only `webExtensionManagementServer` (no `localExtensionManagementServer`), causing `_isDisabledByExtensionKind()` to disable workspace-type extensions like `vscode.git` as "not supported in VS Codeee for the Web"
- **Fix**: Create `TauriExtensionManagementServerService` that sets `localExtensionManagementServer` (matching Desktop VS Code behavior), so the enablement check is skipped entirely

### 3. ESM Compatibility (require() of ESM-only packages)
- **Problem**: `file-type` and `@vscode/fs-copyfile` are ESM-only packages (`"type": "module"`) that cannot be `require()`'d from CJS-transpiled extension output
- **Fix**: Convert static imports to dynamic `import()` calls in `git.ts` and `repository.ts`

### 4. PATH Enrichment (git binary not found)
- **Problem**: macOS app bundles inherit a minimal PATH from launchd, missing `/opt/homebrew/bin` and `/usr/local/bin` where `git` is commonly installed
- **Fix**: `build_exthost_path()` in `sidecar.rs` prepends well-known tool directories to the child process PATH

## Changed Files

| File | Change |
|------|--------|
| `extensions/git/src/git.ts` | Dynamic import for `file-type` |
| `extensions/git/src/repository.ts` | Dynamic import for `@vscode/fs-copyfile` |
| `src-tauri/src/exthost/sidecar.rs` | `build_exthost_path()` + PATH env |
| `src/vs/workbench/services/extensions/tauri-browser/tauriExtensionService.ts` | Use `IBuiltinExtensionsScannerService` for scanning |
| `src/vs/workbench/services/extensionManagement/tauri-browser/tauriExtensionManagementServerService.ts` | **New** — Tauri-specific server service |
| `src/vs/workbench/workbench.tauri.main.ts` | Import path update |

## Testing

- Verified SCM panel shows repository and changed files
- Verified `vscode.git` extension activates without errors
- Verified diff view works correctly
- Transpile check passed (743 files across 32 extensions)