### PR TITLE
docs: add Phase 5-D (Extension ESM fix) to roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Maintain the current functionality of VSCode while achieving the following:
 |   5A   | [Extension Host](#phase-5-process-model)                     | Node.js sidecar + WebSocket ↔ Rust relay ↔ Unix Socket        | [✅ Complete](https://github.com/j4rviscmd/vscodeee/pull/58)  |
 | **5B** | [**Terminal PTY**](#phase-5-process-model)                   | **Rust PTY → Tauri IPC → TauriTerminalBackend → Terminal UI** |                        **📋 Up Next**                         |
 |   5C   | [Shared Process Elimination](#phase-5-process-model)         | Abolish Shared Process; services in WebView/Rust              |                          📋 Planned                           |
+|   5D   | [Extension ESM Fix](#phase-5-process-model)                  | Fix ESM module resolution for built-in extensions             |                          📋 Planned                           |
 |   6    | [Platform Features](#phase-6-platform-features)              | Auto-update, native menus, system tray                        |                          📋 Planned                           |
 |   7    | [Build & Packaging](#phase-7-build--packaging)               | Installers, code signing, CI/CD                               |                          📋 Planned                           |
 
@@ -189,6 +190,7 @@ Extension Host via Node.js sidecar + named pipe, Terminal via Rust `portable-pty
 | Extension Host (Node sidecar) | Node.js sidecar + WebSocket ↔ Rust relay ↔ Unix Socket full pipeline (PR [#58](https://github.com/j4rviscmd/vscodeee/pull/58))          |     ✅     |
 | Terminal PTY integration      | Rust `portable-pty` → Tauri IPC → `TauriTerminalBackend` → VS Code Terminal UI ([#87](https://github.com/j4rviscmd/vscodeee/issues/87)) | 📋 Planned |
 | Shared Process elimination    | Abolish Shared Process sidecar; implement services directly in WebView/Rust ([#88](https://github.com/j4rviscmd/vscodeee/issues/88))    | 📋 Planned |
+| Extension ESM fix             | Fix ESM module resolution for built-in extensions in Extension Host ([#93](https://github.com/j4rviscmd/vscodeee/issues/93))            | 📋 Planned |
 
 ### Phase 6: Platform Features
 


### PR DESCRIPTION
## Summary

Add Phase 5-D sub-task to track ESM module resolution fix for built-in extensions in Extension Host.

## Background

Extension Host infrastructure (5-A) is complete (PR #58), but built-in extensions using ESM (`json-language-features`, `typescript-language-features`) fail to load at runtime due to module resolution issues. This is a separate concern from the build-time ESM transpile fix (Issue #57, closed).

## Changes

- Add 5-D row to roadmap overview table
- Add "Extension ESM fix" row to Phase 5 detail sub-task table
- Both reference Issue #93

## Related

- #93 — Phase 5-D: Fix ESM module resolution for built-in extensions
- #87 — Phase 5-B: Terminal PTY integration
- #88 — Phase 5-C: Shared Process elimination