### PR TITLE
feat: integrate Rust PTY with VS Code terminal UI via TauriTerminalBackend

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ Maintain the current functionality of VSCode while achieving the following:
 |   3D   | [Lifecycle Close Handshake](#phase-3-window-management)      | Two-phase close for reliable session restore                  | [✅ Complete](https://github.com/j4rviscmd/vscodeee/pull/39)  |
 | **4**  | [**Native Host Services**](#phase-4-native-host-services-)   | **Extension scanner, OS theme, native host modularization**   | [✅ Complete](https://github.com/j4rviscmd/vscodeee/pull/48)  |
 |   5A   | [Extension Host](#phase-5-process-model)                     | Node.js sidecar + WebSocket ↔ Rust relay ↔ Unix Socket        | [✅ Complete](https://github.com/j4rviscmd/vscodeee/pull/58)  |
-| **5B** | [**Terminal PTY**](#phase-5-process-model)                   | **Rust PTY → Tauri IPC → TauriTerminalBackend → Terminal UI** |                        **📋 Up Next**                         |
+| **5B** | [**Terminal PTY**](#phase-5-process-model)                   | **Rust PTY → Tauri IPC → TauriTerminalBackend → Terminal UI** | [✅ Complete](https://github.com/j4rviscmd/vscodeee/pull/105) |
 |   5C   | [Shared Process Elimination](#phase-5-process-model)         | Abolish Shared Process; services in WebView/Rust              |                          📋 Planned                           |
-|   5D   | [Extension ESM Fix](#phase-5-process-model)                  | Fix ESM module resolution for built-in extensions             |                          📋 Planned                           |
+|   5D   | [Extension ESM Fix](#phase-5-process-model)                  | Fix ESM module resolution for built-in extensions             | [✅ Complete](https://github.com/j4rviscmd/vscodeee/pull/103) |
 |   6    | [Platform Features](#phase-6-platform-features)              | Auto-update, native menus, system tray                        |                          📋 Planned                           |
 |   7    | [Build & Packaging](#phase-7-build--packaging)               | Installers, code signing, CI/CD                               |                          📋 Planned                           |
 
@@ -188,9 +188,9 @@ Extension Host via Node.js sidecar + named pipe, Terminal via Rust `portable-pty
 | Sub-task                      | Description                                                                                                                             |   Status   |
 | ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | :--------: |
 | Extension Host (Node sidecar) | Node.js sidecar + WebSocket ↔ Rust relay ↔ Unix Socket full pipeline (PR [#58](https://github.com/j4rviscmd/vscodeee/pull/58))          |     ✅     |
-| Terminal PTY integration      | Rust `portable-pty` → Tauri IPC → `TauriTerminalBackend` → VS Code Terminal UI ([#87](https://github.com/j4rviscmd/vscodeee/issues/87)) | 📋 Planned |
+| Terminal PTY integration      | Rust `portable-pty` → Tauri IPC → `TauriTerminalBackend` → VS Code Terminal UI (PR [#105](https://github.com/j4rviscmd/vscodeee/pull/105)) |     ✅     |
 | Shared Process elimination    | Abolish Shared Process sidecar; implement services directly in WebView/Rust ([#88](https://github.com/j4rviscmd/vscodeee/issues/88))    | 📋 Planned |
-| Extension ESM fix             | Fix ESM module resolution for built-in extensions in Extension Host ([#93](https://github.com/j4rviscmd/vscodeee/issues/93))            | 📋 Planned |
+| Extension ESM fix             | Fix ESM module resolution for built-in extensions in Extension Host (PR [#103](https://github.com/j4rviscmd/vscodeee/pull/103))            |     ✅     |
 
 ### Phase 6: Platform Features
 

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -84,3 +84,35 @@ pub fn resize_terminal(
 pub fn close_terminal(id: u32, pty_manager: State<'_, PtyManager>) -> Result<(), String> {
     pty_manager.close(id)
 }
+
+/// Get the user's default shell.
+///
+/// Reads the `SHELL` environment variable on Unix-like systems.
+/// Falls back to platform-specific defaults if the variable is not set.
+///
+/// # Returns
+/// The path to the default shell (e.g., `/bin/zsh`, `/bin/bash`).
+#[tauri::command]
+pub fn get_default_shell() -> String {
+    std::env::var("SHELL").unwrap_or_else(|_| {
+        if cfg!(target_os = "macos") {
+            "/bin/zsh".to_string()
+        } else if cfg!(target_os = "windows") {
+            "powershell.exe".to_string()
+        } else {
+            "/bin/bash".to_string()
+        }
+    })
+}
+
+/// Get the current process environment variables.
+///
+/// Returns all environment variables as a key-value map. Used by the
+/// terminal backend to pass the environment to the VS Code terminal UI.
+///
+/// # Returns
+/// A map of environment variable names to their values.
+#[tauri::command]
+pub fn get_environment() -> std::collections::HashMap<String, String> {
+    std::env::vars().collect()
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -106,6 +106,8 @@ pub fn run() {
             commands::terminal::write_terminal,
             commands::terminal::resize_terminal,
             commands::terminal::close_terminal,
+            commands::terminal::get_default_shell,
+            commands::terminal::get_environment,
             // ── Window commands ──
             commands::native_host::is_fullscreen,
             commands::native_host::toggle_fullscreen,

--- a/src/vs/workbench/contrib/terminal/browser/terminalProfileResolverService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalProfileResolverService.ts
@@ -371,15 +371,16 @@ export class BrowserTerminalProfileResolverService extends BaseTerminalProfileRe
 			{
 				getDefaultSystemShell: async (remoteAuthority, os) => {
 					const backend = await terminalInstanceService.getBackend(remoteAuthority);
-					if (!remoteAuthority || !backend) {
-						// Just return basic values, this is only for serverless web and wouldn't be used
+					if (!backend) {
+						// No backend available — return basic fallback values
+						// (serverless web scenario)
 						return os === OperatingSystem.Windows ? 'pwsh' : 'bash';
 					}
 					return backend.getDefaultSystemShell(os);
 				},
 				getEnvironment: async (remoteAuthority) => {
 					const backend = await terminalInstanceService.getBackend(remoteAuthority);
-					if (!remoteAuthority || !backend) {
+					if (!backend) {
 						return env;
 					}
 					return backend.getEnvironment();

--- a/src/vs/workbench/contrib/terminal/tauri-browser/tauriPty.ts
+++ b/src/vs/workbench/contrib/terminal/tauri-browser/tauriPty.ts
@@ -1,0 +1,311 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) VS Codeee Contributors. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * TauriPty — ITerminalChildProcess implementation backed by Rust PTY via Tauri IPC.
+ *
+ * Each TauriPty instance corresponds to a single Rust PTY instance managed by
+ * PtyManager on the Rust side. Communication happens through:
+ *   - invoke('create_terminal') → spawn a new PTY
+ *   - invoke('write_terminal')  → send input to PTY stdin
+ *   - invoke('resize_terminal') → resize PTY dimensions
+ *   - invoke('close_terminal')  → close and cleanup PTY
+ *   - listen('pty-output-{id}') → receive PTY stdout data
+ *   - listen('pty-exit-{id}')   → receive PTY exit notification
+ *
+ * ## Flow Control
+ *
+ * Implements VS Code's flow control mechanism via acknowledgeDataEvent().
+ * When unacknowledged characters exceed HighWatermarkChars, output is buffered
+ * until the client catches up to LowWatermarkChars.
+ */
+
+import { Emitter } from '../../../../base/common/event.js';
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { FlowControlConstants, ProcessPropertyType, type IProcessDataEvent, type IProcessProperty, type IProcessPropertyMap, type IProcessReadyEvent, type ITerminalChildProcess, type ITerminalLaunchError, type ITerminalLaunchResult } from '../../../../platform/terminal/common/terminal.js';
+import { ITerminalLogService } from '../../../../platform/terminal/common/terminal.js';
+
+// Tauri IPC types
+declare function __TAURI_INVOKE__(cmd: string, args?: Record<string, unknown>): Promise<unknown>;
+// eslint-disable-next-line @typescript-eslint/naming-convention
+declare function __TAURI_INTERNALS__listenEvent(event: string, handler: (event: { payload: unknown }) => void): Promise<() => void>;
+
+/**
+ * Helper to call Tauri invoke. Falls back to window.__TAURI_INTERNALS__.invoke
+ * which is the standard Tauri v2 WebView API.
+ */
+function tauriInvoke<T>(cmd: string, args?: Record<string, unknown>): Promise<T> {
+	// Tauri v2 exposes invoke via window.__TAURI_INTERNALS__
+	const w = globalThis as unknown as {
+		__TAURI_INTERNALS__?: {
+			invoke: (cmd: string, args?: Record<string, unknown>) => Promise<T>;
+		};
+	};
+	if (w.__TAURI_INTERNALS__?.invoke) {
+		return w.__TAURI_INTERNALS__.invoke(cmd, args);
+	}
+	throw new Error('Tauri IPC not available');
+}
+
+/**
+ * Helper to listen to Tauri events. Returns an unlisten function.
+ */
+function tauriListen(event: string, handler: (payload: unknown) => void): Promise<() => void> {
+	const w = globalThis as unknown as {
+		__TAURI_INTERNALS__?: {
+			invoke: (cmd: string, args?: Record<string, unknown>) => Promise<number>;
+		};
+	};
+	if (w.__TAURI_INTERNALS__?.invoke) {
+		// Tauri v2 event listening via plugin:event
+		// Use the core event system
+		const eventId = w.__TAURI_INTERNALS__.invoke('plugin:event|listen', {
+			event,
+			target: { kind: 'Any' },
+			handler: (window as unknown as { __TAURI_INTERNALS__: { transformCallback: (cb: (event: { payload: unknown }) => void) => number } }).__TAURI_INTERNALS__.transformCallback(
+				(ev: { payload: unknown }) => handler(ev.payload)
+			),
+		});
+		return eventId.then(id => {
+			return () => {
+				w.__TAURI_INTERNALS__?.invoke('plugin:event|unlisten', { event, eventId: id });
+			};
+		});
+	}
+	throw new Error('Tauri event system not available');
+}
+
+export class TauriPty extends Disposable implements ITerminalChildProcess {
+	// The Rust PTY id, assigned after start()
+	private _ptyId: number = 0;
+	id: number;
+	shouldPersist: boolean = false;
+
+	// Flow control state
+	private _unacknowledgedCharCount = 0;
+	private _isPaused = false;
+	private _pendingData: string[] = [];
+
+	// Event unlisten functions
+	private _unlistenOutput: (() => void) | undefined;
+	private _unlistenExit: (() => void) | undefined;
+
+	// Process properties
+	private readonly _properties: IProcessPropertyMap = {
+		cwd: '',
+		initialCwd: '',
+		fixedDimensions: { cols: undefined, rows: undefined },
+		title: '',
+		shellType: undefined,
+		hasChildProcesses: true,
+		resolvedShellLaunchConfig: {},
+		overrideDimensions: undefined,
+		failedShellIntegrationActivation: false,
+		usedShellIntegrationInjection: undefined,
+		shellIntegrationInjectionFailureReason: undefined,
+	};
+
+	// Dimensions tracking
+	private _lastDimensions: { cols: number; rows: number } = { cols: -1, rows: -1 };
+
+	// Events
+	private readonly _onProcessData = this._register(new Emitter<IProcessDataEvent | string>());
+	readonly onProcessData = this._onProcessData.event;
+	private readonly _onProcessReady = this._register(new Emitter<IProcessReadyEvent>());
+	readonly onProcessReady = this._onProcessReady.event;
+	private readonly _onDidChangeProperty = this._register(new Emitter<IProcessProperty>());
+	readonly onDidChangeProperty = this._onDidChangeProperty.event;
+	private readonly _onProcessExit = this._register(new Emitter<number | undefined>());
+	readonly onProcessExit = this._onProcessExit.event;
+
+	constructor(
+		id: number,
+		private readonly _shell: string,
+		private readonly _cwd: string,
+		private readonly _cols: number,
+		private readonly _rows: number,
+		private readonly _logService: ITerminalLogService,
+	) {
+		super();
+		this.id = id;
+		this._properties.initialCwd = _cwd;
+		this._properties.cwd = _cwd;
+		this._lastDimensions = { cols: _cols, rows: _rows };
+	}
+
+	async start(): Promise<ITerminalLaunchError | ITerminalLaunchResult | undefined> {
+		try {
+			this._logService.trace('TauriPty#start', { id: this.id, shell: this._shell, cwd: this._cwd });
+
+			// Spawn the PTY via Rust
+			this._ptyId = await tauriInvoke<number>('create_terminal', {
+				shell: this._shell,
+				cwd: this._cwd,
+				cols: this._cols,
+				rows: this._rows,
+			});
+
+			this._logService.trace('TauriPty#start result', { id: this.id, ptyId: this._ptyId });
+
+			// Listen for output data from the Rust PTY
+			this._unlistenOutput = await tauriListen(`pty-output-${this._ptyId}`, (payload: unknown) => {
+				// Payload is Vec<u8> from Rust, arrives as number[] in JS
+				const data = payload instanceof Uint8Array
+					? new TextDecoder().decode(payload)
+					: typeof payload === 'string'
+						? payload
+						: Array.isArray(payload)
+							? new TextDecoder().decode(new Uint8Array(payload as number[]))
+							: String(payload);
+
+				this._handleOutput(data);
+			});
+
+			// Listen for exit event
+			this._unlistenExit = await tauriListen(`pty-exit-${this._ptyId}`, (payload: unknown) => {
+				const exitData = payload as { id: number; exitCode: number } | undefined;
+				const exitCode = exitData?.exitCode ?? undefined;
+				this._logService.trace('TauriPty#exit', { id: this.id, ptyId: this._ptyId, exitCode });
+				this._onProcessExit.fire(exitCode);
+			});
+
+			// Fire process ready event
+			// TODO: Get actual PID from Rust if needed
+			this._onProcessReady.fire({
+				pid: this._ptyId, // Use pty ID as pseudo-PID
+				cwd: this._cwd,
+				requiresWindowsMode: false,
+			});
+
+			return undefined; // Success
+		} catch (err) {
+			const message = err instanceof Error ? err.message : String(err);
+			this._logService.error('TauriPty#start failed', message);
+			return { message };
+		}
+	}
+
+	/**
+	 * Handle output data with flow control.
+	 */
+	private _handleOutput(data: string): void {
+		if (this._isPaused) {
+			this._pendingData.push(data);
+			return;
+		}
+
+		this._unacknowledgedCharCount += data.length;
+		this._onProcessData.fire(data);
+
+		// Check if we need to pause
+		if (this._unacknowledgedCharCount > FlowControlConstants.HighWatermarkChars) {
+			this._isPaused = true;
+			this._logService.trace('TauriPty#flowControl paused', {
+				id: this.id,
+				unacknowledgedChars: this._unacknowledgedCharCount,
+			});
+		}
+	}
+
+	acknowledgeDataEvent(charCount: number): void {
+		this._unacknowledgedCharCount = Math.max(this._unacknowledgedCharCount - charCount, 0);
+
+		// Resume if we've dropped below the low watermark
+		if (this._isPaused && this._unacknowledgedCharCount < FlowControlConstants.LowWatermarkChars) {
+			this._isPaused = false;
+			this._logService.trace('TauriPty#flowControl resumed', {
+				id: this.id,
+				unacknowledgedChars: this._unacknowledgedCharCount,
+			});
+
+			// Flush any buffered data
+			const pending = this._pendingData.splice(0);
+			for (const data of pending) {
+				this._handleOutput(data);
+			}
+		}
+	}
+
+	input(data: string): void {
+		if (this._ptyId === 0) {
+			return; // Not started yet
+		}
+		tauriInvoke('write_terminal', { id: this._ptyId, data }).catch(err => {
+			this._logService.error('TauriPty#input failed', err instanceof Error ? err.message : String(err));
+		});
+	}
+
+	resize(cols: number, rows: number): void {
+		if (this._ptyId === 0) {
+			return; // Not started yet
+		}
+		if (this._lastDimensions.cols === cols && this._lastDimensions.rows === rows) {
+			return; // No change
+		}
+		this._lastDimensions = { cols, rows };
+		tauriInvoke('resize_terminal', { id: this._ptyId, cols, rows }).catch(err => {
+			this._logService.error('TauriPty#resize failed', err instanceof Error ? err.message : String(err));
+		});
+	}
+
+	shutdown(immediate: boolean): void {
+		if (this._ptyId === 0) {
+			return;
+		}
+		this._logService.trace('TauriPty#shutdown', { id: this.id, ptyId: this._ptyId, immediate });
+		tauriInvoke('close_terminal', { id: this._ptyId }).catch(err => {
+			this._logService.error('TauriPty#shutdown failed', err instanceof Error ? err.message : String(err));
+		});
+	}
+
+	sendSignal(_signal: string): void {
+		// TODO: Implement signal sending via Rust
+		// For now, this is a no-op. Signals would require a new Tauri command.
+		this._logService.trace('TauriPty#sendSignal (not implemented)', { signal: _signal });
+	}
+
+	async processBinary(_data: string): Promise<void> {
+		// Binary data processing — not typically used in basic scenarios
+	}
+
+	async clearBuffer(): Promise<void> {
+		// TODO: Could be implemented by sending clear escape sequence
+	}
+
+	async setUnicodeVersion(_version: '6' | '11'): Promise<void> {
+		// No-op — unicode version handling is done client-side by xterm.js
+	}
+
+	async getInitialCwd(): Promise<string> {
+		return this._properties.initialCwd;
+	}
+
+	async getCwd(): Promise<string> {
+		return this._properties.cwd || this._properties.initialCwd;
+	}
+
+	async refreshProperty<T extends ProcessPropertyType>(_property: T): Promise<IProcessPropertyMap[T]> {
+		return this._properties[_property];
+	}
+
+	async updateProperty<T extends ProcessPropertyType>(property: T, value: IProcessPropertyMap[T]): Promise<void> {
+		(this._properties as Record<string, unknown>)[property] = value;
+		this._onDidChangeProperty.fire({ type: property, value });
+	}
+
+	override dispose(): void {
+		// Unlisten from Tauri events
+		this._unlistenOutput?.();
+		this._unlistenExit?.();
+
+		// Close the PTY if still running
+		if (this._ptyId !== 0) {
+			tauriInvoke('close_terminal', { id: this._ptyId }).catch(() => { /* ignore errors during dispose */ });
+			this._ptyId = 0;
+		}
+
+		super.dispose();
+	}
+}

--- a/src/vs/workbench/contrib/terminal/tauri-browser/tauriPtyHostController.ts
+++ b/src/vs/workbench/contrib/terminal/tauri-browser/tauriPtyHostController.ts
@@ -1,0 +1,66 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) VS Codeee Contributors. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Dummy IPtyHostController for Tauri.
+ *
+ * In Tauri there is no separate pty host process — PTY management is handled
+ * directly by the Rust backend. This controller satisfies the
+ * BaseTerminalBackend constructor requirement while reporting the pty host
+ * as always responsive.
+ */
+
+import { Emitter, Event } from '../../../../base/common/event.js';
+import { ITerminalProfile, type IPtyHostController, type IRequestResolveVariablesEvent } from '../../../../platform/terminal/common/terminal.js';
+
+export class TauriPtyHostController implements IPtyHostController {
+	// The pty host never exits in Tauri (Rust backend is always alive)
+	private readonly _onPtyHostExit = new Emitter<number>();
+	readonly onPtyHostExit: Event<number> = this._onPtyHostExit.event;
+
+	// Fire once on construction to signal the pty host is ready
+	private readonly _onPtyHostStart = new Emitter<void>();
+	readonly onPtyHostStart: Event<void> = this._onPtyHostStart.event;
+
+	// Never fires — the Rust backend is always responsive
+	private readonly _onPtyHostUnresponsive = new Emitter<void>();
+	readonly onPtyHostUnresponsive: Event<void> = this._onPtyHostUnresponsive.event;
+
+	// Never fires — the Rust backend is always responsive
+	private readonly _onPtyHostResponsive = new Emitter<void>();
+	readonly onPtyHostResponsive: Event<void> = this._onPtyHostResponsive.event;
+
+	// Variable resolution is handled differently in Tauri
+	private readonly _onPtyHostRequestResolveVariables = new Emitter<IRequestResolveVariablesEvent>();
+	readonly onPtyHostRequestResolveVariables: Event<IRequestResolveVariablesEvent> = this._onPtyHostRequestResolveVariables.event;
+
+	constructor() {
+		// Signal that the pty host is started (Rust backend is always ready)
+		setTimeout(() => this._onPtyHostStart.fire(), 0);
+	}
+
+	async restartPtyHost(): Promise<void> {
+		// No-op in Tauri — the Rust backend cannot be restarted independently.
+		// Fire start event to satisfy any listeners expecting a restart cycle.
+		this._onPtyHostStart.fire();
+	}
+
+	async acceptPtyHostResolvedVariables(_requestId: number, _resolved: string[]): Promise<void> {
+		// No-op — variable resolution is not used via pty host in Tauri
+	}
+
+	async getProfiles(_workspaceId: string, _profiles: unknown, _defaultProfile: unknown, _includeDetectedProfiles?: boolean): Promise<ITerminalProfile[]> {
+		// Profile detection is handled by the TauriTerminalBackend
+		return [];
+	}
+
+	dispose(): void {
+		this._onPtyHostExit.dispose();
+		this._onPtyHostStart.dispose();
+		this._onPtyHostUnresponsive.dispose();
+		this._onPtyHostResponsive.dispose();
+		this._onPtyHostRequestResolveVariables.dispose();
+	}
+}

--- a/src/vs/workbench/contrib/terminal/tauri-browser/tauriTerminalBackend.ts
+++ b/src/vs/workbench/contrib/terminal/tauri-browser/tauriTerminalBackend.ts
@@ -1,0 +1,266 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) VS Codeee Contributors. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * TauriTerminalBackend — ITerminalBackend implementation for Tauri.
+ *
+ * Bridges VS Code's terminal infrastructure with the Rust PTY backend
+ * via Tauri IPC. Registered as a terminal backend via the
+ * TerminalBackendRegistry.
+ *
+ * ## Architecture
+ *
+ * ```
+ * VS Code Terminal UI (xterm.js)
+ *   ↕ ITerminalBackend (TauriTerminalBackend)
+ *   ↕ ITerminalChildProcess (TauriPty)
+ * Tauri IPC
+ *   ↕
+ * Rust PTY Manager (portable-pty)
+ * ```
+ */
+
+import { DeferredPromise } from '../../../../base/common/async.js';
+import { Emitter } from '../../../../base/common/event.js';
+import { OperatingSystem, type IProcessEnvironment } from '../../../../base/common/platform.js';
+import { Registry } from '../../../../platform/registry/common/platform.js';
+import { ITerminalBackend, ITerminalBackendRegistry, ITerminalChildProcess, ITerminalLogService, ITerminalProcessOptions, ITerminalProfile, ITerminalsLayoutInfo, ITerminalsLayoutInfoById, ProcessPropertyType, TerminalExtensions, TerminalIcon, TitleEventSource, type IPtyHostLatencyMeasurement, type IProcessPropertyMap, type IShellLaunchConfig } from '../../../../platform/terminal/common/terminal.js';
+import { IProcessDetails } from '../../../../platform/terminal/common/terminalProcess.js';
+import { IWorkspaceContextService } from '../../../../platform/workspace/common/workspace.js';
+import { IWorkbenchContribution } from '../../../common/contributions.js';
+import { BaseTerminalBackend } from '../browser/baseTerminalBackend.js';
+import { TauriPty } from './tauriPty.js';
+import { TauriPtyHostController } from './tauriPtyHostController.js';
+import { IConfigurationResolverService } from '../../../services/configurationResolver/common/configurationResolver.js';
+import { IHistoryService } from '../../../services/history/common/history.js';
+import { IStatusbarService } from '../../../services/statusbar/browser/statusbar.js';
+import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
+import { ITerminalInstanceService } from '../browser/terminal.js';
+import { PerformanceMark } from '../../../../base/common/performance.js';
+
+// Tauri IPC helper
+function tauriInvoke<T>(cmd: string, args?: Record<string, unknown>): Promise<T> {
+	const w = globalThis as unknown as {
+		__TAURI_INTERNALS__?: {
+			invoke: (cmd: string, args?: Record<string, unknown>) => Promise<T>;
+		};
+	};
+	if (w.__TAURI_INTERNALS__?.invoke) {
+		return w.__TAURI_INTERNALS__.invoke(cmd, args);
+	}
+	throw new Error('Tauri IPC not available');
+}
+
+/**
+ * Registers the TauriTerminalBackend when running in a Tauri environment.
+ */
+export class TauriTerminalBackendContribution implements IWorkbenchContribution {
+	static readonly ID = 'tauriTerminalBackend';
+
+	constructor(
+		@IInstantiationService instantiationService: IInstantiationService,
+		@ITerminalInstanceService terminalInstanceService: ITerminalInstanceService
+	) {
+		// Only register when Tauri IPC is available
+		const w = globalThis as unknown as {
+			__TAURI_INTERNALS__?: unknown;
+		};
+		if (!w.__TAURI_INTERNALS__) {
+			return;
+		}
+
+		const backend = instantiationService.createInstance(TauriTerminalBackend);
+		Registry.as<ITerminalBackendRegistry>(TerminalExtensions.Backend).registerTerminalBackend(backend);
+		terminalInstanceService.didRegisterBackend(backend);
+	}
+}
+
+// Counter for assigning unique terminal child process IDs
+let nextTerminalId = 1;
+
+class TauriTerminalBackend extends BaseTerminalBackend implements ITerminalBackend {
+	readonly remoteAuthority: string | undefined = undefined; // Local terminal — no remote authority
+
+	private readonly _whenConnected = new DeferredPromise<void>();
+	get whenReady(): Promise<void> { return this._whenConnected.p; }
+	setReady(): void { this._whenConnected.complete(); }
+
+	private readonly _onDidRequestDetach = this._register(new Emitter<{ requestId: number; workspaceId: string; instanceId: number }>());
+	readonly onDidRequestDetach = this._onDidRequestDetach.event;
+
+	private readonly _tauriPtyHostController: TauriPtyHostController;
+
+	constructor(
+		@ITerminalLogService logService: ITerminalLogService,
+		@IHistoryService historyService: IHistoryService,
+		@IConfigurationResolverService configurationResolverService: IConfigurationResolverService,
+		@IStatusbarService statusBarService: IStatusbarService,
+		@IWorkspaceContextService workspaceContextService: IWorkspaceContextService,
+	) {
+		const ptyHostController = new TauriPtyHostController();
+		super(ptyHostController, logService, historyService, configurationResolverService, statusBarService, workspaceContextService);
+		this._tauriPtyHostController = ptyHostController;
+
+		// Signal that the backend is connected
+		this._onPtyHostConnected.fire();
+	}
+
+	async createProcess(
+		shellLaunchConfig: IShellLaunchConfig,
+		cwd: string,
+		cols: number,
+		rows: number,
+		_unicodeVersion: '6' | '11',
+		_env: IProcessEnvironment,
+		_options: ITerminalProcessOptions,
+		_shouldPersist: boolean
+	): Promise<ITerminalChildProcess> {
+		const id = nextTerminalId++;
+
+		// Determine the shell executable
+		let shell = shellLaunchConfig.executable;
+		if (!shell) {
+			shell = await this.getDefaultSystemShell();
+		}
+
+		// Determine the working directory
+		const resolvedCwd = typeof shellLaunchConfig.cwd === 'string'
+			? shellLaunchConfig.cwd
+			: shellLaunchConfig.cwd?.fsPath ?? cwd;
+
+		this._logService.trace('TauriTerminalBackend#createProcess', { id, shell, cwd: resolvedCwd, cols, rows });
+
+		const pty = new TauriPty(id, shell, resolvedCwd, cols, rows, this._logService);
+		return pty;
+	}
+
+	async attachToProcess(_id: number): Promise<ITerminalChildProcess | undefined> {
+		// TODO: Implement process attachment for persistence
+		this._logService.trace('TauriTerminalBackend#attachToProcess (not implemented)', { id: _id });
+		return undefined;
+	}
+
+	async attachToRevivedProcess(_id: number): Promise<ITerminalChildProcess | undefined> {
+		// TODO: Implement process revival for persistence
+		this._logService.trace('TauriTerminalBackend#attachToRevivedProcess (not implemented)', { id: _id });
+		return undefined;
+	}
+
+	async listProcesses(): Promise<IProcessDetails[]> {
+		// TODO: Implement via Rust command to list running PTY instances
+		return [];
+	}
+
+	async getLatency(): Promise<IPtyHostLatencyMeasurement[]> {
+		// Tauri IPC latency is negligible (in-process)
+		return [{ label: 'tauri-ipc', latency: 0 }];
+	}
+
+	async getDefaultSystemShell(_osOverride?: OperatingSystem): Promise<string> {
+		try {
+			const shell = await tauriInvoke<string>('get_default_shell');
+			return shell;
+		} catch {
+			// Fallback: try to determine from platform
+			return '/bin/zsh'; // macOS default
+		}
+	}
+
+	async getProfiles(_profiles: unknown, _defaultProfile: unknown, _includeDetectedProfiles?: boolean): Promise<ITerminalProfile[]> {
+		// TODO: Detect available shells via Rust
+		// For now, return a basic profile based on the default shell
+		try {
+			const defaultShell = await this.getDefaultSystemShell();
+			const shellName = defaultShell.split('/').pop() ?? 'shell';
+			return [{
+				profileName: shellName,
+				path: defaultShell,
+				isDefault: true,
+			}];
+		} catch {
+			return [];
+		}
+	}
+
+	async getWslPath(original: string, _direction: 'unix-to-win' | 'win-to-unix'): Promise<string> {
+		// WSL is not applicable in Tauri
+		return original;
+	}
+
+	async getEnvironment(): Promise<IProcessEnvironment> {
+		try {
+			return await tauriInvoke<IProcessEnvironment>('get_environment');
+		} catch {
+			return {};
+		}
+	}
+
+	async getShellEnvironment(): Promise<IProcessEnvironment | undefined> {
+		return this.getEnvironment();
+	}
+
+	async setTerminalLayoutInfo(_layoutInfo?: ITerminalsLayoutInfoById): Promise<void> {
+		// TODO: Implement layout persistence
+	}
+
+	async updateTitle(_id: number, _title: string, _titleSource: TitleEventSource): Promise<void> {
+		// TODO: Implement title tracking
+	}
+
+	async updateIcon(_id: number, _userInitiated: boolean, _icon: TerminalIcon, _color?: string): Promise<void> {
+		// TODO: Implement icon tracking
+	}
+
+	async setNextCommandId(_id: number, _commandLine: string, _commandId: string): Promise<void> {
+		// TODO: Implement for shell integration
+	}
+
+	async getTerminalLayoutInfo(): Promise<ITerminalsLayoutInfo | undefined> {
+		// TODO: Implement layout restoration
+		return undefined;
+	}
+
+	async getPerformanceMarks(): Promise<PerformanceMark[]> {
+		return [];
+	}
+
+	async reduceConnectionGraceTime(): Promise<void> {
+		// No-op — no reconnection in current implementation
+	}
+
+	async requestDetachInstance(_workspaceId: string, _instanceId: number): Promise<IProcessDetails | undefined> {
+		// TODO: Implement for persistence
+		return undefined;
+	}
+
+	async acceptDetachInstanceReply(_requestId: number, _persistentProcessId?: number): Promise<void> {
+		// TODO: Implement for persistence
+	}
+
+	async persistTerminalState(): Promise<void> {
+		// TODO: Implement terminal state persistence
+	}
+
+	async installAutoReply(_match: string, _reply: string): Promise<void> {
+		// TODO: Implement auto-reply
+	}
+
+	async uninstallAllAutoReplies(): Promise<void> {
+		// TODO: Implement auto-reply removal
+	}
+
+	async updateProperty<T extends ProcessPropertyType>(_id: number, _property: T, _value: IProcessPropertyMap[T]): Promise<void> {
+		// TODO: Implement property updates
+	}
+
+	override dispose(): void {
+		this._tauriPtyHostController.dispose();
+		super.dispose();
+	}
+}
+
+// Register the TauriTerminalBackendContribution as a workbench contribution
+import { registerWorkbenchContribution2, WorkbenchPhase } from '../../../common/contributions.js';
+registerWorkbenchContribution2(TauriTerminalBackendContribution.ID, TauriTerminalBackendContribution, WorkbenchPhase.AfterRestored);

--- a/src/vs/workbench/workbench.tauri.main.ts
+++ b/src/vs/workbench/workbench.tauri.main.ts
@@ -179,6 +179,7 @@ import './contrib/extensions/browser/extensions.web.contribution.js';
 import './contrib/terminal/browser/terminal.web.contribution.js';
 import './contrib/externalTerminal/browser/externalTerminal.contribution.js';
 import './contrib/terminal/browser/terminalInstanceService.js';
+import './contrib/terminal/tauri-browser/tauriTerminalBackend.js';
 
 // Tasks
 import './contrib/tasks/browser/taskService.js';


### PR DESCRIPTION
## Summary

Implement Phase 5-B terminal PTY integration, connecting the Rust `portable-pty` backend with VS Code's xterm.js terminal UI through Tauri IPC.

Closes #87

## Changes

### New Files
- **`tauriPty.ts`** — `ITerminalChildProcess` implementation with flow control (`acknowledgeDataEvent`), Tauri IPC for `create_terminal`/`write_terminal`/`resize_terminal`/`close_terminal`, and event listeners for `pty-output-{id}`/`pty-exit-{id}`
- **`tauriPtyHostController.ts`** — Dummy `IPtyHostController` for `BaseTerminalBackend` (always responsive, no reconnection logic)
- **`tauriTerminalBackend.ts`** — `ITerminalBackend` extending `BaseTerminalBackend`, registered via `registerWorkbenchContribution2`. Creates `TauriPty` instances and delegates shell/environment queries to Rust

### Modified Files
- **`commands/terminal.rs`** — Added `get_default_shell` (reads `$SHELL` env var) and `get_environment` (returns all env vars)
- **`lib.rs`** — Register new Tauri commands
- **`terminalProfileResolverService.ts`** — Fix `BrowserTerminalProfileResolverService` to use `backend.getDefaultSystemShell()` when a local backend exists (was hardcoded to `'bash'` when `remoteAuthority` is undefined)
- **`workbench.tauri.main.ts`** — Add import for `tauriTerminalBackend.js`

## Architecture

```
VS Code Terminal UI (xterm.js)
  ↕ ITerminalBackend (TauriTerminalBackend)
  ↕ ITerminalChildProcess (TauriPty)
Tauri IPC
  ↕
Rust PTY Manager (portable-pty)
```

## Testing

- [x] TypeScript transpile succeeds
- [x] Rust build succeeds
- [x] App launches without module loading errors
- [x] Terminal panel opens with correct default shell (zsh on macOS)
- [x] Command execution works (ls, echo)
- [x] Output display works correctly

## Stubs (Future Work)

- Terminal persistence / detach / attach
- Shell Integration
- Layout persistence
- Auto-reply
- Signal sending