### PR TITLE
feat: register DevTools toggle command in command palette

### DIFF
--- a/src-tauri/src/commands/native_host/window.rs
+++ b/src-tauri/src/commands/native_host/window.rs
@@ -247,3 +247,43 @@ pub fn get_cursor_screen_point(window: tauri::Window) -> Result<CursorScreenInfo
         },
     })
 }
+
+// ─── DevTools commands ──────────────────────────────────────────────────
+// NOTE: These commands use `tauri::WebviewWindow` instead of `tauri::Window`
+// because `open_devtools()` / `close_devtools()` / `is_devtools_open()` are
+// webview-specific APIs in Tauri 2.0.
+
+/// Open the developer tools for the given webview window.
+///
+/// Only works in debug builds or when the `devtools` feature flag is enabled.
+/// On macOS this uses a private API (WKWebView._inspectElement) and is not
+/// suitable for App Store distribution.
+#[tauri::command]
+pub fn open_devtools(window: tauri::WebviewWindow) -> Result<(), NativeHostError> {
+    window.open_devtools();
+    Ok(())
+}
+
+/// Close the developer tools for the given webview window.
+#[tauri::command]
+pub fn close_devtools(window: tauri::WebviewWindow) -> Result<(), NativeHostError> {
+    window.close_devtools();
+    Ok(())
+}
+
+/// Check whether the developer tools are currently open.
+#[tauri::command]
+pub fn is_devtools_open(window: tauri::WebviewWindow) -> Result<bool, NativeHostError> {
+    Ok(window.is_devtools_open())
+}
+
+/// Toggle the developer tools open/closed state.
+#[tauri::command]
+pub fn toggle_devtools(window: tauri::WebviewWindow) -> Result<(), NativeHostError> {
+    if window.is_devtools_open() {
+        window.close_devtools();
+    } else {
+        window.open_devtools();
+    }
+    Ok(())
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -118,6 +118,11 @@ pub fn run() {
             commands::native_host::set_minimum_size,
             commands::native_host::get_active_window_position,
             commands::native_host::get_cursor_screen_point,
+            // ── DevTools commands ──
+            commands::native_host::open_devtools,
+            commands::native_host::close_devtools,
+            commands::native_host::is_devtools_open,
+            commands::native_host::toggle_devtools,
             // ── Clipboard commands ──
             commands::native_host::read_clipboard_text,
             commands::native_host::write_clipboard_text,

--- a/src/vs/platform/native/tauri-browser/nativeHostService.ts
+++ b/src/vs/platform/native/tauri-browser/nativeHostService.ts
@@ -638,11 +638,11 @@ export class TauriNativeHostService extends Disposable implements INativeHostSer
 	// #region Development
 
 	async openDevTools(_options?: Partial<OpenDevToolsOptions> & INativeHostOptions): Promise<void> {
-		// Cannot open DevTools in system WebView — no-op
+		return invoke('open_devtools');
 	}
 
 	async toggleDevTools(_options?: INativeHostOptions): Promise<void> {
-		// Cannot toggle DevTools in system WebView — no-op
+		return invoke('toggle_devtools');
 	}
 
 	async openGPUInfoWindow(): Promise<void> { }

--- a/src/vs/workbench/tauri-browser/actions/developerActions.ts
+++ b/src/vs/workbench/tauri-browser/actions/developerActions.ts
@@ -1,0 +1,38 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) VS Codeee Contributors. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { localize2 } from '../../../nls.js';
+import { Action2, registerAction2 } from '../../../platform/actions/common/actions.js';
+import { Categories } from '../../../platform/action/common/actionCommonCategories.js';
+import { KeybindingWeight } from '../../../platform/keybinding/common/keybindingsRegistry.js';
+import { KeyCode, KeyMod } from '../../../base/common/keyCodes.js';
+import { INativeHostService } from '../../../platform/native/common/native.js';
+import { ServicesAccessor } from '../../../platform/instantiation/common/instantiation.js';
+
+class ToggleDevToolsAction extends Action2 {
+	constructor() {
+		super({
+			id: 'workbench.action.toggleDevTools',
+			title: localize2('toggleDevTools', "Toggle Developer Tools"),
+			category: Categories.Developer,
+			f1: true,
+			keybinding: {
+				weight: KeybindingWeight.WorkbenchContrib,
+				primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.KeyI,
+				mac: { primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.KeyI }
+			}
+		});
+	}
+
+	run(accessor: ServicesAccessor): void {
+		const nativeHostService = accessor.get(INativeHostService);
+		nativeHostService.toggleDevTools();
+	}
+}
+
+registerAction2(ToggleDevToolsAction);
+
+// TODO(Phase 2): Add OpenDevToolsAction with mode support (right, bottom, undocked)
+// TODO(Phase 2): Gate DevTools commands behind debug builds only in production

--- a/src/vs/workbench/workbench.tauri.main.ts
+++ b/src/vs/workbench/workbench.tauri.main.ts
@@ -30,6 +30,13 @@ import './tauri-browser/desktop.tauri.main.js';
 //#endregion
 
 
+//#region --- workbench actions (Tauri-specific)
+
+import './tauri-browser/actions/developerActions.js';
+
+//#endregion
+
+
 //#region --- workbench services (Tauri-specific overrides)
 
 import './services/lifecycle/tauri-browser/lifecycleService.js';


### PR DESCRIPTION
## Summary

- Add Tauri-specific DevTools commands (`open_devtools`, `close_devtools`, `is_devtools_open`, `toggle_devtools`) in Rust using `WebviewWindow` API
- Replace no-op `openDevTools()`/`toggleDevTools()` in `nativeHostService.ts` with actual `invoke()` calls to the new Rust commands
- Register `ToggleDevToolsAction` in the command palette with keybinding `Cmd+Alt+I` (macOS) / `Ctrl+Alt+I` (Windows/Linux)

## Test plan

- [ ] Build and launch the app in debug mode
- [ ] Open command palette (`Cmd+Shift+P`) and search for "Developer: Toggle Developer Tools"
- [ ] Execute the command and verify DevTools (Web Inspector) opens
- [ ] Execute again and verify DevTools closes
- [ ] Press `Cmd+Alt+I` and verify the keybinding works
- [ ] Verify no errors in the DevTools console

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)