### PR TITLE
fix: extract shared extension types to avoid gulp-vinyl-zip import error

### DIFF
--- a/build/lib/extensions-shared.ts
+++ b/build/lib/extensions-shared.ts
@@ -1,0 +1,55 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Shared types and utilities for extensions that are used by both the gulp build
+// system (build/lib/extensions.ts) and the esbuild-based build (build/next/index.ts).
+// This module is intentionally kept free of heavy dependencies (like gulp-vinyl-zip)
+// so it can be imported without pulling in the full gulp build infrastructure.
+
+type ExtensionKind = 'ui' | 'workspace' | 'web';
+
+export interface IExtensionManifest {
+	main?: string;
+	browser?: string;
+	extensionKind?: ExtensionKind | ExtensionKind[];
+	extensionPack?: string[];
+	extensionDependencies?: string[];
+	contributes?: { [id: string]: any };
+}
+
+/**
+ * Loosely based on `getExtensionKind` from `src/vs/workbench/services/extensions/common/extensionManifestPropertiesService.ts`
+ */
+export function isWebExtension(manifest: IExtensionManifest): boolean {
+	if (Boolean(manifest.browser)) {
+		return true;
+	}
+	if (Boolean(manifest.main)) {
+		return false;
+	}
+	// neither browser nor main
+	if (typeof manifest.extensionKind !== 'undefined') {
+		const extensionKind = Array.isArray(manifest.extensionKind) ? manifest.extensionKind : [manifest.extensionKind];
+		if (extensionKind.indexOf('web') >= 0) {
+			return true;
+		}
+	}
+	if (typeof manifest.contributes !== 'undefined') {
+		for (const id of ['debuggers', 'terminal', 'typescriptServerPlugins']) {
+			if (manifest.contributes.hasOwnProperty(id)) {
+				return false;
+			}
+		}
+	}
+	return true;
+}
+
+export interface IScannedBuiltinExtension {
+	readonly extensionPath: string;
+	readonly packageJSON: unknown;
+	readonly packageNLS: unknown | undefined;
+	readonly readmePath: string | undefined;
+	readonly changelogPath: string | undefined;
+}

--- a/build/lib/extensions.ts
+++ b/build/lib/extensions.ts
@@ -322,41 +322,11 @@ const productJson = JSON.parse(fs.readFileSync(path.join(import.meta.dirname, '.
 const builtInExtensions: IExtensionDefinition[] = productJson.builtInExtensions || [];
 const webBuiltInExtensions: IExtensionDefinition[] = productJson.webBuiltInExtensions || [];
 
-type ExtensionKind = 'ui' | 'workspace' | 'web';
-interface IExtensionManifest {
-	main?: string;
-	browser?: string;
-	extensionKind?: ExtensionKind | ExtensionKind[];
-	extensionPack?: string[];
-	extensionDependencies?: string[];
-	contributes?: { [id: string]: any };
-}
-/**
- * Loosely based on `getExtensionKind` from `src/vs/workbench/services/extensions/common/extensionManifestPropertiesService.ts`
- */
-export function isWebExtension(manifest: IExtensionManifest): boolean {
-	if (Boolean(manifest.browser)) {
-		return true;
-	}
-	if (Boolean(manifest.main)) {
-		return false;
-	}
-	// neither browser nor main
-	if (typeof manifest.extensionKind !== 'undefined') {
-		const extensionKind = Array.isArray(manifest.extensionKind) ? manifest.extensionKind : [manifest.extensionKind];
-		if (extensionKind.indexOf('web') >= 0) {
-			return true;
-		}
-	}
-	if (typeof manifest.contributes !== 'undefined') {
-		for (const id of ['debuggers', 'terminal', 'typescriptServerPlugins']) {
-			if (manifest.contributes.hasOwnProperty(id)) {
-				return false;
-			}
-		}
-	}
-	return true;
-}
+// Re-export shared types and utilities used by both gulp and esbuild builds
+export { type IExtensionManifest, type IScannedBuiltinExtension } from './extensions-shared.ts';
+// Import for local use within this file
+import { isWebExtension, type IScannedBuiltinExtension } from './extensions-shared.ts';
+export { isWebExtension };
 
 /**
  * Package local extensions that are known to not have native dependencies. Mutually exclusive to {@link packageNativeLocalExtensionsStream}.
@@ -468,14 +438,6 @@ export function packageMarketplaceExtensionsStream(forWeb: boolean): Stream {
 		marketplaceExtensionsStream
 			.pipe(util2.setExecutableBit(['**/*.sh']))
 	);
-}
-
-export interface IScannedBuiltinExtension {
-	readonly extensionPath: string;
-	readonly packageJSON: unknown;
-	readonly packageNLS: unknown | undefined;
-	readonly readmePath: string | undefined;
-	readonly changelogPath: string | undefined;
 }
 
 export function scanBuiltinExtensions(extensionsRoot: string, exclude: string[] = []): IScannedBuiltinExtension[] {

--- a/build/next/index.ts
+++ b/build/next/index.ts
@@ -17,7 +17,7 @@ import { getGitCommitDate } from '../lib/date.ts';
 import product from '../../product.json' with { type: 'json' };
 import packageJson from '../../package.json' with { type: 'json' };
 import { useEsbuildTranspile } from '../buildConfig.ts';
-import { isWebExtension, type IScannedBuiltinExtension } from '../lib/extensions.ts';
+import { isWebExtension, type IScannedBuiltinExtension } from '../lib/extensions-shared.ts';
 
 const globAsync = promisify(glob);
 


### PR DESCRIPTION
## Summary

- Extract `isWebExtension`, `IExtensionManifest`, and `IScannedBuiltinExtension` from `build/lib/extensions.ts` into a new dependency-free module `build/lib/extensions-shared.ts`
- Update `build/next/index.ts` to import from the shared module instead of the gulp-heavy `extensions.ts`
- Update `build/lib/extensions.ts` to re-export from the shared module for backward compatibility

## Problem

Running `npm run tauri:dev` after `npm install` fails with:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'gulp-vinyl-zip' imported from build/lib/extensions.ts
```

`build/next/index.ts` (esbuild build) only needs `isWebExtension` and `IScannedBuiltinExtension` from `build/lib/extensions.ts`, but that module has a top-level `import vzip from 'gulp-vinyl-zip'`. Since `gulp-vinyl-zip` is not in the root `package.json`, ESM module resolution fails before the needed exports can be accessed.

## Solution

Create `build/lib/extensions-shared.ts` with zero external dependencies containing only the types and utilities needed by both build systems. This cleanly separates the esbuild build from the gulp build infrastructure.

## Testing

- `node build/next/index.ts transpile` - passes
- `node build/next/index.ts transpile-extensions` - passes