### PR TITLE
feat: patch Keychain ACL on secret_get to prevent password prompts across worktrees

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1334,6 +1334,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2023,6 +2034,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2537,7 +2563,10 @@ version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
 dependencies = [
+ "bitflags 2.11.0",
  "libc",
+ "plain",
+ "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -2681,6 +2710,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
 
 [[package]]
 name = "miniz_oxide"
@@ -3052,6 +3087,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-osa-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3127,6 +3174,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3179,6 +3232,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "pango"
 version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3227,7 +3294,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link 0.2.1",
 ]
@@ -3474,6 +3541,12 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plist"
@@ -3840,6 +3913,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+dependencies = [
+ "bitflags 2.11.0",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3922,15 +4004,20 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -3964,6 +4051,20 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4051,6 +4152,79 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.7.0",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework 3.7.0",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4063,6 +4237,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4536,7 +4719,7 @@ dependencies = [
  "objc2-foundation",
  "objc2-quartz-core",
  "raw-window-handle",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "tracing",
  "wasm-bindgen",
  "web-sys",
@@ -4765,6 +4948,17 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
 
 [[package]]
 name = "target-lexicon"
@@ -5040,6 +5234,39 @@ dependencies = [
  "tauri-plugin",
  "thiserror 2.0.18",
  "tokio",
+]
+
+[[package]]
+name = "tauri-plugin-updater"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
+dependencies = [
+ "base64 0.22.1",
+ "dirs",
+ "flate2",
+ "futures-util",
+ "http",
+ "infer",
+ "log",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest",
+ "rustls",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.60.2",
+ "zip 4.6.1",
 ]
 
 [[package]]
@@ -5349,6 +5576,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -5715,6 +5952,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5825,6 +6068,7 @@ dependencies = [
  "tauri-plugin-log",
  "tauri-plugin-os",
  "tauri-plugin-shell",
+ "tauri-plugin-updater",
  "tauri-plugin-window-state",
  "thiserror 2.0.18",
  "time",
@@ -5832,7 +6076,7 @@ dependencies = [
  "tokio-tungstenite",
  "trash",
  "uuid",
- "zip",
+ "zip 2.4.2",
 ]
 
 [[package]]
@@ -6143,6 +6387,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webview2-com"
 version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6440,6 +6693,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6923,6 +7185,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
 name = "xz2"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7137,6 +7409,18 @@ dependencies = [
  "zeroize",
  "zopfli",
  "zstd",
+]
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.13.1",
+ "memchr",
 ]
 
 [[package]]

--- a/src-tauri/src/commands/secret_storage.rs
+++ b/src-tauri/src/commands/secret_storage.rs
@@ -40,30 +40,60 @@ const SERVICE_NAME: &str = "vscodeee.secrets";
 ///
 /// # Returns
 /// The secret value as a string, or `None` if no entry exists.
+///
+/// On macOS debug builds, after successfully reading a Keychain item,
+/// the ACL is automatically patched to "any application" if it currently
+/// restricts access to specific binaries. This ensures that subsequent
+/// reads from different worktree binaries will not trigger a password prompt.
 #[tauri::command]
 pub fn secret_get(key: String) -> Result<Option<String>, String> {
     log::trace!(target: "vscodeee::secrets", "secret_get: key={key}");
 
-    match keyring::Entry::new(SERVICE_NAME, &key) {
-        Ok(entry) => match entry.get_password() {
-            Ok(password) => {
-                log::trace!(target: "vscodeee::secrets", "secret_get: found value for key={key}");
+    // On macOS debug builds, use the permissive ACL path: read the password
+    // and then patch the ACL to "any application" so future reads from
+    // different worktree binaries won't trigger a password dialog.
+    #[cfg(all(target_os = "macos", debug_assertions))]
+    {
+        return match macos_permissive::get_password_and_patch_acl(SERVICE_NAME, &key) {
+            Ok(Some(password)) => {
+                log::trace!(target: "vscodeee::secrets", "secret_get: found value for key={key} (permissive path)");
                 Ok(Some(password))
             }
-            Err(keyring::Error::NoEntry) => {
+            Ok(None) => {
                 log::trace!(target: "vscodeee::secrets", "secret_get: no entry for key={key}");
                 Ok(None)
             }
             Err(e) => {
-                log::warn!(target: "vscodeee::secrets", "secret_get: keyring error for key={key}: {e}");
-                Err(format!("Failed to get secret for key '{key}': {e}"))
+                log::warn!(target: "vscodeee::secrets", "secret_get: permissive path error for key={key}: {e}");
+                Err(e)
             }
-        },
-        Err(e) => {
-            log::warn!(target: "vscodeee::secrets", "secret_get: failed to create entry for key={key}: {e}");
-            Err(format!(
-                "Failed to create keyring entry for key '{key}': {e}"
-            ))
+        };
+    }
+
+    // On release builds (and non-macOS), use the default keyring behavior.
+    #[cfg(not(all(target_os = "macos", debug_assertions)))]
+    {
+        match keyring::Entry::new(SERVICE_NAME, &key) {
+            Ok(entry) => match entry.get_password() {
+                Ok(password) => {
+                    log::trace!(target: "vscodeee::secrets", "secret_get: found value for key={key}");
+                    Ok(Some(password))
+                }
+                Err(keyring::Error::NoEntry) => {
+                    log::trace!(target: "vscodeee::secrets", "secret_get: no entry for key={key}");
+                    Ok(None)
+                }
+                Err(e) => {
+                    log::warn!(target: "vscodeee::secrets", "secret_get: keyring error for key={key}: {e}");
+                    Err(format!("Failed to get secret for key '{key}': {e}"))
+                }
+            },
+            Err(e) => {
+                log::warn!(target: "vscodeee::secrets", "secret_get: failed to create entry for key={key}: {e}");
+                Err(format!(
+                    "Failed to create keyring entry for key '{key}': {e}"
+                ))
+            }
         }
     }
 }
@@ -150,9 +180,10 @@ mod macos_permissive {
         CFDictionaryCreateMutable, CFDictionaryRef, CFMutableDictionaryRef,
     };
     use security_framework_sys::item::{
-        kSecAttrAccount, kSecAttrService, kSecClass, kSecClassGenericPassword, kSecValueData,
+        kSecAttrAccount, kSecAttrService, kSecClass, kSecClassGenericPassword, kSecMatchLimit,
+        kSecReturnData, kSecValueData,
     };
-    use security_framework_sys::keychain_item::{SecItemAdd, SecItemDelete};
+    use security_framework_sys::keychain_item::{SecItemAdd, SecItemCopyMatching, SecItemDelete};
     use std::ffi::c_void;
     use std::ptr;
 
@@ -162,6 +193,10 @@ mod macos_permissive {
         // kSecAttrAccess: CFStringRef key for setting the access object on a
         // legacy Keychain item (macOS only, not available on iOS).
         static kSecAttrAccess: core_foundation_sys::string::CFStringRef;
+
+        // kSecMatchLimitOne: CFStringRef value for kSecMatchLimit that limits
+        // SecItemCopyMatching to return at most one item.
+        static kSecMatchLimitOne: core_foundation_sys::string::CFStringRef;
 
         // SecAccessCreate: Creates a new access object.
         // trustedList=NULL → only calling app; empty CFArray → empty list.
@@ -368,6 +403,103 @@ mod macos_permissive {
             );
 
             Ok(())
+        }
+    }
+
+    /// Read a generic password from the macOS Keychain and, if the item's ACL
+    /// restricts access to specific binaries, re-save it with an "any application"
+    /// ACL so that future reads from any worktree binary succeed without prompting.
+    ///
+    /// ## Behavior
+    /// 1. Use `SecItemCopyMatching` to read the password value.
+    /// 2. If the item does not exist, return `Ok(None)`.
+    /// 3. If the read succeeds, re-save the same value via `set_password_any_app`
+    ///    which deletes + re-creates the item with a fully permissive ACL.
+    ///    This is idempotent — if the ACL is already permissive, the re-save
+    ///    simply overwrites with the same value and ACL.
+    ///
+    /// ## Important
+    /// The first call from a new binary **may still trigger a password dialog**
+    /// if the existing item has a binary-restricted ACL and the user allowed
+    /// access. After that, the ACL is patched and subsequent calls won't prompt.
+    pub(super) fn get_password_and_patch_acl(
+        service: &str,
+        account: &str,
+    ) -> Result<Option<String>, String> {
+        unsafe {
+            let cf_service = CFString::new(service);
+            let cf_account = CFString::new(account);
+
+            // Build the query dictionary for SecItemCopyMatching.
+            let query = create_mutable_dict();
+            CFDictionaryAddValue(
+                query,
+                kSecClass as *const c_void,
+                kSecClassGenericPassword as *const c_void,
+            );
+            CFDictionaryAddValue(
+                query,
+                kSecAttrService as *const c_void,
+                cf_service.as_concrete_TypeRef() as *const c_void,
+            );
+            CFDictionaryAddValue(
+                query,
+                kSecAttrAccount as *const c_void,
+                cf_account.as_concrete_TypeRef() as *const c_void,
+            );
+            CFDictionaryAddValue(
+                query,
+                kSecReturnData as *const c_void,
+                core_foundation_sys::number::kCFBooleanTrue as *const c_void,
+            );
+            CFDictionaryAddValue(
+                query,
+                kSecMatchLimit as *const c_void,
+                kSecMatchLimitOne as *const c_void,
+            );
+
+            let mut result: CFTypeRef = ptr::null();
+            let status = SecItemCopyMatching(query as CFDictionaryRef, &mut result);
+            CFRelease(query as CFTypeRef);
+
+            // errSecItemNotFound = -25300
+            if status == -25300 {
+                return Ok(None);
+            }
+
+            if status != 0 {
+                return Err(format!(
+                    "Failed to get secret for key '{account}': Platform secure storage failure (status {status})"
+                ));
+            }
+
+            if result.is_null() {
+                return Ok(None);
+            }
+
+            // Convert CFData → String.
+            let data_ref = result as core_foundation_sys::data::CFDataRef;
+            let len = core_foundation_sys::data::CFDataGetLength(data_ref) as usize;
+            let ptr = core_foundation_sys::data::CFDataGetBytePtr(data_ref);
+            let bytes = std::slice::from_raw_parts(ptr, len);
+            let password = String::from_utf8_lossy(bytes).into_owned();
+            CFRelease(result);
+
+            // Re-save with permissive ACL to patch any binary-restricted ACL.
+            // This is idempotent — overwrites with same value + any-app ACL.
+            log::info!(
+                target: "vscodeee::secrets",
+                "get_password_and_patch_acl: re-saving with permissive ACL for key={account}"
+            );
+            if let Err(e) = set_password_any_app(service, account, &password) {
+                // Log the error but still return the password — the read succeeded.
+                log::warn!(
+                    target: "vscodeee::secrets",
+                    "get_password_and_patch_acl: failed to patch ACL for key={account}: {e}"
+                );
+            }
+
+            Ok(Some(password))
         }
     }
 }


### PR DESCRIPTION
## Summary

- `secret_get` でmacOS Keychainアイテムを読み取った後、ACLを自動的に「any application」にパッチする機能を追加
- debugビルドのみで有効（`#[cfg(all(target_os = "macos", debug_assertions))]`）
- releaseビルドでは従来の `keyring` crate によるアクセスを維持

## Background

PR #138 で `secret_set` 時にany app ACLを設定する機能を実装したが、**既存のKeychainエントリ**は `secret_set` が呼ばれるまでバイナリ制限付きACLのままだった。このため、新しいworktreeバイナリから `secret_get` を呼び出すとmacOSがパスワードダイアログを表示する問題が残っていた。

## Changes

### `secret_storage.rs`
- `get_password_and_patch_acl()` 関数を `macos_permissive` モジュールに追加
  - `SecItemCopyMatching` でKeychainアイテムを直接読み取り
  - 読み取り成功後、`set_password_any_app` で同じ値を再保存（ACLをany appにパッチ）
  - アイテムが存在しない場合は `Ok(None)` を返す
  - ACLパッチが失敗しても読み取った値は正常に返す（ログ警告のみ）
- `kSecMatchLimitOne` のFFI宣言を追加（`security-framework-sys v2` にはエクスポートされていないため）
- `secret_get` を `#[cfg]` で条件分岐：debugビルドでは新しいパス、releaseビルドでは従来のパス

## Testing

- worktreeから起動してダイアログが表示されないことを確認済み
- 3つのKeychainエントリすべてが `applications: <null>` で保存されていることを `security dump-keychain` で確認済み
- `cargo check` パス（既存のwarningのみ）

## Related

- Closes the remaining issue from #138