### PR TITLE
docs: split Phase 5 into 5A/5B/5C in roadmap overview table

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ Maintain the current functionality of VSCode while achieving the following:
 |   3C   | [State Persistence](#phase-3-window-management)              | Window position/size + workspace session restore            | [✅ Complete](https://github.com/j4rviscmd/vscodeee/pull/36)  |
 |   3D   | [Lifecycle Close Handshake](#phase-3-window-management)      | Two-phase close for reliable session restore                | [✅ Complete](https://github.com/j4rviscmd/vscodeee/pull/39)  |
 | **4**  | [**Native Host Services**](#phase-4-native-host-services-)   | **Extension scanner, OS theme, native host modularization** | [✅ Complete](https://github.com/j4rviscmd/vscodeee/pull/48)  |
-|   5    | [Process Model](#phase-5-process-model)                      | Extension Host, Terminal (PTY), Shared Process              |                        **📋 Up Next**                         |
+|   5A   | [Extension Host](#phase-5-process-model)                     | Node.js sidecar + WebSocket ↔ Rust relay ↔ Unix Socket      | [✅ Complete](https://github.com/j4rviscmd/vscodeee/pull/58)  |
+|  **5B** | [**Terminal PTY**](#phase-5-process-model)                   | **Rust PTY → Tauri IPC → TauriTerminalBackend → Terminal UI** |                        **📋 Up Next**                         |
+|   5C   | [Shared Process Elimination](#phase-5-process-model)         | Abolish Shared Process; services in WebView/Rust            |                          📋 Planned                           |
 |   6    | [Platform Features](#phase-6-platform-features)              | Auto-update, native menus, system tray                      |                          📋 Planned                           |
 |   7    | [Build & Packaging](#phase-7-build--packaging)               | Installers, code signing, CI/CD                             |                          📋 Planned                           |
 


### PR DESCRIPTION
## Summary

Split the single Phase 5 row in the roadmap overview table into three sub-phases (5A/5B/5C), matching the style of Phase 3 (3A/3B/3C/3D).

## Changes

**Before (1 row):**
| Phase | Description | Status |
|---|---|---|
| 5 | Extension Host, Terminal (PTY), Shared Process | 📋 Up Next |

**After (3 rows):**
| Phase | Description | Status |
|---|---|---|
| 5A | Extension Host — Node.js sidecar + WebSocket ↔ Rust relay | ✅ Complete (PR #58) |
| **5B** | **Terminal PTY — Rust PTY → Tauri IPC → TauriTerminalBackend** | **📋 Up Next** |
| 5C | Shared Process Elimination — services in WebView/Rust | 📋 Planned |

## Related
- #87 — Phase 5-A: Terminal PTY integration
- #88 — Phase 5-C: Shared Process elimination
- PR #89 — Phase 5 sub-task detail table (merged)