### PR TITLE
feat: register missing native desktop commands for Tauri

### DIFF
--- a/src/vs/workbench/tauri-browser/actions/nativeActions.ts
+++ b/src/vs/workbench/tauri-browser/actions/nativeActions.ts
@@ -1,0 +1,245 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) VS Codeee Contributors. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { localize2 } from '../../../nls.js';
+import { Action2, MenuId, registerAction2 } from '../../../platform/actions/common/actions.js';
+import { Categories } from '../../../platform/action/common/actionCommonCategories.js';
+import { KeybindingWeight } from '../../../platform/keybinding/common/keybindingsRegistry.js';
+import { KeyCode, KeyMod } from '../../../base/common/keyCodes.js';
+import { INativeHostService } from '../../../platform/native/common/native.js';
+import { ServicesAccessor } from '../../../platform/instantiation/common/instantiation.js';
+import { IConfigurationService } from '../../../platform/configuration/common/configuration.js';
+
+// #region Quit
+
+/** Quits the application, triggering the Rust-side close handshake for async veto support. */
+class QuitAction extends Action2 {
+	constructor() {
+		super({
+			id: 'workbench.action.quit',
+			title: localize2('quit', "Quit"),
+			category: Categories.File,
+			f1: true,
+			keybinding: {
+				weight: KeybindingWeight.WorkbenchContrib + 1,
+				primary: KeyMod.CtrlCmd | KeyCode.KeyQ
+			},
+			menu: {
+				id: MenuId.MenubarFileMenu,
+				group: 'z_Quit',
+				order: 1
+			}
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const nativeHostService = accessor.get(INativeHostService);
+
+		// Calling quit() triggers the Rust-side close handshake
+		// which goes through TauriLifecycleService.handleCloseRequested()
+		// for async veto support (dirty file save dialogs, etc.).
+		await nativeHostService.quit();
+	}
+}
+
+registerAction2(QuitAction);
+
+// #endregion
+
+// #region Close Window
+
+/** Closes the current window via the Tauri backend. */
+class CloseWindowAction extends Action2 {
+	constructor() {
+		super({
+			id: 'workbench.action.closeWindow',
+			title: localize2('closeWindow', "Close Window"),
+			category: Categories.View,
+			f1: true,
+			keybinding: {
+				weight: KeybindingWeight.WorkbenchContrib,
+				primary: KeyMod.CtrlCmd | KeyCode.KeyW
+			}
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const nativeHostService = accessor.get(INativeHostService);
+		await nativeHostService.closeWindow();
+	}
+}
+
+registerAction2(CloseWindowAction);
+
+// #endregion
+
+// #region Window Management
+
+/** Minimizes the current window. */
+class MinimizeWindowAction extends Action2 {
+	constructor() {
+		super({
+			id: 'workbench.action.minimizeWindow',
+			title: localize2('minimizeWindow', "Minimize Window"),
+			category: Categories.View,
+			f1: true
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const nativeHostService = accessor.get(INativeHostService);
+		await nativeHostService.minimizeWindow();
+	}
+}
+
+registerAction2(MinimizeWindowAction);
+
+/** Maximizes the current window. */
+class MaximizeWindowAction extends Action2 {
+	constructor() {
+		super({
+			id: 'workbench.action.maximizeWindow',
+			title: localize2('maximizeWindow', "Maximize Window"),
+			category: Categories.View,
+			f1: true
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const nativeHostService = accessor.get(INativeHostService);
+		await nativeHostService.maximizeWindow();
+	}
+}
+
+registerAction2(MaximizeWindowAction);
+
+/** Toggles the maximized state of the current window. */
+class ToggleMaximizedWindowAction extends Action2 {
+	constructor() {
+		super({
+			id: 'workbench.action.toggleMaximizedWindow',
+			title: localize2('toggleMaximizedWindow', "Toggle Maximized Window"),
+			category: Categories.View,
+			f1: true
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const nativeHostService = accessor.get(INativeHostService);
+		const maximized = await nativeHostService.isMaximized();
+		if (maximized) {
+			await nativeHostService.unmaximizeWindow();
+		} else {
+			await nativeHostService.maximizeWindow();
+		}
+	}
+}
+
+registerAction2(ToggleMaximizedWindowAction);
+
+// #endregion
+
+// #region Zoom
+
+/** Increases the workbench zoom level by 1. */
+class ZoomInAction extends Action2 {
+	constructor() {
+		super({
+			id: 'workbench.action.zoomIn',
+			title: localize2('zoomIn', "Zoom In"),
+			category: Categories.View,
+			f1: true,
+			keybinding: {
+				weight: KeybindingWeight.WorkbenchContrib,
+				primary: KeyMod.CtrlCmd | KeyCode.Equal
+			}
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const configurationService = accessor.get(IConfigurationService);
+		const currentZoom = configurationService.getValue<number>('window.zoomLevel') ?? 0;
+		await configurationService.updateValue('window.zoomLevel', currentZoom + 1);
+	}
+}
+
+registerAction2(ZoomInAction);
+
+/** Decreases the workbench zoom level by 1. */
+class ZoomOutAction extends Action2 {
+	constructor() {
+		super({
+			id: 'workbench.action.zoomOut',
+			title: localize2('zoomOut', "Zoom Out"),
+			category: Categories.View,
+			f1: true,
+			keybinding: {
+				weight: KeybindingWeight.WorkbenchContrib,
+				primary: KeyMod.CtrlCmd | KeyCode.Minus
+			}
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const configurationService = accessor.get(IConfigurationService);
+		const currentZoom = configurationService.getValue<number>('window.zoomLevel') ?? 0;
+		await configurationService.updateValue('window.zoomLevel', currentZoom - 1);
+	}
+}
+
+registerAction2(ZoomOutAction);
+
+/** Resets the workbench zoom level to the default (0). */
+class ZoomResetAction extends Action2 {
+	constructor() {
+		super({
+			id: 'workbench.action.zoomReset',
+			title: localize2('zoomReset', "Reset Zoom"),
+			category: Categories.View,
+			f1: true,
+			keybinding: {
+				weight: KeybindingWeight.WorkbenchContrib,
+				primary: KeyMod.CtrlCmd | KeyCode.Numpad0,
+				secondary: [KeyMod.CtrlCmd | KeyCode.Digit0]
+			}
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const configurationService = accessor.get(IConfigurationService);
+		await configurationService.updateValue('window.zoomLevel', 0);
+	}
+}
+
+registerAction2(ZoomResetAction);
+
+// #endregion
+
+// #region Relaunch
+
+/** Relaunches the application via the Tauri backend. */
+class RelaunchAction extends Action2 {
+	constructor() {
+		super({
+			id: 'workbench.action.relaunch',
+			title: localize2('relaunch', "Relaunch Application"),
+			category: Categories.View,
+			f1: true
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const nativeHostService = accessor.get(INativeHostService);
+		await nativeHostService.relaunch();
+	}
+}
+
+registerAction2(RelaunchAction);
+
+// #endregion
+
+// TODO(Phase 2): Add switchWindow action when multi-window support is stable
+// TODO(Phase 2): Add macOS window tab commands (newWindowTab, mergeAllTabs, etc.)
+// TODO(Phase 2): Integrate QuitAction with ShutdownReason.QUIT for correct dialog messages

--- a/src/vs/workbench/workbench.tauri.main.ts
+++ b/src/vs/workbench/workbench.tauri.main.ts
@@ -33,6 +33,7 @@ import './tauri-browser/desktop.tauri.main.js';
 //#region --- workbench actions (Tauri-specific)
 
 import './tauri-browser/actions/developerActions.js';
+import './tauri-browser/actions/nativeActions.js';
 
 //#endregion
 


### PR DESCRIPTION
## Summary

- Register 9 native desktop commands that were lost during the Electron→Tauri migration via new `nativeActions.ts` file
- **Quit** (`Cmd+Q`) — triggers Rust-side close handshake with async veto support (dirty file save dialogs)
- **Close Window** (`Cmd+W`) — closes the current window via Tauri backend
- **Window Management** — minimize, maximize, toggle maximized window
- **Zoom** — zoom in (`Cmd+=`), zoom out (`Cmd+-`), reset zoom (`Cmd+Numpad0/Digit0`)
- **Relaunch** — restarts the application

All commands delegate to `INativeHostService` methods which invoke the corresponding Tauri backend commands (`quit_app`, `close_window`, `minimize_window`, etc.).

## Test plan

- [ ] Verify Cmd+Q triggers application quit with dirty file confirmation dialog
- [ ] Verify Cmd+W closes the current window
- [ ] Verify minimize/maximize/toggle maximize commands work from command palette
- [ ] Verify zoom in/out/reset via keyboard shortcuts and command palette
- [ ] Verify relaunch command works from command palette
- [ ] Verify quit action appears in File menu
- [ ] Verify no regression in existing `workbench.action.toggleDevTools` command

🤖 Generated with [Claude Code](https://claude.com/claude-code)