### PR TITLE
fix: update stale CSP hash in webWorkerExtensionHostIframe.html (#96 regression)

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
 		"symlink-local-component-explorer": "npm install ../vscode-packages/js-component-explorer/packages/explorer ../vscode-packages/js-component-explorer/packages/cli --no-save && cd build/rspack && npm install ../../../vscode-packages/js-component-explorer/packages/webpack-plugin ../../../vscode-packages/js-component-explorer/packages/explorer --no-save && cd ../vite && npm install ../../../vscode-packages/js-component-explorer/packages/vite-plugin ../../../vscode-packages/js-component-explorer/packages/explorer --no-save",
 		"install-latest-component-explorer": "npm install @vscode/component-explorer@next @vscode/component-explorer-cli@next && cd build/rspack && npm install @vscode/component-explorer-webpack-plugin@next @vscode/component-explorer@next && cd ../vite && npm install @vscode/component-explorer-vite-plugin@next @vscode/component-explorer@next",
 		"tauri": "tauri",
-		"tauri:dev": "node build/next/index.ts transpile && node build/next/index.ts transpile-extensions && tauri dev",
+		"tauri:dev": "bash scripts/check-csp-hash.sh && node build/next/index.ts transpile && node build/next/index.ts transpile-extensions && tauri dev",
 		"tauri:build": "tauri build"
 	},
 	"dependencies": {

--- a/scripts/check-csp-hash.sh
+++ b/scripts/check-csp-hash.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#----------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE in the project root for license information.
+#----------------------------------------------------------
+#
+# check-csp-hash.sh — Verify that the CSP hash in webWorkerExtensionHostIframe.html
+# matches the actual SHA-256 of the inline <script> content.
+#
+# Exit codes:
+#   0 — hash matches
+#   1 — hash mismatch (prints expected vs actual)
+#   2 — file not found or other error
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# Resolve repo root: scripts/ is one level below repo root
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+IFRAME_HTML="$REPO_ROOT/src/vs/workbench/services/extensions/worker/webWorkerExtensionHostIframe.html"
+
+if [ ! -f "$IFRAME_HTML" ]; then
+    echo "ERROR: $IFRAME_HTML not found" >&2
+    exit 2
+fi
+
+# Compute the SHA-256 hash of the inline <script> content.
+# The browser computes the hash over the FULL text between <script> and </script>,
+# including leading/trailing whitespace and newlines. We use Python to extract the
+# content and hash it because the extraction logic is non-trivial in pure shell.
+# The file path is passed via sys.argv to avoid shell-injection issues with paths
+# containing special characters.
+COMPUTED_HASH=$(python3 -c "
+import hashlib, base64, re, sys
+
+filepath = sys.argv[1]
+with open(filepath, 'r') as f:
+    content = f.read()
+
+match = re.search(r'<script>(.*?)</script>', content, re.DOTALL)
+if not match:
+    print('ERROR: no <script> block found', file=sys.stderr)
+    sys.exit(2)
+
+script_text = match.group(1)
+sha = hashlib.sha256(script_text.encode('utf-8')).digest()
+print(base64.b64encode(sha).decode('ascii'))
+" "$IFRAME_HTML") || {
+    echo "ERROR: failed to compute hash" >&2
+    exit 2
+}
+
+# Extract the hash currently declared in the CSP meta tag.
+CSP_HASH=$(python3 -c "
+import re, sys
+
+filepath = sys.argv[1]
+with open(filepath, 'r') as f:
+    content = f.read()
+
+match = re.search(r'sha256-([A-Za-z0-9+/=]+)', content)
+if not match:
+    print('ERROR: no sha256- hash found in CSP', file=sys.stderr)
+    sys.exit(2)
+
+print(match.group(1))
+" "$IFRAME_HTML") || {
+    echo "ERROR: failed to extract CSP hash" >&2
+    exit 2
+}
+
+# Compare
+if [ "$COMPUTED_HASH" = "$CSP_HASH" ]; then
+    echo "[OK] CSP hash matches: sha256-$CSP_HASH"
+    exit 0
+else
+    echo "ERROR: CSP hash mismatch in webWorkerExtensionHostIframe.html" >&2
+    echo "  Declared in CSP:  sha256-$CSP_HASH" >&2
+    echo "  Actual (computed): sha256-$COMPUTED_HASH" >&2
+    echo "" >&2
+    echo "The inline <script> content was modified without updating the CSP hash." >&2
+    echo "Update the sha256- value in the script-src directive to match the computed hash." >&2
+    exit 1
+fi

--- a/src/vs/workbench/services/extensions/worker/webWorkerExtensionHostIframe.html
+++ b/src/vs/workbench/services/extensions/worker/webWorkerExtensionHostIframe.html
@@ -20,7 +20,7 @@
 		<meta http-equiv="Content-Security-Policy" content="
 			default-src 'none';
 			child-src 'self' data: blob:;
-			script-src 'self' 'unsafe-eval' 'sha256-cl8ijlOzEe+0GRCQNJQu2k6nUQ0fAYNYIuuKEm72JDs=' https: http://localhost:* blob: vscode-file:;
+			script-src 'self' 'unsafe-eval' 'sha256-Az3P+8se4ZoLKOwSJS4ytf0PiEIeK9E4/VoA1ACCj2w=' https: http://localhost:* blob: vscode-file:;
 			connect-src 'self' https: wss: http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:* vscode-file:;"/>
 	</head>
 	<body>


### PR DESCRIPTION
## Summary

- **Update the CSP `sha256` hash** in `webWorkerExtensionHostIframe.html` to match the current inline `<script>` content, which changed when JSDoc comments were added in PR #96
- **Add `scripts/check-csp-hash.sh`** — a pre-dev validation script that computes the actual SHA-256 of the inline script and compares it against the declared CSP hash, exiting with an error on mismatch
- **Add CSP hash check to `npm run tauri:dev`** so the app cannot start with a stale hash

## Root Cause

PR #96 added JSDoc comments to the inline `<script>` in `webWorkerExtensionHostIframe.html` but did not update the `sha256-` value in the CSP `script-src` directive. The browser's CSP validation computes the hash over the **full text** between `<script>` and `</script>` (including leading/trailing whitespace), while the original hash only covered the inner content. This mismatch caused the browser to block script execution in the Web Worker Extension Host iframe, resulting in a 60-second timeout and infinite loading on startup.

## Test plan

- [x] `bash scripts/check-csp-hash.sh` passes with `[OK]`
- [ ] Web Worker Extension Host starts without CSP violation
- [ ] No "Refused to execute a script" error in DevTools console
- [ ] No "The Web Worker Extension Host did not start in 60s" warning
- [ ] Workbench loads past the splash screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)