### PR TITLE
feat: implement Tauri-native auto-update service

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1334,6 +1334,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2023,6 +2034,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2537,7 +2563,10 @@ version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
 dependencies = [
+ "bitflags 2.11.0",
  "libc",
+ "plain",
+ "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -2681,6 +2710,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
 
 [[package]]
 name = "miniz_oxide"
@@ -3052,6 +3087,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-osa-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3127,6 +3174,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3179,6 +3232,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "pango"
 version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3227,7 +3294,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link 0.2.1",
 ]
@@ -3474,6 +3541,12 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plist"
@@ -3840,6 +3913,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+dependencies = [
+ "bitflags 2.11.0",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3922,15 +4004,20 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -3964,6 +4051,20 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4051,6 +4152,79 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.7.0",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework 3.7.0",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4063,6 +4237,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4536,7 +4719,7 @@ dependencies = [
  "objc2-foundation",
  "objc2-quartz-core",
  "raw-window-handle",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "tracing",
  "wasm-bindgen",
  "web-sys",
@@ -4765,6 +4948,17 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
 
 [[package]]
 name = "target-lexicon"
@@ -5040,6 +5234,39 @@ dependencies = [
  "tauri-plugin",
  "thiserror 2.0.18",
  "tokio",
+]
+
+[[package]]
+name = "tauri-plugin-updater"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
+dependencies = [
+ "base64 0.22.1",
+ "dirs",
+ "flate2",
+ "futures-util",
+ "http",
+ "infer",
+ "log",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest",
+ "rustls",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.60.2",
+ "zip 4.6.1",
 ]
 
 [[package]]
@@ -5349,6 +5576,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -5715,6 +5952,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5825,6 +6068,7 @@ dependencies = [
  "tauri-plugin-log",
  "tauri-plugin-os",
  "tauri-plugin-shell",
+ "tauri-plugin-updater",
  "tauri-plugin-window-state",
  "thiserror 2.0.18",
  "time",
@@ -5832,7 +6076,7 @@ dependencies = [
  "tokio-tungstenite",
  "trash",
  "uuid",
- "zip",
+ "zip 2.4.2",
 ]
 
 [[package]]
@@ -6143,6 +6387,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webview2-com"
 version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6440,6 +6693,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6923,6 +7185,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
 name = "xz2"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7137,6 +7409,18 @@ dependencies = [
  "zeroize",
  "zopfli",
  "zstd",
+]
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.13.1",
+ "memchr",
 ]
 
 [[package]]

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -15,6 +15,7 @@ pub mod native_host;
 pub mod secret_storage;
 pub mod spawn_exthost;
 pub mod terminal;
+pub mod updater;
 pub mod window;
 
 use serde::Serialize;

--- a/src-tauri/src/commands/native_host/lifecycle.rs
+++ b/src-tauri/src/commands/native_host/lifecycle.rs
@@ -17,6 +17,15 @@ pub fn notify_ready() {
     log::info!(target: "vscodeee::commands::native_host", "Workbench notified ready");
 }
 
+/// Return whether the app was compiled in debug (development) mode.
+///
+/// Used by the TypeScript updater service to decide whether the
+/// `update.enabled` dev-flag is required.
+#[tauri::command]
+pub fn is_dev_build() -> bool {
+    cfg!(debug_assertions)
+}
+
 /// Close the current window.
 #[tauri::command]
 pub fn close_window(window: tauri::Window) -> Result<(), NativeHostError> {

--- a/src-tauri/src/commands/updater/commands.rs
+++ b/src-tauri/src/commands/updater/commands.rs
@@ -1,0 +1,198 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) VS Codeee Contributors. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+//! Tauri commands for the application update lifecycle.
+//!
+//! Wraps [`tauri_plugin_updater`] with four IPC commands:
+//! - [`updater_check_for_updates`] — query the endpoint for a new version
+//! - [`updater_download_and_install`] — download, stage, and stream progress
+//! - [`updater_restart_and_update`] — persist session and restart
+//! - [`updater_get_current_version`] — report the running version
+
+use serde::Serialize;
+use tauri::ipc::Channel;
+use tauri::Manager;
+use tauri_plugin_updater::UpdaterExt;
+
+use super::error::UpdateError;
+
+// ── Types shared with the WebView ──────────────────────────────────────────
+
+/// Update metadata returned by [`updater_check_for_updates`].
+#[derive(Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateInfo {
+    pub version: String,
+    pub current_version: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub date: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub body: Option<String>,
+}
+
+/// Single progress event streamed through the [`Channel`] during download.
+#[derive(Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct DownloadProgress {
+    pub phase: DownloadPhase,
+    pub downloaded_bytes: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_bytes: Option<u64>,
+}
+
+/// Phase labels matching the VS Code `StateType.Downloading` lifecycle.
+#[derive(Serialize, Clone)]
+#[serde(rename_all = "lowercase")]
+pub enum DownloadPhase {
+    Started,
+    Progress,
+    Finished,
+}
+
+// ── Shared state ───────────────────────────────────────────────────────────
+
+/// Holds the cached [`tauri_plugin_updater::Update`] between check and download.
+///
+/// The `Option` is `take()`n by [`updater_download_and_install`] to prevent
+/// stale updates from being applied.
+#[derive(Default)]
+pub struct UpdaterState {
+    pending: tokio::sync::Mutex<Option<tauri_plugin_updater::Update>>,
+}
+
+type Result<T> = std::result::Result<T, UpdateError>;
+
+// ── Commands ───────────────────────────────────────────────────────────────
+
+/// Query the configured endpoint for an available update.
+///
+/// Returns `Some(UpdateInfo)` when a newer version exists, `None` otherwise.
+/// The result is cached in [`UpdaterState`] for the subsequent
+/// [`updater_download_and_install`] call.
+#[tauri::command]
+pub async fn updater_check_for_updates(
+    app: tauri::AppHandle,
+    state: tauri::State<'_, UpdaterState>,
+) -> Result<Option<UpdateInfo>> {
+    log::info!(target: "vscodeee::updater", "Checking for updates");
+
+    let update = app
+        .updater_builder()
+        .build()
+        .map_err(|e| UpdateError::NotAvailable(e.to_string()))?
+        .check()
+        .await
+        .map_err(|e| {
+            log::warn!(target: "vscodeee::updater", "Update check failed: {e}");
+            UpdateError::CheckFailed(e.to_string())
+        })?;
+
+    match update {
+        Some(u) => {
+            let info = UpdateInfo {
+                version: u.version.clone(),
+                current_version: u.current_version.clone(),
+                date: u.date.map(|d| {
+                    d.format(&time::format_description::well_known::Rfc3339)
+                        .unwrap_or_else(|_| d.to_string())
+                }),
+                body: u.body.clone(),
+            };
+            log::info!(
+                target: "vscodeee::updater",
+                "Update available: {} (current: {})",
+                info.version,
+                info.current_version
+            );
+            *state.pending.lock().await = Some(u);
+            Ok(Some(info))
+        }
+        None => {
+            log::info!(target: "vscodeee::updater", "No update available");
+            *state.pending.lock().await = None;
+            Ok(None)
+        }
+    }
+}
+
+/// Download and stage the pending update, streaming progress to the WebView.
+///
+/// The update is applied on next restart. Call [`updater_restart_and_update`]
+/// to persist the session and trigger the actual restart.
+#[tauri::command]
+pub async fn updater_download_and_install(
+    state: tauri::State<'_, UpdaterState>,
+    on_progress: Channel<DownloadProgress>,
+) -> Result<()> {
+    // Take ownership of the pending update (prevents double-download).
+    let update = {
+        let mut guard = state.pending.lock().await;
+        guard.take().ok_or(UpdateError::NoPendingUpdate)?
+    };
+
+    log::info!(target: "vscodeee::updater", "Starting download and install");
+
+    // Clone the channel handles for the two closures.
+    let ch_progress = on_progress.clone();
+    let ch_finished = on_progress.clone();
+
+    // Signal download start.
+    let _ = on_progress.send(DownloadProgress {
+        phase: DownloadPhase::Started,
+        downloaded_bytes: 0,
+        total_bytes: None,
+    });
+
+    update
+        .download_and_install(
+            {
+                let mut cumulative: u64 = 0;
+                move |chunk_length: usize, content_length: Option<u64>| {
+                    cumulative += chunk_length as u64;
+                    let _ = ch_progress.send(DownloadProgress {
+                        phase: DownloadPhase::Progress,
+                        downloaded_bytes: cumulative,
+                        total_bytes: content_length,
+                    });
+                }
+            },
+            move || {
+                let _ = ch_finished.send(DownloadProgress {
+                    phase: DownloadPhase::Finished,
+                    downloaded_bytes: 0,
+                    total_bytes: None,
+                });
+            },
+        )
+        .await
+        .map_err(|e| {
+            log::error!(target: "vscodeee::updater", "Download failed: {e}");
+            UpdateError::DownloadFailed(e.to_string())
+        })?;
+
+    log::info!(target: "vscodeee::updater", "Update downloaded and staged");
+    Ok(())
+}
+
+/// Persist session state and restart the application to apply the staged update.
+#[tauri::command]
+pub async fn updater_restart_and_update(
+    app: tauri::AppHandle,
+    window_manager: tauri::State<'_, std::sync::Arc<crate::window::manager::WindowManager>>,
+) -> Result<()> {
+    log::info!(target: "vscodeee::updater", "Restarting to apply update");
+
+    crate::window::events::save_session_snapshot(&window_manager).await;
+    tauri::process::restart(&app.env());
+
+    #[allow(unreachable_code)]
+    Ok(())
+}
+
+/// Return the currently running application version.
+#[tauri::command]
+pub fn updater_get_current_version(app: tauri::AppHandle) -> String {
+    app.config().version.clone().unwrap_or_default()
+}

--- a/src-tauri/src/commands/updater/error.rs
+++ b/src-tauri/src/commands/updater/error.rs
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) VS Codeee Contributors. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+//! Typed error enum for updater commands.
+
+use serde::Serialize;
+
+/// Unified error type for updater commands.
+///
+/// All variants serialize to a plain string for the Tauri IPC boundary,
+/// matching the pattern established by [`NativeHostError`].
+///
+/// [`NativeHostError`]: crate::commands::native_host::error::NativeHostError
+#[derive(Debug, thiserror::Error)]
+pub enum UpdateError {
+    #[error("Updater not available: {0}")]
+    NotAvailable(String),
+
+    #[error("No pending update to download")]
+    NoPendingUpdate,
+
+    #[error("Update check failed: {0}")]
+    CheckFailed(String),
+
+    #[error("Download failed: {0}")]
+    DownloadFailed(String),
+
+    #[error("{0}")]
+    Other(String),
+}
+
+impl Serialize for UpdateError {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl From<tauri_plugin_updater::Error> for UpdateError {
+    fn from(e: tauri_plugin_updater::Error) -> Self {
+        UpdateError::CheckFailed(e.to_string())
+    }
+}

--- a/src-tauri/src/commands/updater/mod.rs
+++ b/src-tauri/src/commands/updater/mod.rs
@@ -1,0 +1,16 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) VS Codeee Contributors. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+//! Updater commands — check, download, install, and restart.
+//!
+//! Thin wrappers over [`tauri_plugin_updater`] that expose the update lifecycle
+//! to the WebView via typed IPC commands. TypeScript owns the state machine
+//! (the 11-state discriminated union in `platform/update/common/update.ts`);
+//! Rust provides the capability layer.
+
+pub mod commands;
+pub mod error;
+
+pub use commands::*;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -84,6 +84,7 @@ pub fn run() {
         .manage(Arc::clone(&channel_router))
         .manage(Arc::clone(&window_manager))
         .manage(Arc::clone(&pending_closes))
+        .manage(commands::updater::UpdaterState::new())
         .on_window_event(window::events::handle_window_event)
         .register_uri_scheme_protocol("vscode-file", move |ctx, request| {
             // On first call the state will have been initialized by setup().
@@ -168,6 +169,7 @@ pub fn run() {
             commands::native_host::windows_get_string_reg_key,
             // ── Lifecycle commands ──
             commands::native_host::notify_ready,
+            commands::native_host::is_dev_build,
             commands::native_host::close_window,
             commands::native_host::lifecycle_close_confirmed,
             commands::native_host::lifecycle_close_vetoed,
@@ -241,6 +243,11 @@ pub fn run() {
             commands::secret_storage::secret_get,
             commands::secret_storage::secret_set,
             commands::secret_storage::secret_delete,
+            // ── Updater commands ──
+            commands::updater::updater_check_for_updates,
+            commands::updater::updater_download_and_install,
+            commands::updater::updater_restart_and_update,
+            commands::updater::updater_get_current_version,
         ])
         .setup(move |app| {
             use tauri::Manager;

--- a/src/vs/platform/tauri/common/tauriApi.ts
+++ b/src/vs/platform/tauri/common/tauriApi.ts
@@ -68,3 +68,23 @@ export function emit(event: string, payload?: unknown): Promise<void> {
 export function listen<T>(event: string, handler: (event: { payload: T }) => void): Promise<UnlistenFn> {
 	return getTauriGlobal().event.listen<T>(event, handler);
 }
+
+/**
+ * Create a Tauri IPC Channel for streaming data from Rust to the WebView.
+ *
+ * Channels are passed as command arguments and allow Rust to call
+ * `channel.send(payload)` which dispatches to the `onmessage` callback.
+ *
+ * @param onmessage - Callback invoked for each message sent from Rust.
+ * @returns A Channel object that can be passed to `invoke()` args.
+ */
+export function createChannel<T>(onmessage: (message: T) => void): unknown {
+	const tauri = (globalThis as any).__TAURI__;
+	if (!tauri) {
+		throw new Error('Tauri API not available.');
+	}
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-call
+	const channel = new tauri.core.Channel();
+	channel.onmessage = onmessage;
+	return channel;
+}

--- a/src/vs/platform/update/common/update.config.contribution.ts
+++ b/src/vs/platform/update/common/update.config.contribution.ts
@@ -84,6 +84,13 @@ configurationRegistry.registerConfiguration({
 			scope: ConfigurationScope.APPLICATION,
 			description: localize('showPostInstallInfo', "Show update information tooltip in the title bar after a new version is installed."),
 			included: false,
+		},
+		'update.enabled': {
+			type: 'boolean',
+			default: false,
+			scope: ConfigurationScope.APPLICATION,
+			description: localize('updateEnabled', "Enable the auto-updater in development builds. Production builds always have the updater enabled regardless of this setting. Set to true to test update behavior during development."),
+			included: false,
 		}
 	}
 });

--- a/src/vs/workbench/services/update/tauri-browser/updateService.ts
+++ b/src/vs/workbench/services/update/tauri-browser/updateService.ts
@@ -1,0 +1,391 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) VS Codeee Contributors. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Event, Emitter } from '../../../../base/common/event.js';
+import { Disposable, MutableDisposable } from '../../../../base/common/lifecycle.js';
+import { IUpdateService, IUpdate, State, StateType, UpdateType, DisablementReason } from '../../../../platform/update/common/update.js';
+import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
+import { invoke, createChannel } from '../../../../platform/tauri/common/tauriApi.js';
+
+// ── Types matching the Rust `commands/updater/commands.rs` structs ─────────
+
+interface UpdateInfo {
+	version: string;
+	currentVersion: string;
+	date?: string;
+	body?: string;
+}
+
+interface DownloadProgress {
+	phase: 'started' | 'progress' | 'finished';
+	downloadedBytes: number;
+	totalBytes?: number;
+}
+
+// ── Service ────────────────────────────────────────────────────────────────
+
+/**
+ * Tauri-native implementation of [`IUpdateService`].
+ *
+ * TypeScript owns the 11-state discriminated-union state machine; Rust
+ * provides the capability layer (check / download / restart). This keeps
+ * `update.mode` configuration, periodic scheduling, and UI orchestration
+ * in the same layer that already houses VS Code's settings infrastructure.
+ *
+ * **Enable logic**:
+ * - Production builds (`!isDev`): updater is always enabled on startup.
+ * - Development builds (`isDev`): updater is gated by the `update.enabled`
+ *   boolean setting (default `false`). Set to `true` to test update behavior.
+ *
+ * Both environments respect `update.mode` (none/manual/start/default) once
+ * the updater is enabled.
+ */
+export class TauriUpdateService extends Disposable implements IUpdateService {
+
+	declare readonly _serviceBrand: undefined;
+
+	private _onStateChange = this._register(new Emitter<State>());
+	readonly onStateChange: Event<State> = this._onStateChange.event;
+
+	private _state: State = State.Disabled(DisablementReason.NotBuilt);
+	get state(): State { return this._state; }
+	set state(state: State) {
+		this._state = state;
+		this._onStateChange.fire(state);
+	}
+
+	private cachedUpdateInfo: UpdateInfo | undefined;
+	private periodicCheckTimer: ReturnType<typeof setTimeout> | undefined;
+	private readonly periodicCheckDisposable = this._register(new MutableDisposable());
+
+	constructor(
+		@IConfigurationService private readonly configurationService: IConfigurationService,
+		@ILogService private readonly logService: ILogService,
+	) {
+		super();
+
+		// Listen for configuration changes.
+		this._register(this.configurationService.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration('update.mode')) {
+				this.onModeChange();
+			}
+			if (e.affectsConfiguration('update.enabled')) {
+				this.onEnabledChange();
+			}
+		}));
+
+		// Async-initialize: determine dev/production, then decide enablement.
+		this.initializeUpdater();
+	}
+
+	/**
+	 * Determine whether the updater should be enabled, then start it.
+	 *
+	 * - Production builds: always enabled.
+	 * - Development builds: enabled only when `update.enabled` is `true`.
+	 */
+	private async initializeUpdater(): Promise<void> {
+		try {
+			const isDev = await invoke<boolean>('is_dev_build');
+			const enabled = isDev
+				? this.configurationService.getValue<boolean>('update.enabled')
+				: true;
+
+			if (!enabled) {
+				this.logService.info('Updater disabled (dev build, update.enabled=false).');
+				this.state = State.Disabled(DisablementReason.DisabledByEnvironment);
+				return;
+			}
+
+			this.logService.info(`Updater enabled (isDev=${isDev}).`);
+			this.initializeFromConfig();
+		} catch (err) {
+			this.logService.error(`Failed to initialize updater: ${String(err)}`);
+			this.state = State.Disabled(DisablementReason.NotBuilt);
+		}
+	}
+
+	/**
+	 * Read `update.mode` and set the initial state accordingly.
+	 * Called once at startup (if enabled) and again on `update.mode` changes.
+	 */
+	private initializeFromConfig(): void {
+		const mode = this.getUpdateMode();
+		if (mode === 'none') {
+			this.state = State.Disabled(DisablementReason.ManuallyDisabled);
+			return;
+		}
+		this.state = State.Idle(UpdateType.Archive);
+		if (mode === 'start' || mode === 'default') {
+			this.checkForUpdates(false);
+		}
+		if (mode === 'default') {
+			this.schedulePeriodicCheck();
+		}
+	}
+
+	/**
+	 * Respond to `update.enabled` setting changes in dev builds.
+	 * Toggling from false→true activates the updater; true→false disables it.
+	 */
+	private async onEnabledChange(): Promise<void> {
+		let isDev: boolean;
+		try {
+			isDev = await invoke<boolean>('is_dev_build');
+		} catch {
+			return;
+		}
+		if (!isDev) {
+			return; // Production builds ignore update.enabled.
+		}
+
+		const enabled = this.configurationService.getValue<boolean>('update.enabled');
+		if (enabled && this._state.type === StateType.Disabled) {
+			this.logService.info('update.enabled changed to true — activating updater.');
+			this.initializeFromConfig();
+		} else if (!enabled && this._state.type !== StateType.Disabled) {
+			this.logService.info('update.enabled changed to false — disabling updater.');
+			this.clearPeriodicCheck();
+			this.state = State.Disabled(DisablementReason.DisabledByEnvironment);
+		}
+	}
+
+	/**
+	 * Respond to `update.mode` configuration changes.
+	 *
+	 * - `none`: disables the updater and clears periodic checks.
+	 * - Transitioning from disabled to any other mode: re-enables and
+	 *   triggers an immediate check.
+	 * - `default`: enables periodic background checks (6-hour interval).
+	 * - Other modes: clears periodic checks but keeps the updater active.
+	 */
+	private onModeChange(): void {
+		const mode = this.getUpdateMode();
+
+		if (mode === 'none') {
+			this.state = State.Disabled(DisablementReason.ManuallyDisabled);
+			this.clearPeriodicCheck();
+			return;
+		}
+
+		// Re-enable from disabled state.
+		if (this._state.type === StateType.Disabled) {
+			this.state = State.Idle(UpdateType.Archive);
+			this.checkForUpdates(false);
+		}
+
+		if (mode === 'default') {
+			this.schedulePeriodicCheck();
+		} else {
+			this.clearPeriodicCheck();
+		}
+	}
+
+	// ── IUpdateService methods ──────────────────────────────────────────
+
+	/**
+	 * Check the configured endpoint for an available update.
+	 *
+	 * Transitions to {@link StateType.CheckingForUpdates}, then either
+	 * {@link StateType.AvailableForDownload} (if a newer version exists)
+	 * or back to {@link StateType.Idle}. No-op when the current state is
+	 * not {@link StateType.Idle}.
+	 *
+	 * @param explicit - `true` when the user manually triggered the check,
+	 *                   `false` for automatic/scheduled checks.
+	 */
+	async checkForUpdates(explicit: boolean): Promise<void> {
+		// Only Idle state allows a new check.
+		if (this._state.type !== StateType.Idle) {
+			return;
+		}
+
+		this.state = State.CheckingForUpdates(explicit);
+
+		try {
+			const update = await invoke<UpdateInfo | null>('updater_check_for_updates');
+
+			if (update) {
+				this.cachedUpdateInfo = update;
+				this.logService.info(`Update available: ${update.version}`);
+				this.state = State.AvailableForDownload(this.mapToUpdate(update));
+			} else {
+				this.state = State.Idle(UpdateType.Archive, undefined, explicit ? false : undefined);
+			}
+		} catch (err) {
+			this.logService.error(`Update check failed: ${String(err)}`);
+			this.state = State.Idle(UpdateType.Archive, String(err));
+		}
+	}
+
+	/**
+	 * Download and stage the pending update, streaming progress to the state machine.
+	 *
+	 * Opens a Tauri {@link Channel} to receive byte-level progress events from
+	 * Rust and translates each into a {@link StateType.Downloading} state update.
+	 * On success the update is staged and the state transitions to
+	 * {@link StateType.Ready}; on failure it rolls back to
+	 * {@link StateType.AvailableForDownload} so the user can retry.
+	 *
+	 * No-op unless the current state is {@link StateType.AvailableForDownload}
+	 * and a cached update info is available.
+	 *
+	 * @param explicit - `true` when the user explicitly requested the download.
+	 */
+	async downloadUpdate(explicit: boolean): Promise<void> {
+		if (!this.cachedUpdateInfo || this._state.type !== StateType.AvailableForDownload) {
+			return;
+		}
+
+		const update = this.mapToUpdate(this.cachedUpdateInfo);
+		const startTime = Date.now();
+
+		this.state = State.Downloading(update, explicit, false, 0, undefined, startTime);
+
+		const channel = createChannel<DownloadProgress>((progress: DownloadProgress) => {
+			if (this._state.type !== StateType.Downloading) {
+				return;
+			}
+			this.state = State.Downloading(
+				this._state.update,
+				this._state.explicit,
+				this._state.overwrite,
+				progress.phase === 'finished' ? this._state.downloadedBytes : progress.downloadedBytes,
+				progress.totalBytes,
+				this._state.startTime,
+			);
+		});
+
+		try {
+			await invoke('updater_download_and_install', { onProgress: channel });
+			// Tauri updater stages the update; restart applies it.
+			this.state = State.Ready(update, explicit, false);
+		} catch (err) {
+			this.logService.error(`Update download failed: ${String(err)}`);
+			// Go back to AvailableForDownload so the user can retry.
+			this.state = State.AvailableForDownload(update);
+		}
+	}
+
+	/**
+	 * Transition from {@link StateType.Downloaded} to {@link StateType.Ready}.
+	 *
+	 * In the Tauri updater flow the download and install steps are combined
+	 * (`download_and_install` stages the update automatically), so this method
+	 * only advances the state machine. No-op unless the current state is
+	 * {@link StateType.Downloaded}.
+	 */
+	async applyUpdate(): Promise<void> {
+		// Tauri updater combines download + install; the update is already
+		// staged after downloadAndInstall. Transition directly to Ready.
+		if (this._state.type === StateType.Downloaded) {
+			this.state = State.Ready(this._state.update, this._state.explicit, this._state.overwrite);
+		}
+	}
+
+	/**
+	 * Persist the current session and restart the application to apply the staged update.
+	 *
+	 * Transitions to {@link StateType.Restarting}, then invokes the Rust
+	 * `updater_restart_and_update` command. On failure, rolls back to
+	 * {@link StateType.Ready} so the user can retry.
+	 */
+	async quitAndInstall(): Promise<void> {
+		if (!this.cachedUpdateInfo) {
+			return;
+		}
+
+		this.state = State.Restarting(this.mapToUpdate(this.cachedUpdateInfo));
+
+		try {
+			await invoke('updater_restart_and_update');
+		} catch (err) {
+			this.logService.error(`Restart for update failed: ${String(err)}`);
+			// Go back to Ready so the user can try again.
+			this.state = State.Ready(this.mapToUpdate(this.cachedUpdateInfo), true, false);
+		}
+	}
+
+	/**
+	 * Check whether the running version is the latest available.
+	 *
+	 * @returns `true` when no update is available, `false` when an update
+	 *          exists, or `undefined` when the updater is disabled or the
+	 *          check fails.
+	 */
+	async isLatestVersion(): Promise<boolean | undefined> {
+		if (this._state.type === StateType.Disabled) {
+			return undefined;
+		}
+
+		try {
+			const update = await invoke<UpdateInfo | null>('updater_check_for_updates');
+			this.cachedUpdateInfo = update ?? undefined;
+			return update === null;
+		} catch {
+			return undefined;
+		}
+	}
+
+	/**
+	 * Not applicable in Tauri — updates are fetched from the configured endpoint,
+	 * not from a local package path.
+	 */
+	async _applySpecificUpdate(_packagePath: string): Promise<void> {
+		// Not applicable in Tauri — updates come from the configured endpoint.
+	}
+
+	/** Not applicable in Tauri. */
+	async setInternalOrg(_internalOrg: string | undefined): Promise<void> {
+		// Not applicable in Tauri.
+	}
+
+	// ── Helpers ─────────────────────────────────────────────────────────
+
+	/** Read the current `update.mode` configuration value. */
+	private getUpdateMode(): 'none' | 'manual' | 'start' | 'default' {
+		return this.configurationService.getValue<'none' | 'manual' | 'start' | 'default'>('update.mode');
+	}
+
+	/** Map the Rust `UpdateInfo` struct to the platform-level {@link IUpdate} interface. */
+	private mapToUpdate(info: UpdateInfo): IUpdate {
+		return {
+			version: info.version,
+			productVersion: info.version,
+		};
+	}
+
+	/**
+	 * Schedule automatic update checks on a 6-hour interval.
+	 *
+	 * Each tick verifies that `update.mode` is still `default` before
+	 * checking, and re-schedules itself. The timer is tracked via
+	 * {@link periodicCheckDisposable} for cleanup on dispose.
+	 */
+	private schedulePeriodicCheck(): void {
+		this.clearPeriodicCheck();
+		const CHECK_INTERVAL = 6 * 60 * 60 * 1000; // 6 hours
+
+		const check = async () => {
+			if (this.getUpdateMode() === 'default') {
+				await this.checkForUpdates(false);
+			}
+			this.periodicCheckTimer = setTimeout(check, CHECK_INTERVAL);
+		};
+
+		this.periodicCheckTimer = setTimeout(check, CHECK_INTERVAL);
+		this.periodicCheckDisposable.value = { dispose: () => this.clearPeriodicCheck() };
+	}
+
+	/** Clear the periodic check timer, if one is active. */
+	private clearPeriodicCheck(): void {
+		clearTimeout(this.periodicCheckTimer);
+		this.periodicCheckTimer = undefined;
+	}
+}
+
+registerSingleton(IUpdateService, TauriUpdateService, InstantiationType.Eager);

--- a/src/vs/workbench/workbench.tauri.main.ts
+++ b/src/vs/workbench/workbench.tauri.main.ts
@@ -67,7 +67,7 @@ import './services/mcp/browser/mcpWorkbenchManagementService.js';
 import './services/extensionManagement/browser/extensionGalleryManifestService.js';
 import './services/telemetry/browser/telemetryService.js';
 import './services/url/browser/urlService.js';
-import './services/update/browser/updateService.js';
+import './services/update/tauri-browser/updateService.js';
 import './services/workspaces/browser/workspacesService.js';
 import './services/workspaces/browser/workspaceEditingService.js';
 import './services/dialogs/tauri-browser/fileDialogService.js';


### PR DESCRIPTION
## Summary
- Replace no-op `BrowserUpdateService` with `TauriUpdateService` using `tauri-plugin-updater` for checking, downloading, and installing updates (#21)
- Add 4 Rust commands (`updater_check_for_updates`, `updater_download_and_install`, `updater_restart_and_update`, `updater_get_current_version`) and `is_dev_build` for dev/production detection
- Implement TypeScript 11-state machine (`IUpdateService`) with `update.mode` configuration support (none/manual/start/default) and 6-hour periodic checks
- Production builds: updater always enabled; dev builds: gated by `update.enabled` boolean setting (default false, hidden from Settings UI)
- Add `createChannel<T>()` helper to `tauriApi.ts` for streaming download progress

## Test plan
- [ ] Verify dev build starts with updater disabled (`update.enabled` defaults to false)
- [ ] Set `update.enabled: true` in `settings.json` and verify updater activates
- [ ] Verify `update.mode` setting transitions (none → disabled, manual → idle, start → auto-check, default → periodic 6h)
- [ ] Release 0.1.0, run locally at 0.0.1 with `update.enabled: true`, verify update detection
- [ ] Verify `update.enabled` config changes at runtime toggle updater on/off in dev builds

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)