### PR TITLE
docs: add Phase 5 sub-task table and update architecture diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,13 @@ Built-in extension scanning and OS theme detection for the Tauri backend. Modula
 
 ### Phase 5: Process Model
 
-Extension Host via Node.js sidecar + named pipe, Terminal via Rust `portable-pty`, Shared Process services.
+Extension Host via Node.js sidecar + named pipe, Terminal via Rust `portable-pty`, Shared Process elimination.
+
+| Sub-task                      | Description                                                                                                                                              |   Status   |
+| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | :--------: |
+| Extension Host (Node sidecar) | Node.js sidecar + WebSocket ↔ Rust relay ↔ Unix Socket full pipeline (PR [#58](https://github.com/j4rviscmd/vscodeee/pull/58))                           |     ✅     |
+| Terminal PTY integration      | Rust `portable-pty` → Tauri IPC → `TauriTerminalBackend` → VS Code Terminal UI ([#87](https://github.com/j4rviscmd/vscodeee/issues/87))                  | 📋 Planned |
+| Shared Process elimination    | Abolish Shared Process sidecar; implement services directly in WebView/Rust ([#88](https://github.com/j4rviscmd/vscodeee/issues/88))                     | 📋 Planned |
 
 ### Phase 6: Platform Features
 
@@ -205,6 +211,7 @@ Tauri build pipeline, code signing (macOS/Windows), installers (.dmg, .msi, .App
 ┌──────────────────────────────────────────┐
 │           Tauri WebView (Renderer)       │
 │  workbench.html + VS Code TypeScript     │
+│  • Extension Gallery / Management        │
 └──────────────┬───────────────────────────┘
                │  invoke / emit (Tauri IPC)
 ┌──────────────▼───────────────────────────┐
@@ -216,11 +223,12 @@ Tauri build pipeline, code signing (macOS/Windows), installers (.dmg, .msi, .App
 └──────────────┬───────────────────────────┘
                │  socket / named pipe
 ┌──────────────▼───────────────────────────┐
-│         Node.js Sidecar Processes        │
+│         Node.js Sidecar Process          │
 │  • Extension Host                        │
-│  • Shared Process                        │
 └──────────────────────────────────────────┘
 ```
+
+> **Note**: Shared Process (upstream VS Code's hidden renderer for gallery, sync, telemetry) is **eliminated** in VSCodeee. Its services are implemented directly in the WebView or Rust backend — see [#88](https://github.com/j4rviscmd/vscodeee/issues/88).
 
 ## MVP Excluded Features
 


### PR DESCRIPTION
## Summary

- Add Phase 5 (Process Model) sub-task table to README.md with status tracking
- Update architecture diagram to reflect Shared Process elimination decision
- Reference newly created issues #87 (Terminal PTY integration) and #88 (Shared Process elimination)

## Changes

### Phase 5 Sub-task Table
| Sub-task | Status |
|---|---|
| Extension Host (Node sidecar) | ✅ Done (PR #58) |
| Terminal PTY integration | 📋 Planned (#87) |
| Shared Process elimination | 📋 Planned (#88) |

### Architecture Diagram Updates
- Removed "Shared Process" from Node.js Sidecar section
- Added "Extension Gallery / Management" to WebView section
- Changed "Node.js Sidecar Processes" (plural) → "Node.js Sidecar Process" (singular)
- Added explanatory note about Shared Process elimination strategy

## Related Issues
- #87 — Phase 5-A: Terminal PTY integration
- #88 — Phase 5-C: Shared Process elimination