### PR TITLE
fix: register workbench.action.quit and fix Tauri native service gaps

### DIFF
--- a/src/vs/base/common/platform.ts
+++ b/src/vs/base/common/platform.ts
@@ -106,6 +106,17 @@ else if (typeof navigator === 'object' && !isElectronRenderer) {
 	_isMobile = _userAgent?.indexOf('Mobi') >= 0;
 	_isWeb = true;
 	_isTauri = typeof ($globalThis as any).__TAURI_INTERNALS__ !== 'undefined';
+
+	// Tauri is a desktop app with native OS integration - treat as native
+	// desktop, not web. This ensures isNative-gated code paths (settings
+	// relauncher, native context keys, extension signature verification,
+	// etc.) activate correctly, while preventing web-only code paths from
+	// running in the Tauri WebView environment.
+	if (_isTauri) {
+		_isNative = true;
+		_isWeb = false;
+	}
+
 	_language = nls.getNLSLanguage() || LANGUAGE_DEFAULT;
 	_locale = navigator.language.toLowerCase();
 	_platformLocale = _locale;
@@ -149,6 +160,14 @@ export const isLinuxSnap = _isLinuxSnap;
 export const isNative = _isNative;
 export const isElectron = _isElectron;
 export const isWeb = _isWeb;
+/**
+ * Whether the application is running inside a Tauri WebView.
+ *
+ * When true, {@link isNative} is also forced to `true` and {@link isWeb}
+ * is set to `false` so that native-gated code paths (settings relauncher,
+ * native context keys, extension signature verification, etc.) activate
+ * correctly inside the Tauri WebView environment.
+ */
 export const isTauri = _isTauri;
 export const isWebWorker = (_isWeb && typeof $globalThis.importScripts === 'function');
 export const webWorkerOrigin = isWebWorker ? $globalThis.origin : undefined;

--- a/src/vs/platform/contextkey/common/contextkeys.ts
+++ b/src/vs/platform/contextkey/common/contextkeys.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { isIOS, isLinux, isMacintosh, isMobile, isWeb, isWindows } from '../../../base/common/platform.js';
+import { isIOS, isLinux, isMacintosh, isMobile, isNative, isWeb, isWindows } from '../../../base/common/platform.js';
 import { localize } from '../../../nls.js';
 import { RawContextKey } from './contextkey.js';
 
@@ -12,7 +12,7 @@ export const IsLinuxContext = new RawContextKey<boolean>('isLinux', isLinux, loc
 export const IsWindowsContext = new RawContextKey<boolean>('isWindows', isWindows, localize('isWindows', "Whether the operating system is Windows"));
 
 export const IsWebContext = new RawContextKey<boolean>('isWeb', isWeb, localize('isWeb', "Whether the platform is a web browser"));
-export const IsMacNativeContext = new RawContextKey<boolean>('isMacNative', isMacintosh && !isWeb, localize('isMacNative', "Whether the operating system is macOS on a non-browser platform"));
+export const IsMacNativeContext = new RawContextKey<boolean>('isMacNative', isMacintosh && isNative, localize('isMacNative', "Whether the operating system is macOS on a desktop platform"));
 export const IsIOSContext = new RawContextKey<boolean>('isIOS', isIOS, localize('isIOS', "Whether the operating system is iOS"));
 export const IsMobileContext = new RawContextKey<boolean>('isMobile', isMobile, localize('isMobile', "Whether the platform is a mobile web browser"));
 

--- a/src/vs/workbench/browser/contextkeys.ts
+++ b/src/vs/workbench/browser/contextkeys.ts
@@ -136,19 +136,17 @@ export class WorkbenchContextKeysHandler extends Disposable {
 
 		// Opening folder support: support for opening a folder workspace
 		// (e.g. "Open Folder...") is limited in web when not connected
-		// to a remote. Tauri has native file system access, so it behaves like desktop.
-		const isTauri = typeof (globalThis as any).__TAURI_INTERNALS__ !== 'undefined';
+		// to a remote.
 		this.openFolderWorkspaceSupportContext = OpenFolderWorkspaceSupportContext.bindTo(this.contextKeyService);
-		this.openFolderWorkspaceSupportContext.set(isNative || isTauri || typeof this.environmentService.remoteAuthority === 'string');
+		this.openFolderWorkspaceSupportContext.set(isNative || typeof this.environmentService.remoteAuthority === 'string');
 
 		// Empty workspace support: empty workspaces require built-in file system
 		// providers to be available that allow to enter a workspace or open loose
 		// files. This condition is met:
 		// - desktop: always
-		// - tauri: always (has native file system)
 		// -     web: only when connected to a remote
 		this.emptyWorkspaceSupportContext = EmptyWorkspaceSupportContext.bindTo(this.contextKeyService);
-		this.emptyWorkspaceSupportContext.set(isNative || isTauri || typeof this.environmentService.remoteAuthority === 'string');
+		this.emptyWorkspaceSupportContext.set(isNative || typeof this.environmentService.remoteAuthority === 'string');
 
 		// Entering a multi root workspace support: support for entering a multi-root
 		// workspace (e.g. "Open Workspace from File...", "Duplicate Workspace", "Save Workspace")
@@ -156,10 +154,9 @@ export class WorkbenchContextKeysHandler extends Disposable {
 		// with a built-in file system provider.
 		// This condition is met:
 		// - desktop: always
-		// - tauri: always (has native file system)
 		// -     web: only when connected to a remote
 		this.enterMultiRootWorkspaceSupportContext = EnterMultiRootWorkspaceSupportContext.bindTo(this.contextKeyService);
-		this.enterMultiRootWorkspaceSupportContext.set(isNative || isTauri || typeof this.environmentService.remoteAuthority === 'string');
+		this.enterMultiRootWorkspaceSupportContext.set(isNative || typeof this.environmentService.remoteAuthority === 'string');
 
 		// Editor Layout
 		this.splitEditorsVerticallyContext = SplitEditorsVertically.bindTo(this.contextKeyService);

--- a/src/vs/workbench/services/host/tauri-browser/hostService.ts
+++ b/src/vs/workbench/services/host/tauri-browser/hostService.ts
@@ -4,15 +4,114 @@
  *--------------------------------------------------------------------------------------------*/
 
 /**
- * Tauri workbench host service registration.
+ * Tauri workbench host service.
  *
- * For Phase 1 we reuse the browser host service, which provides all
- * IHostService methods using standard web APIs. This is appropriate
- * because Tauri's WebView is a browser environment.
+ * Extends BrowserHostService and overrides methods that should delegate to
+ * INativeHostService for proper native OS behavior:
  *
- * In later phases, this can be replaced with a Tauri-specific host
- * service that delegates to INativeHostService for native operations.
+ * - toggleFullScreen: uses native window fullscreen instead of DOM API
+ * - moveTop: brings window to front via native API
+ * - restart: relaunches the entire app (not just WebView reload)
  */
 
-// Re-export the browser host service registration (registerSingleton side-effect)
+import { BrowserHostService } from '../browser/browserHostService.js';
+import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
+import { IHostService } from '../browser/host.js';
+import { INativeHostService } from '../../../../platform/native/common/native.js';
+import { ILayoutService } from '../../../../platform/layout/browser/layoutService.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { IFileService } from '../../../../platform/files/common/files.js';
+import { ILabelService } from '../../../../platform/label/common/label.js';
+import { IBrowserWorkbenchEnvironmentService } from '../../environment/browser/environmentService.js';
+import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
+import { ILifecycleService } from '../../lifecycle/common/lifecycle.js';
+import { BrowserLifecycleService } from '../../lifecycle/browser/lifecycleService.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
+import { IDialogService } from '../../../../platform/dialogs/common/dialogs.js';
+import { IWorkspaceContextService } from '../../../../platform/workspace/common/workspace.js';
+import { IUserDataProfilesService } from '../../../../platform/userDataProfile/common/userDataProfile.js';
+
+// NOTE: This import MUST come after `workbench.common.main.js` which
+// transitively registers `BrowserHostService`. The last registration
+// wins (Map.set semantics), so our Tauri service overrides the browser one.
 import '../browser/browserHostService.js';
+
+/**
+ * Workbench host service for the Tauri platform.
+ *
+ * Extends {@link BrowserHostService} and overrides methods that should
+ * delegate to {@link INativeHostService} for proper native OS behavior
+ * instead of using browser/DOM APIs:
+ *
+ * - {@link toggleFullScreen}: uses native window fullscreen instead of the DOM Fullscreen API
+ * - {@link moveTop}: brings the window to front via the native API
+ * - {@link restart}: relaunches the entire application (not just a WebView reload)
+ *
+ * Registered as a delayed singleton so that it overrides the browser
+ * implementation loaded by `workbench.common.main.js`.
+ */
+export class TauriHostService extends BrowserHostService {
+
+	/**
+	 * @param nativeHostService - The native host service providing OS-level window operations.
+	 */
+	constructor(
+		@ILayoutService layoutService: ILayoutService,
+		@IConfigurationService configurationService: IConfigurationService,
+		@IFileService fileService: IFileService,
+		@ILabelService labelService: ILabelService,
+		@IBrowserWorkbenchEnvironmentService environmentService: IBrowserWorkbenchEnvironmentService,
+		@IInstantiationService instantiationService: IInstantiationService,
+		@ILifecycleService lifecycleService: ILifecycleService,
+		@ILogService logService: ILogService,
+		@IDialogService dialogService: IDialogService,
+		@IWorkspaceContextService contextService: IWorkspaceContextService,
+		@IUserDataProfilesService userDataProfilesService: IUserDataProfilesService,
+		@INativeHostService private readonly nativeHostService: INativeHostService,
+	) {
+		super(
+			layoutService, configurationService, fileService, labelService,
+			environmentService, instantiationService, lifecycleService as unknown as BrowserLifecycleService,
+			logService, dialogService, contextService, userDataProfilesService
+		);
+	}
+
+	/**
+	 * Toggles the native window fullscreen state.
+	 *
+	 * Overrides the browser implementation which uses the DOM Fullscreen API,
+	 * delegating instead to the native Tauri window API for correct desktop
+	 * fullscreen behavior (e.g. macOS Space management).
+	 *
+	 * @param _targetWindow - Ignored; the native API operates on the current window.
+	 */
+	override async toggleFullScreen(_targetWindow: Window): Promise<void> {
+		return this.nativeHostService.toggleFullScreen();
+	}
+
+	/**
+	 * Brings the application window to the front of the OS window stack.
+	 *
+	 * Overrides the browser implementation which uses `window.focus()`,
+	 * delegating instead to the native Tauri API for reliable window raising
+	 * across all desktop platforms.
+	 *
+	 * @param _targetWindow - Ignored; the native API operates on the current window.
+	 */
+	override async moveTop(_targetWindow: Window): Promise<void> {
+		return this.nativeHostService.moveWindowTop();
+	}
+
+	/**
+	 * Relaunches the entire application.
+	 *
+	 * Overrides the browser implementation which would only reload the WebView,
+	 * delegating instead to the native Tauri relaunch API to restart the full
+	 * native process (equivalent to quitting and re-opening the app).
+	 */
+	override async restart(): Promise<void> {
+		return this.nativeHostService.relaunch();
+	}
+}
+
+registerSingleton(IHostService, TauriHostService, InstantiationType.Delayed);

--- a/src/vs/workbench/services/layout/browser/layoutService.ts
+++ b/src/vs/workbench/services/layout/browser/layoutService.ts
@@ -9,7 +9,7 @@ import { ILayoutService } from '../../../../platform/layout/browser/layoutServic
 import { Part } from '../../../browser/part.js';
 import { IDimension } from '../../../../base/browser/dom.js';
 import { Direction, IViewSize } from '../../../../base/browser/ui/grid/grid.js';
-import { isMacintosh, isNative, isTauri, isWeb } from '../../../../base/common/platform.js';
+import { isMacintosh, isNative, isWeb } from '../../../../base/common/platform.js';
 import { isAuxiliaryWindow } from '../../../../base/browser/window.js';
 import { CustomTitleBarVisibility, TitleBarSetting, getMenuBarVisibility, hasCustomTitlebar, hasNativeMenu, hasNativeTitlebar } from '../../../../platform/window/common/window.js';
 import { isFullscreen, isWCOEnabled } from '../../../../base/browser/browser.js';
@@ -364,6 +364,24 @@ export interface IWorkbenchLayoutService extends ILayoutService {
 	getVisibleNeighborPart(part: Parts, direction: Direction): Parts | undefined;
 }
 
+/**
+ * Determines whether the custom (HTML-based) title bar should be displayed.
+ *
+ * The decision tree considers multiple factors in priority order:
+ * 1. Whether a custom title bar is configured at all.
+ * 2. Platform-specific fullscreen behavior (macOS native hides title bar in fullscreen).
+ * 3. Whether the title bar area contains non-empty content (command center, activity bar, etc.).
+ * 4. Menu bar visibility settings.
+ *
+ * On native platforms (including Tauri), the title bar is shown by default
+ * in windowed mode and hidden in fullscreen according to OS conventions.
+ * On web, the title bar is hidden unless explicitly needed for menu bar content.
+ *
+ * @param configurationService - The configuration service for reading title bar and menu bar settings.
+ * @param window - The target window to evaluate (used for fullscreen detection).
+ * @param menuBarToggled - Whether the menu bar was manually toggled by the user.
+ * @returns `true` if the custom title bar should be visible, `false` otherwise.
+ */
 export function shouldShowCustomTitleBar(configurationService: IConfigurationService, window: Window, menuBarToggled?: boolean): boolean {
 	if (!hasCustomTitlebar(configurationService)) {
 		return false;
@@ -388,10 +406,8 @@ export function shouldShowCustomTitleBar(configurationService: IConfigurationSer
 		return false;
 	}
 
-	// macOS (Electron or Tauri): title bar not needed when fullscreen.
-	// Tauri's TitleBarStyle::Overlay provides native traffic lights when windowed,
-	// so the title bar must remain visible to provide spacing and a drag region.
-	if (isMacintosh && (isNative || isTauri)) {
+	// macOS native: title bar not needed when fullscreen.
+	if (isMacintosh && isNative) {
 		return !inFullscreen;
 	}
 

--- a/src/vs/workbench/tauri-browser/actions/nativeActions.ts
+++ b/src/vs/workbench/tauri-browser/actions/nativeActions.ts
@@ -1,0 +1,49 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) VS Codeee Contributors. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Tauri-specific native window actions.
+ *
+ * Registers commands that require native OS integration and are not
+ * available in the browser environment. Follows the same pattern as
+ * developerActions.ts.
+ */
+
+import { localize2 } from '../../../nls.js';
+import { Action2, registerAction2 } from '../../../platform/actions/common/actions.js';
+import { Categories } from '../../../platform/action/common/actionCommonCategories.js';
+import { INativeHostService } from '../../../platform/native/common/native.js';
+import { ServicesAccessor } from '../../../platform/instantiation/common/instantiation.js';
+
+/**
+ * Action that quits the application entirely.
+ *
+ * Delegates to {@link INativeHostService.quit} to perform a clean shutdown
+ * of the native process. Registered under `workbench.action.quit` with the
+ * File category and bound to the Command Palette (`f1: true`).
+ */
+class QuitAction extends Action2 {
+	constructor() {
+		super({
+			id: 'workbench.action.quit',
+			title: localize2('quit', 'Quit'),
+			category: Categories.File,
+			f1: true
+		});
+	}
+
+	/**
+	 * Triggers application quit via the native host service.
+	 *
+	 * @param accessor - The service accessor used to resolve {@link INativeHostService}.
+	 * @returns A promise that resolves when the quit request has been sent.
+	 */
+	run(accessor: ServicesAccessor): Promise<void> {
+		const nativeHostService = accessor.get(INativeHostService);
+		return nativeHostService.quit();
+	}
+}
+
+registerAction2(QuitAction);

--- a/src/vs/workbench/workbench.tauri.main.ts
+++ b/src/vs/workbench/workbench.tauri.main.ts
@@ -33,6 +33,7 @@ import './tauri-browser/desktop.tauri.main.js';
 //#region --- workbench actions (Tauri-specific)
 
 import './tauri-browser/actions/developerActions.js';
+import './tauri-browser/actions/nativeActions.js';
 
 //#endregion
 


### PR DESCRIPTION
## Summary

- Fix `workbench.action.quit` command not found error when pressing Cmd+Q
- Fix `TauriHostService` using DOM APIs instead of native Tauri equivalents
- Fix `isNative` flag being `false` for Tauri, causing native-gated code paths to be skipped

## Changes

### Platform flag fix (`platform.ts`)
- Set `isNative = true` and `isWeb = false` when `isTauri = true`
- This ensures all `isNative`-gated code paths (settings relauncher, native context keys, extension signature verification, etc.) activate correctly for Tauri

### Context key fix (`contextkeys.ts`)
- Fix `IsMacNativeContext` to use `isNative` instead of `!isWeb`
- Restores correct macOS-native menu behavior (About dialog placement, etc.)

### TauriHostService (`hostService.ts`)
- Create `TauriHostService` extending `BrowserHostService` with native overrides:
  - `toggleFullScreen` → delegates to `nativeHostService.toggleFullScreen()` (native window fullscreen instead of DOM Fullscreen API)
  - `moveTop` → delegates to `nativeHostService.moveWindowTop()` (brings window to front)
  - `restart` → delegates to `nativeHostService.relaunch()` (full app relaunch instead of page reload)

### Quit command (`nativeActions.ts`)
- Register `workbench.action.quit` command that delegates to `INativeHostService.quit()` → Rust `quit_app` command
- Follows the same pattern as existing `developerActions.ts`

### Cleanup
- Remove redundant `|| isTauri` patches in `workbench/browser/contextkeys.ts` (3 places) and `layoutService.ts` (1 place), now unified under `isNative`

## Test plan

- [ ] Press Cmd+Q → app quits without "command not found" error
- [ ] F11 → native window fullscreen (not DOM fullscreen)
- [ ] Developer: Restart → full app relaunch (not just page reload)
- [ ] Verify macOS About dialog appears in Help menu (not as native app menu item)
- [ ] Verify settings changes prompt restart correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)