### PR TITLE
fix: use UpdaterState::default() instead of missing new()

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -84,7 +84,7 @@ pub fn run() {
         .manage(Arc::clone(&channel_router))
         .manage(Arc::clone(&window_manager))
         .manage(Arc::clone(&pending_closes))
-        .manage(commands::updater::UpdaterState::new())
+        .manage(commands::updater::UpdaterState::default())
         .on_window_event(window::events::handle_window_event)
         .register_uri_scheme_protocol("vscode-file", move |ctx, request| {
             // On first call the state will have been initialized by setup().


### PR DESCRIPTION
## Summary
- Fix compile error caused by calling `UpdaterState::new()` which doesn't exist — `UpdaterState` only derives `Default` with no custom constructor
- This regression was introduced by the merge of #145 (update-service feature)

## Test plan
- [ ] Verify `npm run tauri:dev` compiles successfully
- [ ] Verify updater commands still work as expected

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)