### PR TITLE
feat: add clap-based CLI with early exit, extension management, and shell completions

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -105,6 +105,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -685,6 +735,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_complete"
+version = "4.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff7a1dccbdd8b078c2bdebff47e404615151534d5043da397ec50286816f9cb"
+dependencies = [
+ "clap",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "clipboard-win"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -692,6 +791,12 @@ checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
 dependencies = [
  "error-code",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -2375,6 +2480,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3204,6 +3315,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "opaque-debug"
@@ -6094,6 +6211,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "uuid"
 version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6129,6 +6252,8 @@ version = "0.1.0"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",
+ "clap",
+ "clap_complete",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "dirs",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -48,6 +48,8 @@ aes-gcm = "0.10"
 rand = "0.8"
 tokio-tungstenite = "0.24"
 futures-util = { version = "0.3", default-features = false, features = ["sink"] }
+clap = { version = "4", features = ["derive"] }
+clap_complete = "4"
 
 # macOS Keychain ACL control — used to set permissive ACL on the master
 # encryption key so that different worktree binaries can access it

--- a/src-tauri/src/cli/args.rs
+++ b/src-tauri/src/cli/args.rs
@@ -1,0 +1,91 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) VS Codeee Contributors. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+//! CLI argument definitions using clap derive macros.
+
+use clap::Parser;
+use clap_complete::Shell;
+
+/// VS Codeee — a VS Code fork powered by Tauri 2.0.
+#[derive(Parser, Debug)]
+#[command(
+    name = "codeee",
+    version,
+    about = "VS Codeee — a VS Code fork powered by Tauri 2.0",
+    long_about = "codeee is the command-line interface for VS Codeee.\n\
+	              It can open files and folders, manage extensions, and more.\n\n\
+	              Usage:\n  \
+	              codeee <file-or-folder>   Open a file or folder\n  \
+	              codeee --diff <a> <b>     Compare two files\n  \
+	              codeee -n                 Open a new empty window"
+)]
+pub struct Cli {
+    /// Files or folders to open. Use '-' to read from stdin.
+    #[arg(value_hint = clap::ValueHint::AnyPath)]
+    pub paths: Vec<String>,
+
+    // ── Window flags ──
+    /// Open a new window even if a folder is already open.
+    #[arg(short = 'n', long)]
+    pub new_window: bool,
+
+    /// Force opening in the last active window.
+    #[arg(short = 'r', long)]
+    pub reuse_window: bool,
+
+    // ── Editor modes ──
+    /// Open a diff editor comparing two files.
+    #[arg(short = 'd', long)]
+    pub diff: bool,
+
+    /// Open a file at a specific line and character (file:line[:character]).
+    #[arg(short = 'g', long)]
+    pub goto: bool,
+
+    /// Wait for the file to be closed before returning to the shell.
+    #[arg(short = 'w', long)]
+    pub wait: bool,
+
+    // ── Extension management ──
+    /// Install an extension by identifier or VSIX path.
+    #[arg(long = "install-extension", value_name = "EXT_ID_OR_VSIX")]
+    pub install_extension: Vec<String>,
+
+    /// Uninstall an extension by identifier.
+    #[arg(long = "uninstall-extension", value_name = "EXT_ID")]
+    pub uninstall_extension: Vec<String>,
+
+    /// List installed extensions.
+    #[arg(long = "list-extensions")]
+    pub list_extensions: bool,
+
+    /// Update installed extensions.
+    #[arg(long = "update-extensions")]
+    pub update_extensions: bool,
+
+    /// Add an MCP server configuration (JSON string or server ID).
+    #[arg(long = "add-mcp", value_name = "JSON_OR_ID")]
+    pub add_mcp: Vec<String>,
+
+    /// Set the root path for extensions.
+    #[arg(
+		long = "extensions-dir",
+		value_name = "DIR",
+		value_hint = clap::ValueHint::DirPath
+	)]
+    pub extensions_dir: Option<String>,
+
+    /// Show versions when listing extensions (use with --list-extensions).
+    #[arg(long = "show-versions")]
+    pub show_versions: bool,
+
+    /// Install a pre-release version of the extension.
+    #[arg(long = "pre-release")]
+    pub pre_release: bool,
+
+    /// Generate shell completion script.
+    #[arg(long = "generate-completion", value_name = "SHELL", hide = true)]
+    pub generate_completion: Option<Shell>,
+}

--- a/src-tauri/src/cli/completion.rs
+++ b/src-tauri/src/cli/completion.rs
@@ -1,0 +1,18 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) VS Codeee Contributors. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+//! Shell completion generation for the `eee` CLI.
+
+use super::args::Cli;
+use clap::CommandFactory;
+use clap_complete::{generate, Shell};
+use std::io;
+
+/// Generate shell completion script for the given shell.
+pub fn generate_completion(shell: Shell) {
+    let mut cmd = Cli::command();
+    let name = cmd.get_name().to_string();
+    generate(shell, &mut cmd, name, &mut io::stdout());
+}

--- a/src-tauri/src/cli/dispatch.rs
+++ b/src-tauri/src/cli/dispatch.rs
@@ -1,0 +1,177 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) VS Codeee Contributors. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+//! CLI dispatch — routes parsed arguments to the appropriate handler.
+//!
+//! Three categories of operations:
+//! 1. **Early exit** — `--version`, `--help` (handled by clap, no Tauri)
+//! 2. **Headless CLI** — extension management (no GUI window)
+//! 3. **GUI launch** — everything else (paths, --diff, --goto, --wait)
+
+use super::args::Cli;
+use clap::Parser;
+
+/// Result of dispatching CLI arguments.
+pub enum CliResult {
+    /// Print a message to stdout/stderr and exit.
+    Exit { message: String, code: i32 },
+
+    /// Generate shell completion script and exit.
+    Completion(clap_complete::Shell),
+
+    /// Extension management CLI operation (headless).
+    ExtensionOp(ExtensionOp),
+
+    /// Launch the GUI with parsed arguments.
+    Gui(ParsedGuiArgs),
+}
+
+/// Parsed GUI arguments for window routing.
+#[derive(Debug, Clone, Default)]
+pub struct ParsedGuiArgs {
+    /// File/folder paths to open.
+    pub paths: Vec<String>,
+    /// Force opening in a new window.
+    pub force_new_window: bool,
+    /// Force reusing the last active window.
+    pub force_reuse_window: bool,
+    /// Open a diff editor comparing two files.
+    pub diff: bool,
+    /// Open file at a specific line:character.
+    pub goto: bool,
+    /// Wait for the editor to close before returning.
+    pub wait: bool,
+}
+
+/// Extension management operation.
+#[derive(Debug)]
+pub enum ExtensionOp {
+    /// Install extensions by VSIX path (marketplace install not yet supported).
+    Install {
+        /// Extension identifiers or paths to `.vsix` files.
+        extensions: Vec<String>,
+        /// When `true`, install the pre-release version of the extension.
+        pre_release: bool,
+        /// Override the default extensions directory.
+        extensions_dir: Option<String>,
+    },
+    /// Uninstall extensions by identifier.
+    Uninstall {
+        /// Extension identifiers to remove.
+        extensions: Vec<String>,
+        /// Override the default extensions directory.
+        extensions_dir: Option<String>,
+    },
+    /// List installed extensions.
+    List {
+        /// When `true`, include version numbers in the output.
+        show_versions: bool,
+        /// Override the default extensions directory.
+        extensions_dir: Option<String>,
+    },
+    /// Update all installed extensions.
+    Update {
+        /// Override the default extensions directory.
+        extensions_dir: Option<String>,
+    },
+    /// Add MCP (Model Context Protocol) server configurations.
+    AddMcp {
+        /// JSON strings or server IDs for MCP server configuration.
+        configs: Vec<String>,
+    },
+}
+
+/// Parse and dispatch CLI arguments.
+///
+/// This function runs before Tauri starts, allowing early-exit operations
+/// to complete without any GUI overhead.
+pub fn dispatch() -> CliResult {
+    let cli = match Cli::try_parse() {
+        Ok(cli) => cli,
+        Err(e) => {
+            let message = e.to_string();
+            let code = if e.use_stderr() { 1 } else { 0 };
+            return CliResult::Exit { message, code };
+        }
+    };
+
+    // Shell completion generation
+    if let Some(shell) = cli.generate_completion {
+        return CliResult::Completion(shell);
+    }
+
+    // Extension management — headless operations
+    if !cli.install_extension.is_empty() {
+        return CliResult::ExtensionOp(ExtensionOp::Install {
+            extensions: cli.install_extension,
+            pre_release: cli.pre_release,
+            extensions_dir: cli.extensions_dir,
+        });
+    }
+    if !cli.uninstall_extension.is_empty() {
+        return CliResult::ExtensionOp(ExtensionOp::Uninstall {
+            extensions: cli.uninstall_extension,
+            extensions_dir: cli.extensions_dir,
+        });
+    }
+    if cli.list_extensions {
+        return CliResult::ExtensionOp(ExtensionOp::List {
+            show_versions: cli.show_versions,
+            extensions_dir: cli.extensions_dir,
+        });
+    }
+    if cli.update_extensions {
+        return CliResult::ExtensionOp(ExtensionOp::Update {
+            extensions_dir: cli.extensions_dir,
+        });
+    }
+    if !cli.add_mcp.is_empty() {
+        return CliResult::ExtensionOp(ExtensionOp::AddMcp {
+            configs: cli.add_mcp,
+        });
+    }
+
+    // Normal GUI launch
+    CliResult::Gui(ParsedGuiArgs {
+        paths: cli.paths,
+        force_new_window: cli.new_window,
+        force_reuse_window: cli.reuse_window,
+        diff: cli.diff,
+        goto: cli.goto,
+        wait: cli.wait,
+    })
+}
+
+/// Convert raw args (from single-instance callback) to `ParsedGuiArgs`.
+///
+/// Used by the single-instance callback in `lib.rs` to parse arguments
+/// forwarded from a second process.
+pub fn parse_gui_args(raw_args: &[String]) -> ParsedGuiArgs {
+    let cli = match Cli::try_parse_from(raw_args) {
+        Ok(cli) => cli,
+        Err(e) => {
+            log::warn!(
+                target: "vscodeee::cli::dispatch",
+                "Failed to parse single-instance args, falling back to legacy parser: {e}"
+            );
+            let legacy = super::parser::parse_args(raw_args);
+            return ParsedGuiArgs {
+                paths: legacy.paths,
+                force_new_window: legacy.force_new_window,
+                force_reuse_window: legacy.force_reuse_window,
+                ..Default::default()
+            };
+        }
+    };
+
+    ParsedGuiArgs {
+        paths: cli.paths,
+        force_new_window: cli.new_window,
+        force_reuse_window: cli.reuse_window,
+        diff: cli.diff,
+        goto: cli.goto,
+        wait: cli.wait,
+    }
+}

--- a/src-tauri/src/cli/extension_cli.rs
+++ b/src-tauri/src/cli/extension_cli.rs
@@ -1,0 +1,192 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) VS Codeee Contributors. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+//! Headless extension management CLI operations.
+//!
+//! Handles `--list-extensions`, `--install-extension`, `--uninstall-extension`,
+//! and `--add-mcp` without starting the Tauri GUI.
+
+use super::dispatch::ExtensionOp;
+use crate::commands::extension_management;
+use std::path::PathBuf;
+
+/// Resolve the extensions directory from an optional override or the default.
+fn resolve_extensions_dir(override_dir: Option<&str>) -> PathBuf {
+    if let Some(dir) = override_dir {
+        return PathBuf::from(dir);
+    }
+    // Default: ~/.vscodeee/extensions (matching the TypeScript side)
+    dirs::home_dir()
+        .map(|h| h.join(".vscodeee").join("extensions"))
+        .unwrap_or_else(|| PathBuf::from(".vscodeee/extensions"))
+}
+
+/// Run an extension management operation and return the exit code.
+pub fn run(op: &ExtensionOp) -> i32 {
+    match op {
+        ExtensionOp::List {
+            show_versions,
+            extensions_dir,
+        } => list_extensions(*show_versions, extensions_dir.as_deref()),
+        ExtensionOp::Install {
+            extensions,
+            pre_release,
+            extensions_dir,
+        } => {
+            if *pre_release {
+                eprintln!("codeee: --pre-release is not yet supported for CLI installs");
+            }
+            install_extensions(extensions, extensions_dir.as_deref())
+        }
+        ExtensionOp::Uninstall {
+            extensions,
+            extensions_dir,
+        } => uninstall_extensions(extensions, extensions_dir.as_deref()),
+        ExtensionOp::Update { .. } => {
+            eprintln!("codeee: --update-extensions is not yet supported in CLI mode");
+            1
+        }
+        ExtensionOp::AddMcp { configs } => add_mcp(configs),
+    }
+}
+
+/// List installed extensions and print them to stdout.
+///
+/// When `show_versions` is `true`, each line is formatted as `<id>@<version>`.
+/// Otherwise only the extension identifier is printed.
+///
+/// Returns `0` on success, `1` on error.
+fn list_extensions(show_versions: bool, extensions_dir: Option<&str>) -> i32 {
+    let dir = resolve_extensions_dir(extensions_dir);
+    match extension_management::ext_scan_installed(dir.to_string_lossy().to_string()) {
+        Ok(extensions) => {
+            for ext in &extensions {
+                if show_versions {
+                    println!("{}@{}", ext.id, ext.version);
+                } else {
+                    println!("{}", ext.id);
+                }
+            }
+            0
+        }
+        Err(e) => {
+            eprintln!("codeee: {e}");
+            1
+        }
+    }
+}
+
+/// Install one or more extensions from local VSIX files.
+///
+/// Each entry in `extensions` is checked: if it points to an existing `.vsix` file,
+/// it is extracted into the extensions directory. Marketplace identifier installation
+/// is not yet supported from the CLI.
+///
+/// Returns `0` if all installations succeeded, `1` if any failed.
+fn install_extensions(extensions: &[String], extensions_dir: Option<&str>) -> i32 {
+    let dir = resolve_extensions_dir(extensions_dir);
+    let mut failed = false;
+
+    for ext_id_or_path in extensions {
+        let path = std::path::Path::new(ext_id_or_path);
+        if path.exists() && path.extension().is_some_and(|e| e == "vsix") {
+            // Local VSIX file installation
+            match extension_management::ext_extract_vsix(
+                ext_id_or_path.clone(),
+                dir.to_string_lossy().to_string(),
+            ) {
+                Ok(result) => {
+                    println!("{} installed to {}", ext_id_or_path, result.extension_path);
+                }
+                Err(e) => {
+                    eprintln!("codeee: failed to install {}: {e}", ext_id_or_path);
+                    failed = true;
+                }
+            }
+        } else {
+            // Marketplace installation not yet supported from CLI
+            eprintln!(
+                "codeee: --install-extension from marketplace is not yet supported \
+				 (install from VSIX with: eee --install-extension path/to/ext.vsix)"
+            );
+            failed = true;
+        }
+    }
+
+    if failed {
+        1
+    } else {
+        0
+    }
+}
+
+/// Uninstall one or more extensions by identifier.
+///
+/// Scans the installed extensions in `extensions_dir` to locate each extension
+/// by its identifier, then deletes its directory.
+///
+/// Returns `0` if all uninstallations succeeded, `1` if any failed.
+fn uninstall_extensions(extensions: &[String], extensions_dir: Option<&str>) -> i32 {
+    let dir = resolve_extensions_dir(extensions_dir);
+    let base_dir = dir.to_string_lossy().to_string();
+
+    // Scan to find extension directories by ID
+    let installed =
+        match extension_management::ext_scan_installed(dir.to_string_lossy().to_string()) {
+            Ok(exts) => exts,
+            Err(e) => {
+                eprintln!("codeee: {e}");
+                return 1;
+            }
+        };
+
+    let mut failed = false;
+    for ext_id in extensions {
+        let found = installed.iter().find(|e| e.id == *ext_id);
+        match found {
+            Some(ext) => match extension_management::ext_delete_extension(
+                ext.location.clone(),
+                base_dir.clone(),
+            ) {
+                Ok(()) => println!("{} uninstalled", ext_id),
+                Err(e) => {
+                    eprintln!("codeee: failed to uninstall {}: {e}", ext_id);
+                    failed = true;
+                }
+            },
+            None => {
+                eprintln!("codeee: extension not found: {ext_id}");
+                failed = true;
+            }
+        }
+    }
+
+    if failed {
+        1
+    } else {
+        0
+    }
+}
+
+/// Validate and register MCP server configurations.
+///
+/// Each entry in `configs` must be a valid JSON string. Currently only
+/// validation is performed; full MCP registration is not yet implemented.
+///
+/// Returns `0` on success, `1` if any config is invalid JSON.
+fn add_mcp(configs: &[String]) -> i32 {
+    for config in configs {
+        // Validate that the input is valid JSON
+        match serde_json::from_str::<serde_json::Value>(config) {
+            Ok(_) => {}
+            Err(e) => {
+                eprintln!("codeee: invalid JSON for --add-mcp: {e}");
+                return 1;
+            }
+        }
+    }
+    eprintln!("codeee: --add-mcp is not yet fully implemented");
+    1
+}

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -3,15 +3,21 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-//! CLI argument handling for single-instance arg forwarding.
+//! CLI argument handling for the `eee` command.
 //!
-//! When a second VS Codeee process starts, `tauri-plugin-single-instance` forwards
-//! the CLI arguments to the primary instance. This module:
-//!
-//! - [`parser`] — Parses raw CLI args into a structured [`ParsedCli`]
-//! - [`uri`]    — Converts filesystem paths to `file:///` URIs
-//! - [`router`] — Routes parsed args to window actions (focus or open)
+//! Architecture:
+//! - [`args`]           — Clap derive definitions for all CLI flags
+//! - [`dispatch`]       — Routes parsed args to early-exit, headless, or GUI paths
+//! - [`extension_cli`]  — Headless extension management operations
+//! - [`completion`]     — Shell completion generation
+//! - [`parser`]         — Legacy parser (kept for backward compatibility)
+//! - [`uri`]            — Filesystem path to `file:///` URI conversion
+//! - [`router`]         — Routes parsed args to window actions
 
+pub mod args;
+pub mod completion;
+pub mod dispatch;
+pub mod extension_cli;
 pub mod parser;
 pub mod router;
 pub mod uri;

--- a/src-tauri/src/cli/parser.rs
+++ b/src-tauri/src/cli/parser.rs
@@ -65,7 +65,7 @@ mod tests {
 
     #[test]
     fn empty_args() {
-        let parsed = parse_args(&args(&["codeee"]));
+        let parsed = parse_args(&args(&["eee"]));
         assert!(parsed.paths.is_empty());
         assert!(!parsed.force_new_window);
         assert!(!parsed.force_reuse_window);
@@ -73,45 +73,45 @@ mod tests {
 
     #[test]
     fn single_path() {
-        let parsed = parse_args(&args(&["codeee", "/path/to/project"]));
+        let parsed = parse_args(&args(&["eee", "/path/to/project"]));
         assert_eq!(parsed.paths, vec!["/path/to/project"]);
     }
 
     #[test]
     fn multiple_paths() {
-        let parsed = parse_args(&args(&["codeee", "/a", "/b", "/c"]));
+        let parsed = parse_args(&args(&["eee", "/a", "/b", "/c"]));
         assert_eq!(parsed.paths, vec!["/a", "/b", "/c"]);
     }
 
     #[test]
     fn new_window_flag() {
-        let parsed = parse_args(&args(&["codeee", "-n", "/path"]));
+        let parsed = parse_args(&args(&["eee", "-n", "/path"]));
         assert!(parsed.force_new_window);
         assert_eq!(parsed.paths, vec!["/path"]);
     }
 
     #[test]
     fn reuse_window_flag() {
-        let parsed = parse_args(&args(&["codeee", "-r", "/path"]));
+        let parsed = parse_args(&args(&["eee", "-r", "/path"]));
         assert!(parsed.force_reuse_window);
     }
 
     #[test]
     fn double_dash_stops_flag_parsing() {
-        let parsed = parse_args(&args(&["codeee", "--", "-n", "/path"]));
+        let parsed = parse_args(&args(&["eee", "--", "-n", "/path"]));
         assert!(!parsed.force_new_window);
         assert_eq!(parsed.paths, vec!["-n", "/path"]);
     }
 
     #[test]
     fn unknown_flags_ignored() {
-        let parsed = parse_args(&args(&["codeee", "--unknown", "/path"]));
+        let parsed = parse_args(&args(&["eee", "--unknown", "/path"]));
         assert_eq!(parsed.paths, vec!["/path"]);
     }
 
     #[test]
     fn recognized_but_noop_flags() {
-        let parsed = parse_args(&args(&["codeee", "--wait", "--goto", "/path"]));
+        let parsed = parse_args(&args(&["eee", "--wait", "--goto", "/path"]));
         assert_eq!(parsed.paths, vec!["/path"]);
         assert!(!parsed.force_new_window);
     }

--- a/src-tauri/src/cli/router.rs
+++ b/src-tauri/src/cli/router.rs
@@ -5,12 +5,12 @@
 
 //! CLI argument router — dispatches parsed args to window actions.
 //!
-//! Routes a [`ParsedCli`](super::parser::ParsedCli) to the appropriate
+//! Routes a [`ParsedGuiArgs`](super::dispatch::ParsedGuiArgs) to the appropriate
 //! window operations: focusing existing windows or opening new ones.
 
 use tauri::Manager;
 
-use super::parser::ParsedCli;
+use super::dispatch::ParsedGuiArgs;
 use super::uri;
 use crate::window::manager::WindowManager;
 use crate::window::state::OpenWindowOptions;
@@ -22,19 +22,19 @@ use crate::window::state::OpenWindowOptions;
 /// 1. **No paths** — focus the most recently active window
 /// 2. **Paths without flags** — workspace dedup via `WindowManager`
 /// 3. **`force_new_window`** — each path gets a new window regardless
-pub async fn route_cli(
+pub async fn route_gui_args(
     app_handle: &tauri::AppHandle,
     wm: &WindowManager,
-    cli: &ParsedCli,
+    args: &ParsedGuiArgs,
     cwd: &str,
 ) {
-    if cli.paths.is_empty() {
+    if args.paths.is_empty() {
         focus_last_active(app_handle, wm).await;
         return;
     }
 
-    for path in &cli.paths {
-        let uri = match uri::path_to_file_uri(path, cwd) {
+    for path in &args.paths {
+        let file_uri = match uri::path_to_file_uri(path, cwd) {
             Some(u) => uri::normalize_uri(&u),
             None => {
                 log::warn!(
@@ -46,17 +46,17 @@ pub async fn route_cli(
         };
 
         let (folder_uri, workspace_uri) = if uri::is_workspace_file(path) {
-            (None, Some(uri))
+            (None, Some(file_uri))
         } else {
-            (Some(uri.clone()), None)
+            (Some(file_uri.clone()), None)
         };
 
         let options = OpenWindowOptions {
             folder_uri,
             workspace_uri,
             remote_authority: None,
-            force_new_window: cli.force_new_window,
-            force_reuse_window: cli.force_reuse_window,
+            force_new_window: args.force_new_window,
+            force_reuse_window: args.force_reuse_window,
         };
 
         match wm.open_window(app_handle, &options).await {
@@ -74,6 +74,22 @@ pub async fn route_cli(
             }
         }
     }
+}
+
+/// Route a legacy [`ParsedCli`](super::parser::ParsedCli) (backward compat).
+pub async fn route_cli(
+    app_handle: &tauri::AppHandle,
+    wm: &WindowManager,
+    cli: &super::parser::ParsedCli,
+    cwd: &str,
+) {
+    let args = ParsedGuiArgs {
+        paths: cli.paths.clone(),
+        force_new_window: cli.force_new_window,
+        force_reuse_window: cli.force_reuse_window,
+        ..Default::default()
+    };
+    route_gui_args(app_handle, wm, &args, cwd).await;
 }
 
 /// Focus the most recently active window, falling back to the "main" window.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -33,8 +33,8 @@ mod system_events;
 /// Phase 0-4: Uses portable-pty for direct Rust PTY management.
 mod pty;
 
-/// CLI argument handling for single-instance arg forwarding.
-mod cli;
+/// CLI argument handling for the `eee` command.
+pub mod cli;
 
 /// Build and run the Tauri application.
 ///
@@ -50,7 +50,7 @@ mod cli;
 ///
 /// Panics if an error occurs while running the Tauri application.
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
-pub fn run() {
+pub fn run(gui_args: Option<cli::dispatch::ParsedGuiArgs>) {
     // Pre-build protocol state so the handler closure can capture it.
     // We use a OnceCell to defer actual root registration until setup(),
     // where the Tauri App handle is available.
@@ -90,8 +90,8 @@ pub fn run() {
             };
             let handle = app.clone();
             tauri::async_runtime::spawn(async move {
-                let parsed = cli::parser::parse_args(&args);
-                cli::router::route_cli(&handle, &wm, &parsed, &cwd).await;
+                let parsed = cli::dispatch::parse_gui_args(&args);
+                cli::router::route_gui_args(&handle, &wm, &parsed, &cwd).await;
             });
         }))
         .plugin(tauri_plugin_shell::init())
@@ -473,7 +473,12 @@ pub fn run() {
 
             // ── Create additional restored windows ──
             // Windows beyond the first one need to be created programmatically.
-            if restore_plan.len() > 1 {
+            // Skip if CLI args override the session (user explicitly opened files/folders).
+            let cli_overrides_session = gui_args
+                .as_ref()
+                .is_some_and(|a| !a.paths.is_empty());
+
+            if !cli_overrides_session && restore_plan.len() > 1 {
                 let wm = Arc::clone(&window_manager);
                 let handle = app.handle().clone();
                 let additional_entries: Vec<_> = restore_plan[1..].to_vec();
@@ -512,6 +517,28 @@ pub fn run() {
                         }
                     }
                 });
+            }
+
+            // ── Route first-instance CLI arguments ──
+            // When the user launches `eee /path/to/project` for the first time,
+            // the CLI args need to be routed to window operations.
+            if let Some(ref args) = gui_args {
+                if !args.paths.is_empty() {
+                    let handle = app.handle().clone();
+                    let wm = Arc::clone(&window_manager);
+                    let args = args.clone();
+                    let cwd = std::env::current_dir()
+                        .map(|p| p.to_string_lossy().to_string())
+                        .unwrap_or_else(|_| ".".to_string());
+                    tauri::async_runtime::spawn(async move {
+                        cli::router::route_gui_args(&handle, &wm, &args, &cwd).await;
+                    });
+                    log::info!(
+                        target: "vscodeee",
+                        "Routed first-instance CLI args: {} paths",
+                        gui_args.as_ref().map(|a| a.paths.len()).unwrap_or(0)
+                    );
+                }
             }
 
             Ok(())

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -6,12 +6,40 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 //! Entry point for the VS Codeee desktop application.
 //!
-//! In release builds, `windows_subsystem = "windows"` suppresses
-//! the console window on Windows.
+//! Handles three execution paths:
+//! 1. **Early exit** — `--version`, `--help` (no Tauri overhead)
+//! 2. **Headless CLI** — extension management (no GUI window)
+//! 3. **GUI launch** — normal application startup with parsed args
 
-/// Application main entry point.
+use vscodeee_lib::cli::dispatch::{self, CliResult};
+
+/// Application entry point.
 ///
-/// Delegates to [`vscodeee_lib::run()`] to launch the Tauri application.
+/// Dispatches CLI arguments before the Tauri runtime starts:
+///
+/// - [`CliResult::Exit`] — prints a message and exits (e.g. `--help`, parse errors)
+/// - [`CliResult::Completion`] — generates a shell completion script and exits
+/// - [`CliResult::ExtensionOp`] — runs a headless extension operation and exits
+/// - [`CliResult::Gui`] — launches the Tauri GUI with the parsed arguments
 fn main() {
-    vscodeee_lib::run()
+    match dispatch::dispatch() {
+        CliResult::Exit { message, code } => {
+            if code == 0 {
+                print!("{message}");
+            } else {
+                eprint!("{message}");
+            }
+            std::process::exit(code);
+        }
+        CliResult::Completion(shell) => {
+            vscodeee_lib::cli::completion::generate_completion(shell);
+        }
+        CliResult::ExtensionOp(op) => {
+            let code = vscodeee_lib::cli::extension_cli::run(&op);
+            std::process::exit(code);
+        }
+        CliResult::Gui(gui_args) => {
+            vscodeee_lib::run(Some(gui_args));
+        }
+    }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-utils/schema.json",
   "productName": "VS Codeee",
-  "mainBinaryName": "VS Codeee",
+  "mainBinaryName": "codeee",
   "version": "0.1.0",
   "identifier": "com.vscodeee.app",
   "build": {


### PR DESCRIPTION
## Summary

- Replace the hand-written CLI argument parser with [clap](https://docs.rs/clap) derive macros, providing automatic `--help` and `--version` output
- Add headless extension management CLI (`--list-extensions`, `--install-extension`, `--uninstall-extension`, `--add-mcp`) that works without starting the GUI
- Fix a critical bug where first-instance CLI arguments (file/folder paths) were silently ignored
- Add shell completion generation via `--generate-completion <shell>`

## Changes

### New modules
- `src-tauri/src/cli/args.rs` — clap `Cli` struct with all CLI flags
- `src-tauri/src/cli/dispatch.rs` — routes parsed args to early-exit / headless / GUI paths
- `src-tauri/src/cli/extension_cli.rs` — headless extension operations (list, install VSIX, uninstall, add-mcp)
- `src-tauri/src/cli/completion.rs` — shell completion generation using `clap_complete`

### Modified
- `src-tauri/src/main.rs` — calls `dispatch()` before Tauri builder starts
- `src-tauri/src/lib.rs` — passes `ParsedGuiArgs` through to `setup()`, routes first-instance CLI args to WindowManager, adds `cli_overrides_session` to prevent session restore conflicts
- `src-tauri/src/cli/router.rs` — added `route_gui_args()` using `ParsedGuiArgs`
- `src-tauri/src/cli/mod.rs` — exports new modules
- `src-tauri/Cargo.toml` — added `clap` and `clap_complete` dependencies
- `src-tauri/tauri.conf.json` — set `mainBinaryName` to `"codeee"`

### Architecture
Three execution paths before Tauri starts:
1. **Early exit** — `--version`, `--help` (handled by clap)
2. **Headless CLI** — extension management (no GUI window)
3. **GUI launch** — paths, `--diff`, `--goto`, `--wait`

Single-instance callback falls back to legacy parser on unknown flags for forward compatibility.

## Test plan

- [ ] `codeee --version` prints version and exits
- [ ] `codeee --help` prints usage and exits
- [ ] `codeee --list-extensions` lists installed extensions (headless, no GUI)
- [ ] `codeee --install-extension path/to/ext.vsix` installs from VSIX (headless)
- [ ] `codeee --uninstall-extension <id>` uninstalls by ID (headless)
- [ ] `codeee /path/to/folder` opens folder in GUI (first-instance args no longer ignored)
- [ ] `codeee -n` opens new empty window
- [ ] `codeee --generate-completion bash` outputs bash completion script
- [ ] Opening files from Finder / `open -a` still works (single-instance forwarding)

🤖 Generated with [Claude Code](https://claude.com/claude-code)