### PR TITLE
feat: persist auth tokens via OS Keychain using keyring crate

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -732,6 +732,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -753,7 +763,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
  "bitflags 2.11.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics-types",
  "foreign-types",
  "libc",
@@ -766,7 +776,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.11.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "libc",
 ]
 
@@ -2428,7 +2438,12 @@ version = "3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
 dependencies = [
+ "byteorder",
+ "linux-keyutils",
  "log",
+ "security-framework 2.11.1",
+ "security-framework 3.7.0",
+ "windows-sys 0.60.2",
  "zeroize",
 ]
 
@@ -2522,6 +2537,16 @@ version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
 dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "linux-keyutils"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83270a18e9f90d0707c41e9f35efada77b64c0e6f3f1810e71c8368a864d5590"
+dependencies = [
+ "bitflags 2.11.0",
  "libc",
 ]
 
@@ -4104,6 +4129,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "selectors"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4658,7 +4719,7 @@ checksum = "9103edf55f2da3c82aea4c7fab7c4241032bfeea0e71fa557d98e00e7ce7cc20"
 dependencies = [
  "bitflags 2.11.0",
  "block2",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics",
  "crossbeam-channel",
  "dispatch2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -41,6 +41,6 @@ tauri-plugin-deep-link = "2"
 thiserror = "2"
 zip = "2"
 notify-rust = "4"
-keyring = "3"
+keyring = { version = "3", features = ["apple-native", "windows-native", "linux-native"] }
 tokio-tungstenite = "0.24"
 futures-util = { version = "0.3", default-features = false, features = ["sink"] }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -12,6 +12,7 @@ pub mod file_watcher;
 pub mod filesystem;
 pub mod ipc_channel;
 pub mod native_host;
+pub mod secret_storage;
 pub mod spawn_exthost;
 pub mod terminal;
 pub mod window;

--- a/src-tauri/src/commands/secret_storage.rs
+++ b/src-tauri/src/commands/secret_storage.rs
@@ -1,0 +1,103 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) VS Codeee Contributors. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+//! Secret storage commands — OS Keychain backend for ISecretStorageProvider.
+//!
+//! Uses the `keyring` crate to access platform-native credential stores:
+//! - macOS: Keychain Access
+//! - Windows: Credential Manager
+//! - Linux: Secret Service (GNOME Keyring / KDE Wallet)
+//!
+//! The service name is fixed to `vscodeee.secrets` to namespace all secrets
+//! under a single application entry.
+
+/// The keyring service name used for all secret storage entries.
+/// Each secret is stored as a separate entry with this service name
+/// and the secret key as the "account" (username) field.
+const SERVICE_NAME: &str = "vscodeee.secrets";
+
+/// Retrieve a secret value from the OS credential store.
+///
+/// # Arguments
+/// * `key` - The secret key to look up.
+///
+/// # Returns
+/// The secret value as a string, or `None` if no entry exists.
+#[tauri::command]
+pub fn secret_get(key: String) -> Result<Option<String>, String> {
+    log::trace!(target: "vscodeee::secrets", "secret_get: key={key}");
+
+    match keyring::Entry::new(SERVICE_NAME, &key) {
+        Ok(entry) => match entry.get_password() {
+            Ok(password) => {
+                log::trace!(target: "vscodeee::secrets", "secret_get: found value for key={key}");
+                Ok(Some(password))
+            }
+            Err(keyring::Error::NoEntry) => {
+                log::trace!(target: "vscodeee::secrets", "secret_get: no entry for key={key}");
+                Ok(None)
+            }
+            Err(e) => {
+                log::warn!(target: "vscodeee::secrets", "secret_get: keyring error for key={key}: {e}");
+                Err(format!("Failed to get secret for key '{key}': {e}"))
+            }
+        },
+        Err(e) => {
+            log::warn!(target: "vscodeee::secrets", "secret_get: failed to create entry for key={key}: {e}");
+            Err(format!(
+                "Failed to create keyring entry for key '{key}': {e}"
+            ))
+        }
+    }
+}
+
+/// Store a secret value in the OS credential store.
+///
+/// # Arguments
+/// * `key` - The secret key.
+/// * `value` - The secret value to store.
+#[tauri::command]
+pub fn secret_set(key: String, value: String) -> Result<(), String> {
+    log::trace!(target: "vscodeee::secrets", "secret_set: key={key}");
+
+    let entry = keyring::Entry::new(SERVICE_NAME, &key)
+        .map_err(|e| format!("Failed to create keyring entry for key '{key}': {e}"))?;
+
+    entry
+        .set_password(&value)
+        .map_err(|e| format!("Failed to set secret for key '{key}': {e}"))?;
+
+    log::trace!(target: "vscodeee::secrets", "secret_set: stored value for key={key}");
+    Ok(())
+}
+
+/// Delete a secret from the OS credential store.
+///
+/// # Arguments
+/// * `key` - The secret key to delete.
+///
+/// Silently succeeds if no entry exists for the given key.
+#[tauri::command]
+pub fn secret_delete(key: String) -> Result<(), String> {
+    log::trace!(target: "vscodeee::secrets", "secret_delete: key={key}");
+
+    let entry = keyring::Entry::new(SERVICE_NAME, &key)
+        .map_err(|e| format!("Failed to create keyring entry for key '{key}': {e}"))?;
+
+    match entry.delete_credential() {
+        Ok(()) => {
+            log::trace!(target: "vscodeee::secrets", "secret_delete: deleted key={key}");
+            Ok(())
+        }
+        Err(keyring::Error::NoEntry) => {
+            log::trace!(target: "vscodeee::secrets", "secret_delete: no entry for key={key} (noop)");
+            Ok(())
+        }
+        Err(e) => {
+            log::warn!(target: "vscodeee::secrets", "secret_delete: keyring error for key={key}: {e}");
+            Err(format!("Failed to delete secret for key '{key}': {e}"))
+        }
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -219,6 +219,10 @@ pub fn run() {
             commands::extension_management::ext_scan_installed,
             commands::extension_management::ext_get_target_platform,
             commands::extension_management::ext_compute_extension_size,
+            // ── Secret storage commands ──
+            commands::secret_storage::secret_get,
+            commands::secret_storage::secret_set,
+            commands::secret_storage::secret_delete,
         ])
         .setup(move |app| {
             log::info!(target: "vscodeee", "Tauri app started");

--- a/src/vs/platform/secrets/tauri-browser/tauriSecretStorageProvider.ts
+++ b/src/vs/platform/secrets/tauri-browser/tauriSecretStorageProvider.ts
@@ -1,0 +1,94 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) VS Codeee Contributors. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Tauri OS Keychain backend for ISecretStorageProvider.
+ *
+ * Delegates actual credential storage to the Rust side (keyring crate),
+ * which uses platform-native credential stores:
+ * - macOS: Keychain Access
+ * - Windows: Credential Manager
+ * - Linux: Secret Service (GNOME Keyring / KDE Wallet)
+ *
+ * Since the keyring crate does not provide a reliable cross-platform
+ * way to enumerate all stored entries, we maintain a key index in
+ * localStorage as a secondary data structure for the keys() method.
+ */
+
+import { ISecretStorageProvider } from '../common/secrets.js';
+import { invoke } from '../../tauri/common/tauriApi.js';
+
+/**
+ * localStorage key used to store the set of known secret keys.
+ * This index is updated on set/delete and read on keys().
+ */
+const KEY_INDEX_STORAGE_KEY = 'vscodeee.secrets.keyIndex';
+
+export class TauriSecretStorageProvider implements ISecretStorageProvider {
+
+	readonly type = 'persisted' as const;
+
+	async get(key: string): Promise<string | undefined> {
+		const result = await invoke<string | null>('secret_get', { key });
+		return result ?? undefined;
+	}
+
+	async set(key: string, value: string): Promise<void> {
+		await invoke<void>('secret_set', { key, value });
+		this._addKeyToIndex(key);
+	}
+
+	async delete(key: string): Promise<void> {
+		await invoke<void>('secret_delete', { key });
+		this._removeKeyFromIndex(key);
+	}
+
+	async keys(): Promise<string[]> {
+		return this._getKeyIndex();
+	}
+
+	// ── Key index management (localStorage) ──
+
+	private _getKeyIndex(): string[] {
+		try {
+			const raw = localStorage.getItem(KEY_INDEX_STORAGE_KEY);
+			if (!raw) {
+				return [];
+			}
+			const parsed = JSON.parse(raw);
+			if (Array.isArray(parsed)) {
+				return parsed;
+			}
+			return [];
+		} catch {
+			return [];
+		}
+	}
+
+	private _saveKeyIndex(keys: string[]): void {
+		try {
+			localStorage.setItem(KEY_INDEX_STORAGE_KEY, JSON.stringify(keys));
+		} catch {
+			// localStorage might be unavailable in some edge cases; ignore
+		}
+	}
+
+	private _addKeyToIndex(key: string): void {
+		const keys = this._getKeyIndex();
+		if (!keys.includes(key)) {
+			keys.push(key);
+			this._saveKeyIndex(keys);
+		}
+	}
+
+	private _removeKeyFromIndex(key: string): void {
+		const keys = this._getKeyIndex();
+		const idx = keys.indexOf(key);
+		if (idx !== -1) {
+			keys.splice(idx, 1);
+			this._saveKeyIndex(keys);
+		}
+	}
+}

--- a/src/vs/workbench/services/accounts/browser/defaultAccount.ts
+++ b/src/vs/workbench/services/accounts/browser/defaultAccount.ts
@@ -521,7 +521,8 @@ class DefaultAccountProvider extends Disposable implements IDefaultAccountProvid
 				return null;
 			}
 
-			return this.getDefaultAccountFromAuthenticatedSessions(authenticationProvider, sessions);
+			const result = await this.getDefaultAccountFromAuthenticatedSessions(authenticationProvider, sessions);
+			return result;
 		} catch (error) {
 			this.logService.error('[DefaultAccount] Failed to get default account for provider:', authenticationProvider.id, getErrorMessage(error));
 			return null;
@@ -613,7 +614,8 @@ class DefaultAccountProvider extends Disposable implements IDefaultAccountProvid
 					}
 				}
 
-				return await this.authenticationService.getSessions(authProviderId, undefined, { account: preferredAccount }, true);
+				const result = await this.authenticationService.getSessions(authProviderId, undefined, { account: preferredAccount }, true);
+				return result;
 			} catch (error) {
 				this.logService.warn(`[DefaultAccount] Attempt ${attempt} to get sessions failed:`, getErrorMessage(error));
 				if (attempt === 3) {

--- a/src/vs/workbench/tauri-browser/desktop.tauri.main.ts
+++ b/src/vs/workbench/tauri-browser/desktop.tauri.main.ts
@@ -71,6 +71,7 @@ import { isFolderToOpen, isWorkspaceToOpen } from '../../platform/window/common/
 import { invoke, listen } from '../../platform/tauri/common/tauriApi.js';
 import { ITauriWindowService, TauriWindowService } from '../../platform/window/tauri-browser/windowService.js';
 import { TauriURLCallbackProvider } from './urlCallbackProvider.js';
+import { TauriSecretStorageProvider } from '../../platform/secrets/tauri-browser/tauriSecretStorageProvider.js';
 
 export class TauriDesktopMain extends Disposable {
 
@@ -176,9 +177,14 @@ export class TauriDesktopMain extends Disposable {
 		this._register(deepLinkDisposable);
 		this._register(urlCallbackProvider);
 
+		// Secret storage provider — uses OS Keychain via Rust keyring crate
+		// to persist authentication tokens across app restarts.
+		const secretStorageProvider = new TauriSecretStorageProvider();
+
 		const workbenchOptions: IWorkbenchConstructionOptions = {
 			workspaceProvider,
 			urlCallbackProvider,
+			secretStorageProvider,
 		};
 
 		const environmentService = new TauriWorkbenchEnvironmentService(


### PR DESCRIPTION
## Summary

- Add `TauriSecretStorageProvider` implementing `ISecretStorageProvider` that delegates credential storage to the Rust `keyring` crate
- Enable platform-native keyring features (`apple-native`, `windows-native`, `linux-native`) — previously the crate used a mock credential store due to missing feature flags
- Register `secret_get`/`secret_set`/`secret_delete` Tauri commands and wire `TauriSecretStorageProvider` into `IWorkbenchConstructionOptions.secretStorageProvider`

## Root Cause

The `keyring` crate v3 has **no default features** — without explicitly enabling platform features, it uses a mock credential store. `set_password()` appeared to succeed but `get_password()` always returned `NoEntry`, causing:
1. Auth tokens lost on every restart (re-authentication required)
2. "Failed to sign in to GitHub" error dialog after OAuth flow

## Changes

| File | Change |
|------|--------|
| `src-tauri/Cargo.toml` | Enable `apple-native`, `windows-native`, `linux-native` features for keyring |
| `src-tauri/src/commands/secret_storage.rs` | New: Tauri commands for OS Keychain CRUD |
| `src-tauri/src/commands/mod.rs` | Register `secret_storage` module |
| `src-tauri/src/lib.rs` | Register 3 secret storage commands in invoke handler |
| `src/vs/platform/secrets/tauri-browser/tauriSecretStorageProvider.ts` | New: `ISecretStorageProvider` implementation with localStorage key index |
| `src/vs/workbench/tauri-browser/desktop.tauri.main.ts` | Wire `TauriSecretStorageProvider` into workbench options |

## Testing

- Verified auth tokens persist across app restarts (no re-authentication)
- Verified "Failed to sign in to GitHub" error no longer appears
- `cargo check` passes

Fixes #122