### PR TITLE
fix: suppress native context menu in Tauri WebView

### DIFF
--- a/src/vs/workbench/tauri-browser/desktop.tauri.main.ts
+++ b/src/vs/workbench/tauri-browser/desktop.tauri.main.ts
@@ -12,7 +12,7 @@
 
 import product from '../../platform/product/common/product.js';
 import { Workbench } from '../browser/workbench.js';
-import { domContentLoaded, addDisposableListener, EventType } from '../../base/browser/dom.js';
+import { domContentLoaded, addDisposableListener, EventHelper, EventType } from '../../base/browser/dom.js';
 import { ServiceCollection } from '../../platform/instantiation/common/serviceCollection.js';
 import { ILogService, ILoggerService, getLogLevel, ConsoleLogger } from '../../platform/log/common/log.js';
 import { FileLoggerService } from '../../platform/log/common/fileLog.js';
@@ -122,6 +122,13 @@ export class TauriDesktopMain extends Disposable {
 			listen('tauri://resize', () => layoutService.layout())
 				.then(unlisten => this._register({ dispose: unlisten }));
 			this._register(addDisposableListener(mainWindow, EventType.RESIZE, () => layoutService.layout()));
+
+			// Prevent native WebView behaviors — mirrors BrowserWindow in window.ts.
+			const mainContainer = layoutService.mainContainer;
+			const preventEvent = (e: Event) => EventHelper.stop(e, true);
+			this._register(addDisposableListener(mainContainer, EventType.CONTEXT_MENU, preventEvent));
+			this._register(addDisposableListener(mainContainer, EventType.DROP, preventEvent));
+			this._register(addDisposableListener(mainContainer, EventType.WHEEL, e => e.preventDefault(), { passive: false }));
 
 			this._register(nativeHostService.onDidMaximizeWindow(() => {
 				layoutService.updateWindowMaximizedState(mainWindow, true);


### PR DESCRIPTION
## Summary

- Add event listeners on `layoutService.mainContainer` to prevent native WebView context menu, default drop navigation, and trackpad back/forward gestures in the Tauri workbench
- Mirrors the `BrowserWindow` pattern from `window.ts:271-277` which was missing in the Tauri entry point
- Extracts a shared `preventEvent` handler for `CONTEXT_MENU` and `DROP` to reduce duplication

## Problem

Right-clicking in the Tauri WebView showed both the native OS context menu and VS Code's custom context menu simultaneously, causing duplication. This occurred because the Tauri workbench entry point (`desktop.tauri.main.ts`) does not instantiate `BrowserWindow`, which is where the suppression is registered in the web build.

## Test plan

- [ ] Right-click in editor area → VS Code custom menu only, no native menu
- [ ] Right-click in explorer/titlebar/statusbar background → no native menu
- [ ] Open DevTools, right-click inside DevTools → native WebKit Inspector menu works
- [ ] Drag a file into the workbench → WebView does not navigate away
- [ ] Trackpad swipe on macOS → no back/forward navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)