### PR TITLE
feat: add append operation support to TauriDiskFileSystemProvider

### DIFF
--- a/src-tauri/src/commands/filesystem.rs
+++ b/src-tauri/src/commands/filesystem.rs
@@ -15,6 +15,7 @@
 
 use base64::{engine::general_purpose::STANDARD, Engine};
 use serde::{Deserialize, Serialize};
+use std::io::Write;
 use std::path::Path;
 use tauri_plugin_dialog::{DialogExt, MessageDialogButtons, MessageDialogResult};
 
@@ -210,15 +211,50 @@ pub fn fs_read_file(path: String) -> Result<String, String> {
 ///
 /// The `content` parameter is base64-encoded binary data.
 /// Respects `create` and `overwrite` options to match VS Code's
-/// `IFileWriteOptions` semantics.
+/// `IFileWriteOptions` semantics. When `append` is true, content is
+/// appended to the end of the file (file is created if it does not exist).
 #[tauri::command]
 pub fn fs_write_file(
     path: String,
     content: String,
     create: bool,
     overwrite: bool,
+    append: Option<bool>,
 ) -> Result<(), String> {
     let p = Path::new(&path);
+    let is_append = append.unwrap_or(false);
+
+    // Append mode: create if missing, preserve existing content.
+    // Note: `create` and `overwrite` flags are intentionally ignored here
+    // because VS Code's FileService always passes `create: true, overwrite: true`
+    // when calling writeFile with append. The append semantics are defined
+    // solely by the `append` flag (create if missing, never truncate).
+    if is_append {
+        if p.is_dir() {
+            return Err("EntryIsADirectory".to_string());
+        }
+
+        // Ensure parent directory exists
+        if let Some(parent) = p.parent() {
+            if !parent.exists() {
+                std::fs::create_dir_all(parent).map_err(map_io_error)?;
+            }
+        }
+
+        let bytes = STANDARD
+            .decode(&content)
+            .map_err(|e| format!("Unknown: base64 decode error: {}", e))?;
+
+        let mut file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(p)
+            .map_err(map_io_error)?;
+        file.write_all(&bytes).map_err(map_io_error)?;
+        return Ok(());
+    }
+
+    // Non-append mode: original behavior preserved exactly
     let exists = p.exists();
 
     // Enforce create/overwrite semantics
@@ -756,5 +792,162 @@ pub async fn show_open_dialog(
                 file_paths: vec![],
             }),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    struct TestDir(std::path::PathBuf);
+
+    impl TestDir {
+        fn new() -> Self {
+            let dir = std::env::temp_dir().join("vscodeee_fs_append_test");
+            let _ = std::fs::create_dir_all(&dir);
+            Self(dir)
+        }
+    }
+
+    impl Drop for TestDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn test_dir() -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join("vscodeee_fs_append_test");
+        let _ = std::fs::create_dir_all(&dir);
+        dir
+    }
+
+    fn cleanup(dir: &std::path::Path) {
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn write_file_append_creates_new_file() {
+        let _guard = TestDir::new();
+        let dir = test_dir();
+        let path = dir.join("append_new.txt");
+        let _ = std::fs::remove_file(&path);
+        let content = STANDARD.encode(b"hello");
+
+        let result = fs_write_file(
+            path.to_str().unwrap().to_string(),
+            content,
+            true,
+            true,
+            Some(true),
+        );
+        assert!(result.is_ok());
+        let data = std::fs::read(&path).unwrap();
+        assert_eq!(data, b"hello");
+    }
+
+    #[test]
+    fn write_file_append_preserves_existing() {
+        let _guard = TestDir::new();
+        let dir = test_dir();
+        let path = dir.join("append_existing.txt");
+        {
+            let mut f = std::fs::File::create(&path).unwrap();
+            f.write_all(b"hello ").unwrap();
+        }
+        let content = STANDARD.encode(b"world");
+
+        let result = fs_write_file(
+            path.to_str().unwrap().to_string(),
+            content,
+            true,
+            true,
+            Some(true),
+        );
+        assert!(result.is_ok());
+        let data = std::fs::read(&path).unwrap();
+        assert_eq!(data, b"hello world");
+    }
+
+    #[test]
+    fn write_file_append_none_is_original_behavior() {
+        let _guard = TestDir::new();
+        let dir = test_dir();
+        let path = dir.join("no_append.txt");
+        {
+            let mut f = std::fs::File::create(&path).unwrap();
+            f.write_all(b"old content").unwrap();
+        }
+        let content = STANDARD.encode(b"new content");
+
+        let result = fs_write_file(
+            path.to_str().unwrap().to_string(),
+            content,
+            true,
+            true,
+            None,
+        );
+        assert!(result.is_ok());
+        let data = std::fs::read(&path).unwrap();
+        assert_eq!(data, b"new content");
+    }
+
+    #[test]
+    fn write_file_append_rejects_directory() {
+        let _guard = TestDir::new();
+        let dir = test_dir();
+        let content = STANDARD.encode(b"should fail");
+
+        let result = fs_write_file(
+            dir.to_str().unwrap().to_string(),
+            content,
+            true,
+            true,
+            Some(true),
+        );
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("EntryIsADirectory"));
+    }
+
+    #[test]
+    fn write_file_append_creates_parent_directories() {
+        let _guard = TestDir::new();
+        let dir = test_dir();
+        let path = dir.join("nested").join("sub").join("file.txt");
+
+        let content = STANDARD.encode(b"deep");
+        let result = fs_write_file(
+            path.to_str().unwrap().to_string(),
+            content,
+            true,
+            true,
+            Some(true),
+        );
+        assert!(result.is_ok());
+        let data = std::fs::read(&path).unwrap();
+        assert_eq!(data, b"deep");
+    }
+
+    #[test]
+    fn write_file_multiple_appends() {
+        let _guard = TestDir::new();
+        let dir = test_dir();
+        let path = dir.join("multi_append.txt");
+        let _ = std::fs::remove_file(&path);
+
+        for i in 0..3 {
+            let chunk = format!("chunk{} ", i);
+            let content = STANDARD.encode(chunk.as_bytes());
+            let result = fs_write_file(
+                path.to_str().unwrap().to_string(),
+                content,
+                true,
+                true,
+                Some(true),
+            );
+            assert!(result.is_ok());
+        }
+        let data = std::fs::read(&path).unwrap();
+        assert_eq!(data, b"chunk0 chunk1 chunk2 ");
     }
 }

--- a/src/vs/workbench/services/files/tauri-browser/diskFileSystemProvider.ts
+++ b/src/vs/workbench/services/files/tauri-browser/diskFileSystemProvider.ts
@@ -67,7 +67,8 @@ export class TauriDiskFileSystemProvider extends AbstractDiskFileSystemProvider 
 		let caps =
 			FileSystemProviderCapabilities.FileReadWrite |
 			FileSystemProviderCapabilities.FileFolderCopy |
-			FileSystemProviderCapabilities.Trash;
+			FileSystemProviderCapabilities.Trash |
+			FileSystemProviderCapabilities.FileAppend;
 		if (isLinux) {
 			caps |= FileSystemProviderCapabilities.PathCaseSensitive;
 		}
@@ -130,6 +131,7 @@ export class TauriDiskFileSystemProvider extends AbstractDiskFileSystemProvider 
 			content: base64,
 			create: opts.create,
 			overwrite: opts.overwrite,
+			append: opts.append ?? false,
 		});
 	}
 


### PR DESCRIPTION
## Summary
- Add `FileAppend` capability to `TauriDiskFileSystemProvider` so that VS Code's `FileService.validateWriteFile()` no longer rejects append writes
- Pass `opts.append` flag through `writeFile()` to the Rust `fs_write_file` command
- Implement append mode in Rust using `std::fs::OpenOptions::new().create(true).append(true)` instead of `std::fs::write()`
- Add 6 unit tests with drop guard cleanup pattern

## Problem
`ChatSessionStore` writes `.jsonl` session history using append mode. Since `TauriDiskFileSystemProvider` did not declare `FileAppend` capability, the `FileService` rejected all append writes with `"Filesystem provider for scheme '...' does not support append"`. This caused chat history to be lost on every restart.

## Test plan
- [ ] Verify Copilot Chat sends/receives messages without console errors about append
- [ ] Restart the app and confirm chat history is preserved
- [ ] Run `cargo test --lib commands::filesystem::tests` (from main repo with `out/` present)

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)