### PR TITLE
chore: reduce verbose startup logs by demoting relay/watcher/debug logs to DEBUG

### DIFF
--- a/src-tauri/src/commands/file_watcher.rs
+++ b/src-tauri/src/commands/file_watcher.rs
@@ -104,7 +104,7 @@ pub fn fs_watch_start(
     let (watch_path, watch_mode) = if !path.exists() {
         if let Some(parent) = path.parent() {
             if parent.exists() {
-                log::info!(
+                log::debug!(
                     target: "vscodeee::file_watcher",
                     "Path {} does not exist, watching parent {} instead",
                     request.path,
@@ -150,10 +150,8 @@ pub fn fs_watch_start(
     )
     .map_err(|e| format!("Failed to create watcher: {e}"))?;
 
-    let mode = watch_mode;
-
     watcher
-        .watch(&watch_path, mode)
+        .watch(&watch_path, watch_mode)
         .map_err(|e| format!("Failed to watch path {}: {e}", watch_path.display()))?;
 
     // Spawn a thread that batches events every 100ms
@@ -213,7 +211,7 @@ pub fn fs_watch_start(
         },
     );
 
-    log::info!(
+    log::debug!(
         target: "vscodeee::file_watcher",
         "Started watching {} (id={}, recursive={}, excludes={})",
         request.path,

--- a/src-tauri/src/exthost/sidecar.rs
+++ b/src-tauri/src/exthost/sidecar.rs
@@ -162,7 +162,7 @@ async fn spawn_and_connect(
     // can find tools installed in non-default locations. This is critical on
     // macOS where app bundles inherit a minimal PATH from launchd.
     let enriched_path = build_exthost_path();
-    log::info!(
+    log::debug!(
         target: "vscodeee::exthost::sidecar",
         "ExtHost PATH: {enriched_path}"
     );

--- a/src-tauri/src/exthost/ws_relay.rs
+++ b/src-tauri/src/exthost/ws_relay.rs
@@ -104,7 +104,7 @@ async fn relay_loop(
                 Ok(tokio_tungstenite::tungstenite::Message::Binary(data)) => {
                     count += 1;
                     if count <= 20 || count % 100 == 0 {
-                        log::info!(
+                        log::debug!(
                             target: "vscodeee::exthost::ws_relay",
                             "WS→pipe #{count}: {len} bytes, first4={first4:?}",
                             len = data.len(),
@@ -143,7 +143,7 @@ async fn relay_loop(
                 Ok(n) => {
                     count += 1;
                     if count <= 20 || count % 100 == 0 {
-                        log::info!(
+                        log::debug!(
                             target: "vscodeee::exthost::ws_relay",
                             "pipe→WS #{count}: {n} bytes, first4={first4:?}",
                             first4 = &buf[..std::cmp::min(4, n)]

--- a/src-tauri/src/ipc/channel.rs
+++ b/src-tauri/src/ipc/channel.rs
@@ -76,7 +76,7 @@ impl ChannelRouter {
         // the channel name, then route to the registered handler.
         // For Phase 2, incoming IPC messages are silently dropped
         // since all services use direct invoke() calls instead.
-        log::info!(
+        log::debug!(
             target: "vscodeee::ipc::channel",
             "Received {} bytes from window {} (no channel routing yet, dropping)",
             raw.len(),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -214,7 +214,7 @@ pub fn run() {
             log::info!(target: "vscodeee", "Tauri app started");
 
             // ── Initialize system event monitoring ──
-            log::info!(target: "vscodeee", "Setting up system event monitors");
+            log::debug!(target: "vscodeee", "Setting up system event monitors");
             system_events::setup(app);
 
             // ── Read user settings and load session ──

--- a/src-tauri/src/logging.rs
+++ b/src-tauri/src/logging.rs
@@ -27,7 +27,7 @@ use tauri_plugin_log::{Target, TargetKind};
 /// - **TARGET**: Rust module path (`vscodeee::pty::manager`) or
 ///   webview caller location (`webview:index.html:221:13`)
 pub fn build_plugin() -> tauri_plugin_log::Builder {
-    tauri_plugin_log::Builder::new()
+    let mut builder = tauri_plugin_log::Builder::new()
         .targets([
             // All logs go to backend terminal (AI-agent readable)
             Target::new(TargetKind::Stdout),
@@ -35,10 +35,23 @@ pub fn build_plugin() -> tauri_plugin_log::Builder {
         .format(log_format)
         // Default level: Info and above
         .level(log::LevelFilter::Info)
-        // Allow Debug for our own modules when RUST_LOG is set
-        .level_for("vscodeee", log::LevelFilter::Debug)
+        // Our own modules: Info by default
+        .level_for("vscodeee", log::LevelFilter::Info)
         // WebView console logs at Trace level (capture everything)
-        .level_for("webview", log::LevelFilter::Trace)
+        .level_for("webview", log::LevelFilter::Trace);
+
+    // Allow RUST_LOG env var to override vscodeee log level at runtime.
+    // Example: RUST_LOG=vscodeee=debug cargo tauri dev
+    // Check trace before debug to avoid incorrect demotion (e.g. vscodeee=trace contains both).
+    if let Ok(rust_log) = std::env::var("RUST_LOG") {
+        if rust_log.contains("vscodeee") && rust_log.contains("trace") {
+            builder = builder.level_for("vscodeee", log::LevelFilter::Trace);
+        } else if rust_log.contains("vscodeee") && rust_log.contains("debug") {
+            builder = builder.level_for("vscodeee", log::LevelFilter::Debug);
+        }
+    }
+
+    builder
 }
 
 /// Custom log format optimized for AI-agent readability.

--- a/src-tauri/src/system_events/monitor.rs
+++ b/src-tauri/src/system_events/monitor.rs
@@ -40,7 +40,7 @@ pub fn setup(app: &tauri::App) {
     std::thread::Builder::new()
         .name("system-event-dispatcher".into())
         .spawn(move || {
-            log::info!(
+            log::debug!(
                 target: "vscodeee",
                 "System event dispatcher started, registered events: [{}]",
                 [

--- a/src-tauri/src/system_events/platform_macos.rs
+++ b/src-tauri/src/system_events/platform_macos.rs
@@ -26,7 +26,7 @@ pub fn spawn_monitor(tx: mpsc::Sender<SystemEvent>) {
     std::thread::Builder::new()
         .name("system-event-monitor-macos".into())
         .spawn(|| {
-            log::info!(
+            log::debug!(
                 target: "vscodeee",
                 "macOS system event monitor thread started (stub)"
             );


### PR DESCRIPTION
## Summary
- Demote routine per-message INFO logs to DEBUG in `ws_relay`, `file_watcher`, `ipc/channel`, `sidecar`, and `system_events` modules to reduce terminal noise during normal app startup
- Change `vscodeee` module default log level from Debug to Info in `logging.rs`
- Add `RUST_LOG` env var support to re-enable verbose output when needed (e.g., `RUST_LOG=vscodeee=debug cargo tauri dev`)

## Changes
| File | Change |
|------|--------|
| `src-tauri/src/exthost/ws_relay.rs` | WS↔pipe packet logs: `info!` → `debug!` |
| `src-tauri/src/ipc/channel.rs` | IPC dispatch log: `info!` → `debug!` |
| `src-tauri/src/commands/file_watcher.rs` | Watch start/fallback logs: `info!` → `debug!` |
| `src-tauri/src/exthost/sidecar.rs` | ExtHost PATH log: `info!` → `debug!` |
| `src-tauri/src/lib.rs` | System event setup log: `info!` → `debug!` |
| `src-tauri/src/system_events/monitor.rs` | Dispatcher start log: `info!` → `debug!` |
| `src-tauri/src/system_events/platform_macos.rs` | macOS monitor stub log: `info!` → `debug!` |
| `src-tauri/src/logging.rs` | Default vscodeee level: Debug → Info + RUST_LOG support |

## Test plan
- [ ] Verify startup logs no longer show `WS→pipe`/`pipe→WS` packet entries
- [ ] Verify startup logs no longer show `file_watcher` started entries
- [ ] Verify lifecycle logs (app start, WS connect, WS close) still appear at INFO
- [ ] Verify `RUST_LOG=vscodeee=debug cargo tauri dev` restores verbose output
- [ ] Verify `RUST_LOG=vscodeee=trace` correctly sets trace level (not demoted to debug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)