### PR TITLE
fix: eliminate window stretching on restore

### DIFF
--- a/src-tauri/src/commands/native_host/lifecycle.rs
+++ b/src-tauri/src/commands/native_host/lifecycle.rs
@@ -12,21 +12,73 @@ use super::error::NativeHostError;
 // ─── Existing commands (moved from native_host.rs) ──────────────────────
 
 /// Notify the backend that the workbench has finished loading.
+///
+/// Validates the restored window geometry against the current display
+/// configuration (corrects off-screen positions), cancels the safety-net
+/// show timeout, marks the window as ready, and makes it visible.
+///
+/// # Parameters
+///
+/// * `window` - The Tauri window that is now ready.
+/// * `window_manager` - Shared window registry, used to mark the window as ready.
+/// * `pending_shows` - Safety-net tracker, cancelled so the timeout does not fire.
+///
+/// # Errors
+///
+/// Returns [`NativeHostError::Window`] if showing or focusing the window fails.
 #[tauri::command]
-pub fn notify_ready() {
-    log::info!(target: "vscodeee::commands::native_host", "Workbench notified ready");
+pub async fn notify_ready(
+    window: tauri::Window,
+    window_manager: tauri::State<'_, std::sync::Arc<crate::window::manager::WindowManager>>,
+    pending_shows: tauri::State<'_, std::sync::Arc<crate::window::events::PendingShows>>,
+) -> Result<(), NativeHostError> {
+    let label = window.label().to_string();
+    log::info!(target: "vscodeee::commands::native_host", "Workbench notified ready for window '{label}'");
+
+    // Cancel the safety-net timeout
+    pending_shows.cancel(&label);
+
+    // Validate geometry before showing — corrects off-screen positions
+    // when the display configuration changed since last session.
+    crate::window::restore_geometry::ensure_on_screen(&window);
+
+    // Mark as ready in the window manager
+    window_manager.set_ready(&label).await;
+
+    // Show and focus the window
+    window
+        .show()
+        .map_err(|e| NativeHostError::Window(e.to_string()))?;
+    window
+        .set_focus()
+        .map_err(|e| NativeHostError::Window(e.to_string()))?;
+
+    Ok(())
 }
 
 /// Return whether the app was compiled in debug (development) mode.
 ///
 /// Used by the TypeScript updater service to decide whether the
 /// `update.enabled` dev-flag is required.
+///
+/// # Returns
+///
+/// `true` if the binary was compiled with `debug_assertions` enabled
+/// (i.e., `cargo build` without `--release`), `false` otherwise.
 #[tauri::command]
 pub fn is_dev_build() -> bool {
     cfg!(debug_assertions)
 }
 
 /// Close the current window.
+///
+/// # Parameters
+///
+/// * `window` - The Tauri window to close.
+///
+/// # Errors
+///
+/// Returns [`NativeHostError::Window`] if the window close operation fails.
 #[tauri::command]
 pub fn close_window(window: tauri::Window) -> Result<(), NativeHostError> {
     window
@@ -35,6 +87,19 @@ pub fn close_window(window: tauri::Window) -> Result<(), NativeHostError> {
 }
 
 /// Confirm window close after the TypeScript lifecycle handshake completes.
+///
+/// Saves the session snapshot, unregisters the window from the manager,
+/// cancels the safety-net close timeout, and destroys the window.
+///
+/// # Parameters
+///
+/// * `window` - The Tauri window to close.
+/// * `window_manager` - Shared window registry, used to save the session and unregister.
+/// * `pending_closes` - Safety-net tracker, cancelled so the timeout does not force-destroy.
+///
+/// # Errors
+///
+/// Returns [`NativeHostError::Window`] if destroying the window fails.
 #[tauri::command]
 pub async fn lifecycle_close_confirmed(
     window: tauri::Window,
@@ -55,6 +120,13 @@ pub async fn lifecycle_close_confirmed(
 }
 
 /// Signal that a window close was vetoed by the TypeScript layer.
+///
+/// Cancels the safety-net close timeout so the window is not force-destroyed.
+///
+/// # Parameters
+///
+/// * `window` - The Tauri window whose close was vetoed.
+/// * `pending_closes` - Safety-net tracker, cancelled to prevent force-destroy.
 #[tauri::command]
 pub fn lifecycle_close_vetoed(
     window: tauri::Window,
@@ -67,13 +139,21 @@ pub fn lifecycle_close_vetoed(
     Ok(())
 }
 
-/// Quit the application gracefully, saving the session first.
-#[tauri::command]
-pub async fn quit_app(
-    app: tauri::AppHandle,
-    window_manager: tauri::State<'_, std::sync::Arc<crate::window::manager::WindowManager>>,
-) -> Result<(), NativeHostError> {
-    crate::window::events::save_session_snapshot(&window_manager).await;
+/// Save session and run shutdown cleanup before exiting.
+///
+/// Persists the current session to disk and triggers the `ShutdownCoordinator`
+/// to kill all registered child processes (extension hosts, PTY instances,
+/// file watchers) in the correct order.
+///
+/// # Parameters
+///
+/// * `app` - The Tauri app handle, used to access managed state.
+/// * `window_manager` - Shared window registry, used to create the session snapshot.
+async fn save_and_shutdown(
+    app: &tauri::AppHandle,
+    window_manager: &tauri::State<'_, std::sync::Arc<crate::window::manager::WindowManager>>,
+) {
+    crate::window::events::save_session_snapshot(window_manager).await;
 
     // Run shutdown cleanup before exiting — kills all child processes.
     if let Some(coordinator) =
@@ -81,32 +161,47 @@ pub async fn quit_app(
     {
         coordinator.shutdown_all();
     }
+}
 
+/// Quit the application gracefully, saving the session first.
+///
+/// # Parameters
+///
+/// * `app` - The Tauri app handle, used to exit the process.
+/// * `window_manager` - Shared window registry, used to save the session.
+#[tauri::command]
+pub async fn quit_app(
+    app: tauri::AppHandle,
+    window_manager: tauri::State<'_, std::sync::Arc<crate::window::manager::WindowManager>>,
+) -> Result<(), NativeHostError> {
+    save_and_shutdown(&app, &window_manager).await;
     app.exit(0);
     Ok(())
 }
 
 /// Exit the application with a specific code, saving the session first.
+///
+/// # Parameters
+///
+/// * `app` - The Tauri app handle, used to exit the process.
+/// * `code` - The exit code to return to the OS.
+/// * `window_manager` - Shared window registry, used to save the session.
 #[tauri::command]
 pub async fn exit_app(
     app: tauri::AppHandle,
     code: i32,
     window_manager: tauri::State<'_, std::sync::Arc<crate::window::manager::WindowManager>>,
 ) -> Result<(), NativeHostError> {
-    crate::window::events::save_session_snapshot(&window_manager).await;
-
-    // Run shutdown cleanup before exiting — kills all child processes.
-    if let Some(coordinator) =
-        app.try_state::<std::sync::Arc<crate::shutdown::ShutdownCoordinator>>()
-    {
-        coordinator.shutdown_all();
-    }
-
+    save_and_shutdown(&app, &window_manager).await;
     app.exit(code);
     Ok(())
 }
 
 /// Explicitly save the current session (all windows + workspaces) to disk.
+///
+/// # Parameters
+///
+/// * `window_manager` - Shared window registry, used to create the session snapshot.
 #[tauri::command]
 pub async fn save_session(
     window_manager: tauri::State<'_, std::sync::Arc<crate::window::manager::WindowManager>>,
@@ -116,6 +211,14 @@ pub async fn save_session(
 }
 
 /// Relaunch the application.
+///
+/// Uses `tauri::process::restart` to spawn a new process and exit the
+/// current one. The session is not explicitly saved — callers should
+/// invoke `save_session` or `quit_app` beforehand if persistence is needed.
+///
+/// # Parameters
+///
+/// * `app` - The Tauri app handle, providing the environment for restart.
 #[tauri::command]
 pub fn relaunch_app(app: tauri::AppHandle) -> Result<(), NativeHostError> {
     tauri::process::restart(&app.env());

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -65,33 +65,36 @@ pub fn run() {
     // Lifecycle — tracks pending close handshakes for safety-net timeouts
     let pending_closes = Arc::new(window::events::PendingCloses::new());
 
+    // Ready-to-show — tracks pending show handshakes so hidden windows
+    // are shown automatically if the TypeScript bootstrap crashes.
+    let pending_shows = Arc::new(window::events::PendingShows::new());
+
     tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_os::init())
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_clipboard_manager::init())
-        .plugin(tauri_plugin_window_state::Builder::default().build())
+        .plugin(
+            tauri_plugin_window_state::Builder::default()
+                .with_state_flags(
+                    tauri_plugin_window_state::StateFlags::all()
+                        - tauri_plugin_window_state::StateFlags::VISIBLE,
+                )
+                .build(),
+        )
         .plugin(tauri_plugin_deep_link::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(logging::build_plugin().build())
-        .manage({
-            let mgr = pty::manager::PtyManager::new();
-            // Initialize terminal state store with app data directory
-            // Note: The actual app_data_dir is only available inside setup(),
-            // so we initialize the store there. Here we just create the manager.
-            mgr
-        })
+        .manage(pty::manager::PtyManager::new())
         .manage(commands::file_watcher::FileWatcherState::new())
         .manage(commands::spawn_exthost::ExtHostState::new())
         .manage(Arc::clone(&channel_router))
         .manage(Arc::clone(&window_manager))
         .manage(Arc::clone(&pending_closes))
+        .manage(Arc::clone(&pending_shows))
         .manage(commands::updater::UpdaterState::default())
-        .manage({
-            let coordinator = shutdown::ShutdownCoordinator::new();
-            coordinator
-        })
+        .manage(shutdown::ShutdownCoordinator::new())
         .on_window_event(window::events::handle_window_event)
         .register_uri_scheme_protocol("vscode-file", move |ctx, request| {
             // On first call the state will have been initialized by setup().
@@ -405,7 +408,7 @@ pub fn run() {
                         .clone()
                         .or_else(|| entry.workspace_uri.clone());
                     if workspace.is_some() {
-                        wm.set_workspace("main", workspace).await;
+                        wm.set_workspace_uri("main", workspace).await;
                     }
                     if entry.is_fullscreen {
                         wm.set_fullscreen("main", true).await;
@@ -417,6 +420,16 @@ pub fn run() {
                     "Registered initial window: id={id}"
                 );
             });
+
+            // Register ready-to-show safety timeout for the main window.
+            // If the TypeScript bootstrap never calls `notify_ready`, the
+            // window is shown after 30 seconds to avoid a permanently
+            // invisible application.
+            {
+                let ps = app.state::<Arc<window::events::PendingShows>>();
+                let handle = app.handle().clone();
+                ps.spawn_safety_timeout(&handle, "main");
+            }
 
             // Apply fullscreen to the main window if restored
             if let Some(ref entry) = first_entry {
@@ -453,6 +466,10 @@ pub fn run() {
                                     entry.label,
                                     entry.folder_uri
                                 );
+
+                                // Register ready-to-show safety timeout
+                                let ps = handle.state::<Arc<window::events::PendingShows>>();
+                                ps.spawn_safety_timeout(&handle, &entry.label);
                             }
                             Err(e) => {
                                 log::error!(

--- a/src-tauri/src/window/events.rs
+++ b/src-tauri/src/window/events.rs
@@ -64,6 +64,90 @@ impl PendingCloses {
 /// If TS does not respond within this duration, the window is force-destroyed.
 const CLOSE_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// Safety-net timeout for the ready-to-show handshake.
+/// If the TypeScript layer does not call `notify_ready` within this duration,
+/// the window is shown automatically to prevent a permanently invisible app.
+const SHOW_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Tracks pending ready-to-show handshakes per window.
+///
+/// Each window starts hidden (`visible: false`). When the TypeScript workbench
+/// calls `notify_ready`, the pending show is cancelled. If TS never responds
+/// (crash/hang), the safety-net timeout shows the window anyway.
+pub struct PendingShows {
+    inner: Mutex<HashMap<String, oneshot::Sender<()>>>,
+}
+
+impl PendingShows {
+    /// Creates a new empty `PendingShows` tracker.
+    pub fn new() -> Self {
+        Self {
+            inner: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Register a pending show for the given window label.
+    /// Returns the receiver that the safety timeout task should await.
+    pub fn register(&self, label: &str) -> oneshot::Receiver<()> {
+        let (tx, rx) = oneshot::channel();
+        let mut map = self.inner.lock().unwrap();
+        // If a previous pending show exists for this label, the old sender
+        // is dropped which cancels the old timeout.
+        map.insert(label.to_string(), tx);
+        rx
+    }
+
+    /// Cancel a pending show for the given window label.
+    /// Called when the TypeScript layer invokes `notify_ready`.
+    pub fn cancel(&self, label: &str) -> bool {
+        let mut map = self.inner.lock().unwrap();
+        if let Some(tx) = map.remove(label) {
+            let _ = tx.send(());
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Spawn a safety timeout task for the given window.
+    ///
+    /// If `notify_ready` is not called within `SHOW_TIMEOUT`, the window
+    /// is shown automatically. Before showing, the window geometry is
+    /// validated against the current display configuration via
+    /// [`restore_geometry::ensure_on_screen`] to handle cases where the
+    /// restored position is off-screen.
+    ///
+    /// # Parameters
+    ///
+    /// * `app_handle` - The Tauri app handle, used to look up the window by label.
+    /// * `label` - The Tauri window label (e.g. `"main"`, `"main_2"`).
+    pub fn spawn_safety_timeout(&self, app_handle: &tauri::AppHandle, label: &str) {
+        use tauri::Manager;
+        let cancel_rx = self.register(label);
+        let label = label.to_string();
+        let handle = app_handle.clone();
+
+        tauri::async_runtime::spawn(async move {
+            tokio::select! {
+                _ = cancel_rx => {
+                    // TS called notify_ready — nothing to do.
+                }
+                _ = tokio::time::sleep(SHOW_TIMEOUT) => {
+                    log::warn!(
+                        "Ready-to-show timed out for window '{label}' after {}s — showing anyway",
+                        SHOW_TIMEOUT.as_secs()
+                    );
+                    if let Some(ww) = handle.get_webview_window(&label) {
+                        crate::window::restore_geometry::ensure_on_screen(&ww.as_ref().window());
+                        let _ = ww.show();
+                        let _ = ww.set_focus();
+                    }
+                }
+            }
+        });
+    }
+}
+
 /// Payload for the unified fullscreen change event.
 ///
 /// Emitted on the `vscodeee:window:fullscreen` channel whenever a window
@@ -106,6 +190,26 @@ pub mod event_names {
     /// The TypeScript `TauriLifecycleService` handles veto logic and responds
     /// with either `lifecycle_close_confirmed` or `lifecycle_close_vetoed`.
     pub const LIFECYCLE_CLOSE_REQUESTED: &str = "vscodeee:lifecycle:close-requested";
+}
+
+/// Emit a state-change event to both the specific window and globally when a
+/// boolean property transitions between `current` and `previous`.
+fn emit_state_change(
+    handle: &tauri::AppHandle,
+    label: &str,
+    window_id: u32,
+    current: bool,
+    previous: bool,
+    enter_event: &str,
+    leave_event: &str,
+) {
+    if current && !previous {
+        let _ = handle.emit_to(label, enter_event, window_id);
+        let _ = handle.emit(enter_event, window_id);
+    } else if !current && previous {
+        let _ = handle.emit_to(label, leave_event, window_id);
+        let _ = handle.emit(leave_event, window_id);
+    }
 }
 
 /// Handle a single window event — called from `Builder::on_window_event()`.
@@ -209,31 +313,28 @@ pub fn handle_window_event(window: &tauri::Window, event: &tauri::WindowEvent) {
                 wm.set_fullscreen(&label_c, is_fullscreen).await;
 
                 if let Some(id) = wm.id_for_label(&label_c).await {
-                    if is_maximized && !was_maximized {
-                        let _ = handle_c.emit_to(&label_c, event_names::WINDOW_MAXIMIZE, id);
-                        let _ = handle_c.emit(event_names::WINDOW_MAXIMIZE, id);
-                    } else if !is_maximized && was_maximized {
-                        let _ = handle_c.emit_to(&label_c, event_names::WINDOW_UNMAXIMIZE, id);
-                        let _ = handle_c.emit(event_names::WINDOW_UNMAXIMIZE, id);
-                    }
+                    emit_state_change(
+                        &handle_c,
+                        &label_c,
+                        id,
+                        is_maximized,
+                        was_maximized,
+                        event_names::WINDOW_MAXIMIZE,
+                        event_names::WINDOW_UNMAXIMIZE,
+                    );
 
-                    if is_fullscreen && !was_fullscreen {
+                    if is_fullscreen != was_fullscreen {
+                        let (specific_event, fullscreen) = if is_fullscreen {
+                            (event_names::WINDOW_ENTER_FULLSCREEN, true)
+                        } else {
+                            (event_names::WINDOW_LEAVE_FULLSCREEN, false)
+                        };
                         let payload = FullscreenPayload {
                             window_id: id,
-                            fullscreen: true,
+                            fullscreen,
                         };
-                        let _ =
-                            handle_c.emit_to(&label_c, event_names::WINDOW_ENTER_FULLSCREEN, id);
-                        let _ = handle_c.emit(event_names::WINDOW_ENTER_FULLSCREEN, id);
-                        let _ = handle_c.emit(event_names::WINDOW_FULLSCREEN, payload);
-                    } else if !is_fullscreen && was_fullscreen {
-                        let payload = FullscreenPayload {
-                            window_id: id,
-                            fullscreen: false,
-                        };
-                        let _ =
-                            handle_c.emit_to(&label_c, event_names::WINDOW_LEAVE_FULLSCREEN, id);
-                        let _ = handle_c.emit(event_names::WINDOW_LEAVE_FULLSCREEN, id);
+                        let _ = handle_c.emit_to(&label_c, specific_event, id);
+                        let _ = handle_c.emit(specific_event, id);
                         let _ = handle_c.emit(event_names::WINDOW_FULLSCREEN, payload);
                     }
                 }

--- a/src-tauri/src/window/manager.rs
+++ b/src-tauri/src/window/manager.rs
@@ -106,24 +106,11 @@ impl WindowManager {
         let id = self.next_id.fetch_add(1, Ordering::Relaxed);
         let label = format!("main_{id}");
 
-        // Build URL with optional query params
-        let mut url_str = String::from("vs/code/tauri-browser/workbench/workbench-tauri.html");
-        let mut has_param = false;
-        if let Some(ref folder) = options.folder_uri {
-            url_str.push_str("?folder=");
-            url_str.push_str(&encode_uri_component(folder));
-            has_param = true;
-        } else if let Some(ref workspace) = options.workspace_uri {
-            url_str.push_str("?workspace=");
-            url_str.push_str(&encode_uri_component(workspace));
-            has_param = true;
-        }
-        // Always pass the window label so the new window can resolve its ID
-        let separator = if has_param { '&' } else { '?' };
-        url_str.push(separator);
-        url_str.push_str("windowLabel=");
-        url_str.push_str(&label);
-
+        let url_str = build_workbench_url(
+            options.folder_uri.as_deref(),
+            options.workspace_uri.as_deref(),
+            &label,
+        );
         let url = WebviewUrl::App(url_str.into());
 
         // macOS: use overlay title bar to keep native traffic lights
@@ -133,6 +120,7 @@ impl WindowManager {
             .inner_size(1200.0, 800.0)
             .min_inner_size(400.0, 270.0)
             .decorations(false)
+            .visible(false)
             .title_bar_style(tauri::TitleBarStyle::Overlay)
             .hidden_title(true);
 
@@ -141,7 +129,8 @@ impl WindowManager {
             .title("VS Codeee")
             .inner_size(1200.0, 800.0)
             .min_inner_size(400.0, 270.0)
-            .decorations(false);
+            .decorations(false)
+            .visible(false);
 
         builder
             .build()
@@ -294,15 +283,6 @@ impl WindowManager {
         }
     }
 
-    /// Set the workspace URI for a window.
-    pub async fn set_workspace(&self, label: &str, workspace_uri: Option<String>) {
-        if let Some(id) = self.id_for_label(label).await {
-            if let Some(info) = self.windows.write().await.get_mut(&id) {
-                info.workspace_uri = workspace_uri;
-            }
-        }
-    }
-
     /// Consume the restored workspace URI for a window.
     ///
     /// Returns the workspace URI on the first call after app start, then marks
@@ -361,25 +341,7 @@ impl WindowManager {
 
         let id = self.next_id.fetch_add(1, Ordering::Relaxed);
 
-        // Build URL with workspace/folder query params
-        let mut url_str = String::from("vs/code/tauri-browser/workbench/workbench-tauri.html");
-        let mut has_param = false;
-
-        if let Some(folder) = folder_uri {
-            url_str.push_str("?folder=");
-            url_str.push_str(&encode_uri_component(folder));
-            has_param = true;
-        } else if let Some(workspace) = workspace_uri {
-            url_str.push_str("?workspace=");
-            url_str.push_str(&encode_uri_component(workspace));
-            has_param = true;
-        }
-
-        let separator = if has_param { '&' } else { '?' };
-        url_str.push(separator);
-        url_str.push_str("windowLabel=");
-        url_str.push_str(label);
-
+        let url_str = build_workbench_url(folder_uri, workspace_uri, label);
         let url = WebviewUrl::App(url_str.into());
 
         #[cfg(target_os = "macos")]
@@ -388,6 +350,7 @@ impl WindowManager {
             .inner_size(1200.0, 800.0)
             .min_inner_size(400.0, 270.0)
             .decorations(false)
+            .visible(false)
             .title_bar_style(tauri::TitleBarStyle::Overlay)
             .hidden_title(true)
             .fullscreen(is_fullscreen);
@@ -398,6 +361,7 @@ impl WindowManager {
             .inner_size(1200.0, 800.0)
             .min_inner_size(400.0, 270.0)
             .decorations(false)
+            .visible(false)
             .fullscreen(is_fullscreen);
 
         builder
@@ -430,6 +394,34 @@ impl WindowManager {
 
         Ok(id)
     }
+}
+
+/// Build the workbench HTML URL with optional workspace/folder query params
+/// and the `windowLabel` query parameter.
+fn build_workbench_url(
+    folder_uri: Option<&str>,
+    workspace_uri: Option<&str>,
+    label: &str,
+) -> String {
+    let mut url = String::from("vs/code/tauri-browser/workbench/workbench-tauri.html");
+    let mut has_param = false;
+
+    if let Some(folder) = folder_uri {
+        url.push_str("?folder=");
+        url.push_str(&encode_uri_component(folder));
+        has_param = true;
+    } else if let Some(workspace) = workspace_uri {
+        url.push_str("?workspace=");
+        url.push_str(&encode_uri_component(workspace));
+        has_param = true;
+    }
+
+    let separator = if has_param { '&' } else { '?' };
+    url.push(separator);
+    url.push_str("windowLabel=");
+    url.push_str(label);
+
+    url
 }
 
 /// Minimal percent-encoding for URI query strings.

--- a/src-tauri/src/window/mod.rs
+++ b/src-tauri/src/window/mod.rs
@@ -12,6 +12,7 @@
 pub mod events;
 pub mod manager;
 pub mod restore;
+pub mod restore_geometry;
 pub mod session;
 pub mod settings;
 pub mod state;

--- a/src-tauri/src/window/restore_geometry.rs
+++ b/src-tauri/src/window/restore_geometry.rs
@@ -1,0 +1,109 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) VS Codeee Contributors. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+//! Off-screen window geometry validation.
+//!
+//! After `tauri-plugin-window-state` restores saved geometry, the window
+//! position may be invalid if the display configuration changed since the
+//! last session (e.g. external monitor disconnected). This module provides
+//! utilities to detect and correct such cases before the window is shown.
+
+use tauri::Manager;
+
+/// Check whether a logical (DPI-independent) position falls within at least
+/// one connected monitor.
+fn is_position_on_screen(app: &tauri::AppHandle, x: f64, y: f64) -> bool {
+    available_monitors(app).iter().any(|m| {
+        let pos = m.position();
+        let size = m.size();
+        let scale = m.scale_factor();
+        let mx = pos.x as f64 / scale;
+        let my = pos.y as f64 / scale;
+        let mw = size.width as f64 / scale;
+        let mh = size.height as f64 / scale;
+
+        x >= mx && x < mx + mw && y >= my && y < my + mh
+    })
+}
+
+/// Check whether a logical size fits within at least one connected monitor's
+/// resolution.
+fn fits_on_any_monitor(app: &tauri::AppHandle, width: f64, height: f64) -> bool {
+    available_monitors(app).iter().any(|m| {
+        let size = m.size();
+        let scale = m.scale_factor();
+        let mw = size.width as f64 / scale;
+        let mh = size.height as f64 / scale;
+
+        width <= mw && height <= mh
+    })
+}
+
+/// Returns the list of connected monitors, or an empty list when detection
+/// fails.
+fn available_monitors(app: &tauri::AppHandle) -> Vec<tauri::Monitor> {
+    app.available_monitors().unwrap_or_default()
+}
+
+/// Ensure a hidden window's geometry is valid before showing it.
+///
+/// If the restored position is off-screen (e.g. external monitor was
+/// disconnected), or the window size exceeds every connected monitor,
+/// reposition it centered on the primary monitor.
+pub fn ensure_on_screen(window: &tauri::Window) {
+    let app = window.app_handle().clone();
+    let scale = match window.scale_factor() {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+
+    let pos = match window.outer_position() {
+        Ok(p) => p,
+        Err(_) => return,
+    };
+
+    let size = match window.inner_size() {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+
+    let logical_x = pos.x as f64 / scale;
+    let logical_y = pos.y as f64 / scale;
+    let logical_w = size.width as f64 / scale;
+    let logical_h = size.height as f64 / scale;
+
+    if is_position_on_screen(&app, logical_x, logical_y)
+        && fits_on_any_monitor(&app, logical_w, logical_h)
+    {
+        return;
+    }
+
+    log::warn!(
+        target: "vscodeee::window::restore_geometry",
+        "Window '{}' is off-screen ({logical_x}, {logical_y}, {logical_w}x{logical_h}) — centering on primary monitor",
+        window.label()
+    );
+
+    // Center on the primary monitor
+    if let Some(primary) = app.primary_monitor().ok().flatten() {
+        let mon_pos = primary.position();
+        let mon_size = primary.size();
+        let mon_scale = primary.scale_factor();
+        let mx = mon_pos.x as f64 / mon_scale;
+        let my = mon_pos.y as f64 / mon_scale;
+        let mw = mon_size.width as f64 / mon_scale;
+        let mh = mon_size.height as f64 / mon_scale;
+
+        // Clamp size to monitor
+        let clamped_w = logical_w.min(mw * 0.9);
+        let clamped_h = logical_h.min(mh * 0.9);
+
+        let new_x = mx + (mw - clamped_w) / 2.0;
+        let new_y = my + (mh - clamped_h) / 2.0;
+
+        let _ = window.set_size(tauri::LogicalSize::new(clamped_w, clamped_h));
+        let _ = window.set_position(tauri::LogicalPosition::new(new_x, new_y));
+    }
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -22,6 +22,7 @@
         "minHeight": 270,
         "resizable": true,
         "fullscreen": false,
+        "visible": false,
         "decorations": true,
         "titleBarStyle": "Overlay",
         "hiddenTitle": true

--- a/src/vs/code/tauri-browser/workbench/workbench-tauri.ts
+++ b/src/vs/code/tauri-browser/workbench/workbench-tauri.ts
@@ -134,7 +134,14 @@
 	const windowConfig = await tauri.core.invoke<ITauriWindowConfig>('get_window_configuration');
 	const hostInfo = await tauri.core.invoke<ITauriHostInfo>('get_native_host_info');
 
-	const tauriConfig = {
+	/**
+ * Merged configuration object passed to `TauriDesktopMain`.
+ *
+ * Combines window-level settings (id, log level) from the Rust backend
+ * with host-level settings (home/tmp directories) to provide the
+ * workbench with all environment information it needs at startup.
+ */
+const tauriConfig = {
 		windowId: windowConfig.windowId,
 		logLevel: windowConfig.logLevel,
 		resourceDir: windowConfig.resourceDir,
@@ -283,6 +290,12 @@
 		const main = new desktopModule.TauriDesktopMain(tauriConfig, folderParam ?? undefined, workspaceParam ?? undefined);
 		await main.open();
 
+		// Notify the Rust backend that the workbench is ready to be shown.
+		// The window is created hidden (visible: false) and only becomes
+		// visible after this call, preventing the "stretching on restore"
+		// effect where the window resizes from default to saved geometry.
+		await tauri.core.invoke('notify_ready');
+
 		performance.mark('code/didStartWorkbench');
 	} catch (error) {
 		console.error('[Tauri Bootstrap] Failed to load workbench:', error);
@@ -293,6 +306,9 @@
 		errorEl.style.cssText = 'padding: 20px; font-family: monospace; white-space: pre-wrap;';
 		errorEl.textContent = `Failed to start workbench:\n\n${error instanceof Error ? error.stack || error.message : String(error)}`;
 		document.body.appendChild(errorEl);
+
+		// Show the window even on error so the user can see the error message
+		tauri.core.invoke('notify_ready').catch(() => { /* best-effort */ });
 	}
 
 	//#endregion


### PR DESCRIPTION
## Summary
- Windows are now created with `visible: false` and only shown after the TypeScript workbench calls `notify_ready`
- Added off-screen detection (ported from Scripta) to correct window position when display configuration changes between sessions
- Added a 30-second safety timeout that shows the window automatically if the TypeScript bootstrap crashes
- Refactored duplicated URL construction and workspace setter methods in WindowManager

Closes #167

## Test plan
- [ ] Verify no visual stretching motion on cold start with saved window geometry
- [ ] Verify window size/position restores correctly from previous session
- [ ] Verify window centers on primary monitor when external monitor is disconnected
- [ ] Verify additional windows (Open Folder) also use ready-to-show pattern
- [ ] Verify error during bootstrap still shows the error message (window becomes visible)
- [ ] Verify DevTools still opens correctly in debug builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)