### PR TITLE
docs: add Installation section with platform download links

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,18 @@
 > **MVP Release Target: Late April 2026**<br>
 > Want to get notified? Watch this repo (**Watch → Custom → Releases**) to stay updated.
 
+## Installation
+
+> [!NOTE]
+> Installers will be available after the first release. Watch this repo (**Watch → Custom → Releases**) to get notified.
+
+| Platform | Installer |
+|----------|-----------|
+| macOS (Apple Silicon) | [`.dmg`](https://github.com/j4rviscmd/vscodeee/releases/latest/download/VSCodeee_macOS_arm64.dmg) |
+| macOS (Intel) | [`.dmg`](https://github.com/j4rviscmd/vscodeee/releases/latest/download/VSCodeee_macOS_x64.dmg) |
+| Linux | [`.AppImage`](https://github.com/j4rviscmd/vscodeee/releases/latest/download/VSCodeee_Linux_x64.AppImage) / [`.deb`](https://github.com/j4rviscmd/vscodeee/releases/latest/download/VSCodeee_Linux_x64.deb) |
+| Windows | [`.exe`](https://github.com/j4rviscmd/vscodeee/releases/latest/download/VSCodeee_Windows_x64-setup.exe) |
+
 ## Purpose
 
 Maintain the current functionality of VSCode while achieving the following:


### PR DESCRIPTION
## Summary

- Add `## Installation` section to README with platform-specific download links
- macOS (Apple Silicon + Intel), Linux (AppImage + deb), Windows (exe)
- `[!NOTE]` alert indicating installers will be available after the first release

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Verify download links point to correct asset names (matching publish.yml `upload-stable-assets` patterns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)