### PR TITLE
fix: set mainBinaryName and macOS bundleName to 'VS Codeee'

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-utils/schema.json",
   "productName": "VS Codeee",
+  "mainBinaryName": "VS Codeee",
   "version": "0.1.0",
   "identifier": "com.vscodeee.app",
   "build": {
@@ -44,6 +45,9 @@
       "icons/32x32.png",
       "icons/128x128.png",
       "icons/128x128@2x.png"
-    ]
+    ],
+    "macOS": {
+      "bundleName": "VS Codeee"
+    }
   }
 }


### PR DESCRIPTION
## Summary

本番ビルドで macOS の強制終了ダイアログや Windows のタスクマネージャーに `VS Codeee` と正しく表示されるよう、`tauri.conf.json` にバイナリ名とバンドル名を明示設定しました。

## Changes

- `mainBinaryName: "VS Codeee"` を追加 — バンドル内のバイナリファイル名を明示制御
- `bundle.macOS.bundleName: "VS Codeee"` を追加 — `CFBundleName` を明示保証

## Note

開発モード（`cargo tauri dev`）では、Cargo の `[package] name = "vscodeee"` がバイナリ名として使われるため、プロセス名は `vscodeee` のままです。これは Cargo/Tauri の仕様上の制約であり、本番ビルド（`.app` / `.exe`）でのみ `VS Codeee` と表示されます。