### PR TITLE
chore: add node_modules existence check before tauri:dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
 		"symlink-local-component-explorer": "npm install ../vscode-packages/js-component-explorer/packages/explorer ../vscode-packages/js-component-explorer/packages/cli --no-save && cd build/rspack && npm install ../../../vscode-packages/js-component-explorer/packages/webpack-plugin ../../../vscode-packages/js-component-explorer/packages/explorer --no-save && cd ../vite && npm install ../../../vscode-packages/js-component-explorer/packages/vite-plugin ../../../vscode-packages/js-component-explorer/packages/explorer --no-save",
 		"install-latest-component-explorer": "npm install @vscode/component-explorer@next @vscode/component-explorer-cli@next && cd build/rspack && npm install @vscode/component-explorer-webpack-plugin@next @vscode/component-explorer@next && cd ../vite && npm install @vscode/component-explorer-vite-plugin@next @vscode/component-explorer@next",
 		"tauri": "tauri",
-		"tauri:dev": "bash scripts/check-csp-hash.sh && node build/next/index.ts transpile && node build/next/index.ts transpile-extensions && tauri dev",
+		"tauri:dev": "bash scripts/check-deps.sh && bash scripts/check-csp-hash.sh && node build/next/index.ts transpile && node build/next/index.ts transpile-extensions && tauri dev",
 		"tauri:build": "tauri build"
 	},
 	"dependencies": {

--- a/scripts/check-deps.sh
+++ b/scripts/check-deps.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#---------------------------------------------------------------------------------------------
+#  Copyright (c) Microsoft Corporation. All rights reserved.
+#  Licensed under the MIT License. See License.txt in the project root for license information.
+#---------------------------------------------------------------------------------------------
+
+# check-deps.sh — Verify node_modules exist before dev server startup.
+# Lightweight guard: checks both root and key extension node_modules.
+# Run as part of npm scripts to prevent "Cannot find module" errors
+# when working in a fresh worktree where postinstall hasn't run.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+if [[ ! -d "$REPO_ROOT/node_modules" ]]; then
+	echo "[ERROR] Root node_modules not found. Run 'npm install' first."
+	echo "  cd $REPO_ROOT && npm install"
+	exit 1
+fi
+
+# Verify postinstall completed by checking a representative extension's node_modules.
+# extensions/git depends on several npm packages (byline, etc.) and is itself
+# a dependency of other extensions, making it a reliable indicator.
+if [[ ! -d "$REPO_ROOT/extensions/git/node_modules" ]]; then
+	echo "[ERROR] Extension node_modules not found (postinstall may have been skipped)."
+	echo "  Run: cd $REPO_ROOT && VSCODE_FORCE_INSTALL=1 npm install"
+	exit 1
+fi


### PR DESCRIPTION
## Summary
- Add `scripts/check-deps.sh` as a lightweight pre-flight check before `tauri:dev`
- Checks both root `node_modules/` and `extensions/git/node_modules/` to detect missing dependencies
- Root `node_modules` missing → `npm install` not run at all
- Extension `node_modules` missing → postinstall was skipped (suggests `VSCODE_FORCE_INSTALL=1`)

## Motivation
When working in a fresh worktree, `npm install` may not have been executed, or postinstall may be skipped. This causes built-in extensions (git, emmet, typescript-language-features, etc.) to fail with "Cannot find module" errors at runtime. This check catches the problem early with a clear error message instead of cryptic extension activation failures.

## Test plan
- [x] Run `npm run tauri:dev` in a worktree with `node_modules` present → passes check
- [ ] Remove `extensions/git/node_modules` and run `npm run tauri:dev` → detects missing extension deps
- [ ] Run `bash scripts/check-deps.sh` directly → validates script syntax and logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)