### PR TITLE
docs: add Microsoft Account login to post-MVP deferred features table

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,11 +185,11 @@ Built-in extension scanning and OS theme detection for the Tauri backend. Modula
 
 Extension Host via Node.js sidecar + named pipe, Terminal via Rust `portable-pty`, Shared Process elimination.
 
-| Sub-task                      | Description                                                                                                                             |   Status   |
-| ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | :--------: |
-| Extension Host (Node sidecar) | Node.js sidecar + WebSocket ↔ Rust relay ↔ Unix Socket full pipeline (PR [#58](https://github.com/j4rviscmd/vscodeee/pull/58))          |     ✅     |
+| Sub-task                      | Description                                                                                                                                |   Status   |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | :--------: |
+| Extension Host (Node sidecar) | Node.js sidecar + WebSocket ↔ Rust relay ↔ Unix Socket full pipeline (PR [#58](https://github.com/j4rviscmd/vscodeee/pull/58))             |     ✅     |
 | Terminal PTY integration      | Rust `portable-pty` → Tauri IPC → `TauriTerminalBackend` → VS Code Terminal UI (PR [#105](https://github.com/j4rviscmd/vscodeee/pull/105)) |     ✅     |
-| Shared Process elimination    | Abolish Shared Process sidecar; implement services directly in WebView/Rust ([#88](https://github.com/j4rviscmd/vscodeee/issues/88))    | 📋 Planned |
+| Shared Process elimination    | Abolish Shared Process sidecar; implement services directly in WebView/Rust ([#88](https://github.com/j4rviscmd/vscodeee/issues/88))       | 📋 Planned |
 | Extension ESM fix             | Fix ESM module resolution for built-in extensions in Extension Host (PR [#103](https://github.com/j4rviscmd/vscodeee/pull/103))            |     ✅     |
 
 ### Phase 6: Platform Features
@@ -248,16 +248,17 @@ The following features depend on Chrome DevTools Protocol (CDP), which has no pu
 
 The following Native Host Service features are deferred to post-MVP:
 
-| Feature                    | Reason                                                                                                                             |
-| -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| System proxy resolution    | Requires platform-specific APIs (CFNetwork, WinHTTP, libproxy). The `resolve_proxy` command returns `None` (direct connection).    |
-| System certificate loading | The `load_certificates` command returns an empty list. Extensions handle their own cert loading.                                   |
-| Kerberos authentication    | `lookupKerberosAuthorization` returns `undefined`. Requires a Kerberos library — rarely needed outside enterprise AD environments. |
-| Window splash persistence  | `saveWindowSplash` is a no-op. Splash data is persisted via `localStorage` through `ISplashStorageService` instead.                |
-| macOS Touch Bar            | Not supported by Tauri's WebView. The Touch Bar API methods are no-ops.                                                            |
-| macOS tab management       | Window tab APIs (`newWindowTab`, `mergeAllWindowTabs`, etc.) are no-ops.                                                           |
-| GPU info / content tracing | `openGPUInfoWindow`, `openContentTracingWindow`, `startTracing`, `stopTracing` are no-ops.                                         |
-| Screenshot capture         | `getScreenshot` returns `undefined`. Requires platform-specific screen capture APIs.                                               |
+| Feature                    | Reason                                                                                                                                                                                      |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Microsoft Account login    | MVP supports GitHub authentication only. Microsoft authentication depends on `@azure/msal-node` and will be implemented post-MVP ([#101](https://github.com/j4rviscmd/vscodeee/issues/101)) |
+| System proxy resolution    | Requires platform-specific APIs (CFNetwork, WinHTTP, libproxy). The `resolve_proxy` command returns `None` (direct connection).                                                             |
+| System certificate loading | The `load_certificates` command returns an empty list. Extensions handle their own cert loading.                                                                                            |
+| Kerberos authentication    | `lookupKerberosAuthorization` returns `undefined`. Requires a Kerberos library — rarely needed outside enterprise AD environments.                                                          |
+| Window splash persistence  | `saveWindowSplash` is a no-op. Splash data is persisted via `localStorage` through `ISplashStorageService` instead.                                                                         |
+| macOS Touch Bar            | Not supported by Tauri's WebView. The Touch Bar API methods are no-ops.                                                                                                                     |
+| macOS tab management       | Window tab APIs (`newWindowTab`, `mergeAllWindowTabs`, etc.) are no-ops.                                                                                                                    |
+| GPU info / content tracing | `openGPUInfoWindow`, `openContentTracingWindow`, `startTracing`, `stopTracing` are no-ops.                                                                                                  |
+| Screenshot capture         | `getScreenshot` returns `undefined`. Requires platform-specific screen capture APIs.                                                                                                        |
 
 > [!NOTE]
 > These features may be revisited if Tauri adds CDP support in the future, or if alternative approaches become viable.


### PR DESCRIPTION
## Summary
- Add "Microsoft Account login" entry to the post-MVP deferred Native Host Service features table
- The feature is deferred because it depends on `@azure/msal-node`; MVP supports GitHub authentication only
- Related: #101

## Test plan
- [ ] Verify README.md renders correctly on GitHub
- [ ] Confirm the new row appears in the "Deferred to post-MVP" table
- [ ] Confirm the Phase 5 table formatting is unchanged (cosmetic column width adjustment only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)