### PR TITLE
feat: add shell command install/uninstall actions for command palette

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6291,6 +6291,7 @@ dependencies = [
  "tokio-tungstenite",
  "trash",
  "uuid",
+ "winreg 0.55.0",
  "zip 2.4.2",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -59,3 +59,7 @@ security-framework = "3"
 security-framework-sys = "2"
 core-foundation = "0.10"
 core-foundation-sys = "0.8"
+
+# Windows shell command install — creates .cmd wrapper and updates user PATH.
+[target.'cfg(target_os = "windows")'.dependencies]
+winreg = "0.55"

--- a/src-tauri/src/commands/native_host/shell.rs
+++ b/src-tauri/src/commands/native_host/shell.rs
@@ -62,139 +62,346 @@ pub fn kill_process(pid: u32, code: String) -> Result<(), NativeHostError> {
     Ok(())
 }
 
-/// Install a shell command (`codeee`) by creating a symlink.
+/// Install a shell command (`codeee`) so it can be run from a terminal.
+///
+/// - macOS: symlink via `osascript` with administrator privileges
+/// - Linux: direct symlink to `/usr/local/bin/codeee`
+/// - Windows: `.cmd` wrapper in `%LOCALAPPDATA%\Programs\VS Codeee\bin\` + user PATH
 #[tauri::command]
 pub async fn install_shell_command(_app: tauri::AppHandle) -> Result<(), NativeHostError> {
     let exe_path = std::env::current_exe()
         .map_err(|e| NativeHostError::Other(format!("Failed to get executable path: {e}")))?;
 
-    let link_path = if cfg!(target_os = "macos") || cfg!(target_os = "linux") {
-        "/usr/local/bin/codeee"
-    } else if cfg!(windows) {
-        return Err(NativeHostError::Unsupported(
-            "Shell command installation on Windows is not yet supported".to_string(),
-        ));
-    } else {
-        return Err(NativeHostError::Unsupported(
-            "Unsupported platform".to_string(),
-        ));
-    };
-
     let exe_str = exe_path.to_string_lossy();
+
+    // Reject paths containing characters that could break shell quoting
+    if exe_str.contains('"') {
+        return Err(NativeHostError::Other(
+            "Executable path contains unsupported characters".to_string(),
+        ));
+    }
 
     #[cfg(target_os = "macos")]
     {
-        // Escape single quotes to prevent command injection in AppleScript
+        let link_path = "/usr/local/bin/codeee";
         let escaped_exe = exe_str.replace('\'', "'\\''");
-        let script = format!(
-            "do shell script \"ln -sf '{}' '{}'\" with administrator privileges",
-            escaped_exe, link_path
-        );
-        let output = std::process::Command::new("osascript")
-            .args(["-e", &script])
-            .output()
-            .map_err(|e| NativeHostError::Other(format!("Failed to run osascript: {e}")))?;
+        let script = format!("ln -sf '{}' '{}'", escaped_exe, link_path);
+        run_osascript_with_admin(&script, "install shell command")?;
 
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            if stderr.contains("User canceled") || stderr.contains("-128") {
-                return Err(NativeHostError::Other(
-                    "User cancelled the operation".to_string(),
-                ));
-            }
-            return Err(NativeHostError::Other(format!(
-                "Failed to install shell command: {stderr}"
-            )));
-        }
+        log::info!(
+            target: "vscodeee::commands::native_host",
+            "Installed shell command: {} -> {}",
+            link_path,
+            exe_path.display()
+        );
     }
 
     #[cfg(target_os = "linux")]
     {
         let _ = _app;
-        if let Err(_) = std::os::unix::fs::symlink(&exe_str.as_ref(), link_path) {
+        let link_path = "/usr/local/bin/codeee";
+        if std::os::unix::fs::symlink(&*exe_str, link_path).is_err() {
             return Err(NativeHostError::Other(format!(
                 "Failed to create symlink. Try: sudo ln -sf '{}' '{}'",
                 exe_str, link_path
             )));
         }
+
+        log::info!(
+            target: "vscodeee::commands::native_host",
+            "Installed shell command: {} -> {}",
+            link_path,
+            exe_path.display()
+        );
     }
 
-    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    #[cfg(target_os = "windows")]
     {
-        let _ = (_app, exe_str, link_path);
+        let _ = (_app, exe_str);
+        install_windows_shell_command(&exe_path)?;
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+    {
+        let _ = (_app, exe_str);
         return Err(NativeHostError::Unsupported(
             "Unsupported platform".to_string(),
         ));
     }
 
+    Ok(())
+}
+
+/// Uninstall the shell command (`codeee`) by removing the symlink or wrapper.
+#[tauri::command]
+pub async fn uninstall_shell_command(_app: tauri::AppHandle) -> Result<(), NativeHostError> {
+    #[cfg(target_os = "macos")]
+    {
+        let link_path = "/usr/local/bin/codeee";
+        if !std::path::Path::new(link_path).exists() {
+            return Ok(());
+        }
+        let script = format!("rm -f '{}'", link_path);
+        run_osascript_with_admin(&script, "uninstall shell command")?;
+
+        log::info!(
+            target: "vscodeee::commands::native_host",
+            "Uninstalled shell command: {}",
+            link_path
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        let _ = _app;
+        let link_path = "/usr/local/bin/codeee";
+        if std::path::Path::new(link_path).exists() {
+            std::fs::remove_file(link_path)?;
+        }
+
+        log::info!(
+            target: "vscodeee::commands::native_host",
+            "Uninstalled shell command: {}",
+            link_path
+        );
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        let _ = _app;
+        uninstall_windows_shell_command()?;
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+    {
+        let _ = _app;
+        return Err(NativeHostError::Unsupported(
+            "Unsupported platform".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+// ─── macOS helper ────────────────────────────────────────────────────────
+
+/// Execute a shell script via `osascript` with administrator privileges.
+///
+/// Handles the common pattern of running a command through macOS's
+/// authorization dialog, including user-cancellation detection.
+#[cfg(target_os = "macos")]
+fn run_osascript_with_admin(script: &str, label: &str) -> Result<(), NativeHostError> {
+    let full_script = format!(
+        "do shell script \"{}\" with administrator privileges",
+        script
+    );
+    let output = std::process::Command::new("osascript")
+        .args(["-e", &full_script])
+        .output()
+        .map_err(|e| NativeHostError::Other(format!("Failed to run osascript: {e}")))?;
+
+    if output.status.success() {
+        return Ok(());
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if stderr.contains("User canceled") || stderr.contains("-128") {
+        return Err(NativeHostError::Other(
+            "User cancelled the operation".to_string(),
+        ));
+    }
+    Err(NativeHostError::Other(format!(
+        "Failed to {label}: {stderr}"
+    )))
+}
+
+// ─── Windows-specific helpers ──────────────────────────────────────────
+
+/// Resolve the `%LOCALAPPDATA%\Programs\VS Codeee\bin\` directory.
+#[cfg(target_os = "windows")]
+fn shell_command_bin_dir() -> Result<std::path::PathBuf, NativeHostError> {
+    dirs::data_local_dir()
+        .ok_or_else(|| {
+            NativeHostError::Other("Failed to resolve local app data directory".to_string())
+        })
+        .map(|d| d.join("Programs").join("VS Codeee").join("bin"))
+}
+
+/// Open the current user's `Environment` registry key with read/write access.
+#[cfg(target_os = "windows")]
+fn open_environment_key() -> Result<winreg::RegKey, NativeHostError> {
+    use winreg::enums::*;
+    use winreg::RegKey;
+
+    RegKey::predef(HKEY_CURRENT_USER)
+        .open_subkey_with_flags("Environment", KEY_READ | KEY_WRITE)
+        .map_err(|e| NativeHostError::Other(format!("Failed to open registry: {e}")))
+}
+
+/// Create a `codeee.cmd` wrapper in `%LOCALAPPDATA%\Programs\VS Codeee\bin\`
+/// and add that directory to the current user's `Path` environment variable.
+///
+/// The generated `.cmd` file forwards all arguments to the running executable.
+/// After updating the registry, a `WM_SETTINGCHANGE` broadcast is sent so that
+/// other processes (e.g. Explorer) pick up the new PATH without a restart.
+#[cfg(target_os = "windows")]
+fn install_windows_shell_command(exe_path: &std::path::Path) -> Result<(), NativeHostError> {
+    use std::io::Write;
+
+    let bin_dir = shell_command_bin_dir()?;
+
+    std::fs::create_dir_all(&bin_dir)
+        .map_err(|e| NativeHostError::Other(format!("Failed to create bin directory: {e}")))?;
+
+    let cmd_path = bin_dir.join("codeee.cmd");
+    let exe_str = exe_path.to_string_lossy();
+    let cmd_content = format!("@echo off\r\n\"{exe_str}\" %*\r\n");
+
+    let mut file = std::fs::File::create(&cmd_path)
+        .map_err(|e| NativeHostError::Other(format!("Failed to create codeee.cmd: {e}")))?;
+    file.write_all(cmd_content.as_bytes())
+        .map_err(|e| NativeHostError::Other(format!("Failed to write codeee.cmd: {e}")))?;
+
+    add_to_user_path(bin_dir.to_string_lossy().as_ref())?;
+
+    broadcast_env_change();
+
     log::info!(
         target: "vscodeee::commands::native_host",
         "Installed shell command: {} -> {}",
-        link_path,
+        cmd_path.display(),
         exe_path.display()
     );
 
     Ok(())
 }
 
-/// Uninstall the shell command (`codeee`) by removing the symlink.
-#[tauri::command]
-pub async fn uninstall_shell_command(_app: tauri::AppHandle) -> Result<(), NativeHostError> {
-    let link_path = if cfg!(target_os = "macos") || cfg!(target_os = "linux") {
-        "/usr/local/bin/codeee"
-    } else {
-        return Err(NativeHostError::Unsupported(
-            "Unsupported platform".to_string(),
-        ));
-    };
+/// Remove the `codeee.cmd` wrapper and clean up the corresponding entry
+/// from the current user's `Path` environment variable.
+///
+/// If the `.cmd` file or the PATH entry does not exist, the function
+/// succeeds silently. A `WM_SETTINGCHANGE` broadcast is sent after
+/// the registry update.
+#[cfg(target_os = "windows")]
+fn uninstall_windows_shell_command() -> Result<(), NativeHostError> {
+    let bin_dir = shell_command_bin_dir()?;
 
-    if !std::path::Path::new(link_path).exists() {
-        return Ok(());
+    let cmd_path = bin_dir.join("codeee.cmd");
+    if cmd_path.exists() {
+        std::fs::remove_file(&cmd_path)?;
     }
 
-    #[cfg(target_os = "macos")]
-    {
-        let script = format!(
-            "do shell script \"rm -f '{}'\" with administrator privileges",
-            link_path
-        );
-        let output = std::process::Command::new("osascript")
-            .args(["-e", &script])
-            .output()
-            .map_err(|e| NativeHostError::Other(format!("Failed to run osascript: {e}")))?;
+    remove_from_user_path(bin_dir.to_string_lossy().as_ref())?;
 
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            if stderr.contains("User canceled") || stderr.contains("-128") {
-                return Err(NativeHostError::Other(
-                    "User cancelled the operation".to_string(),
-                ));
-            }
-            return Err(NativeHostError::Other(format!(
-                "Failed to uninstall shell command: {stderr}"
-            )));
-        }
-    }
-
-    #[cfg(target_os = "linux")]
-    {
-        let _ = _app;
-        std::fs::remove_file(link_path)?;
-    }
-
-    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
-    {
-        let _ = _app;
-        return Err(NativeHostError::Unsupported(
-            "Unsupported platform".to_string(),
-        ));
-    }
+    broadcast_env_change();
 
     log::info!(
         target: "vscodeee::commands::native_host",
         "Uninstalled shell command: {}",
-        link_path
+        cmd_path.display()
     );
 
     Ok(())
+}
+
+/// Append `dir` to the current user's `Path` environment variable in the
+/// Windows registry (`HKCU\Environment`).
+///
+/// The directory is compared case-insensitively; if it is already present
+/// the function returns early without modifying the registry.
+#[cfg(target_os = "windows")]
+fn add_to_user_path(dir: &str) -> Result<(), NativeHostError> {
+    let env = open_environment_key()?;
+    let current_path: String = env.get_value("Path").unwrap_or_default();
+    let dir_normalized = dir.replace('/', "\\");
+
+    if current_path
+        .split(';')
+        .any(|p| p.eq_ignore_ascii_case(&dir_normalized))
+    {
+        return Ok(());
+    }
+
+    let new_path = if current_path.is_empty() {
+        dir_normalized
+    } else {
+        format!("{current_path};{dir_normalized}")
+    };
+
+    env.set_value("Path", &new_path)
+        .map_err(|e| NativeHostError::Other(format!("Failed to update PATH: {e}")))?;
+
+    Ok(())
+}
+
+/// Remove `dir` from the current user's `Path` environment variable in the
+/// Windows registry (`HKCU\Environment`).
+///
+/// Matching is case-insensitive. Empty segments left behind by removal are
+/// pruned. If the value is unchanged the function returns early without
+/// modifying the registry.
+#[cfg(target_os = "windows")]
+fn remove_from_user_path(dir: &str) -> Result<(), NativeHostError> {
+    let env = open_environment_key()?;
+    let current_path: String = env.get_value("Path").unwrap_or_default();
+    let dir_normalized = dir.replace('/', "\\");
+
+    let filtered: Vec<&str> = current_path
+        .split(';')
+        .filter(|p| !p.is_empty() && !p.eq_ignore_ascii_case(&dir_normalized))
+        .collect();
+
+    let new_path = filtered.join(";");
+    if new_path == current_path {
+        return Ok(());
+    }
+    env.set_value("Path", &new_path)
+        .map_err(|e| NativeHostError::Other(format!("Failed to update PATH: {e}")))?;
+
+    Ok(())
+}
+
+/// Broadcast a `WM_SETTINGCHANGE` message with the `"Environment"` parameter
+/// to all top-level windows so they reload their environment variables from
+/// the registry.
+///
+/// Uses `SendMessageTimeoutW` with `SMTO_ABORTIFHUNG` and a 5-second timeout
+/// to avoid blocking on unresponsive windows.
+#[cfg(target_os = "windows")]
+fn broadcast_env_change() {
+    use std::ffi::OsStr;
+    use std::os::windows::ffi::OsStrExt;
+
+    extern "system" {
+        fn SendMessageTimeoutW(
+            hwnd: isize,
+            msg: u32,
+            wparam: usize,
+            lparam: isize,
+            flags: u32,
+            timeout: u32,
+            result: *mut usize,
+        ) -> isize;
+    }
+
+    const HWND_BROADCAST: isize = 0xFFFF;
+    const WM_SETTINGCHANGE: u32 = 0x001A;
+    const SMTO_ABORTIFHUNG: u32 = 0x0002;
+
+    unsafe {
+        let env_wide: Vec<u16> = OsStr::new("Environment")
+            .encode_wide()
+            .chain(std::iter::once(0))
+            .collect();
+
+        SendMessageTimeoutW(
+            HWND_BROADCAST,
+            WM_SETTINGCHANGE,
+            0,
+            env_wide.as_ptr() as isize,
+            SMTO_ABORTIFHUNG,
+            5000,
+            std::ptr::null_mut(),
+        );
+    }
 }

--- a/src/vs/platform/native/common/native.ts
+++ b/src/vs/platform/native/common/native.ts
@@ -246,7 +246,7 @@ export interface ICommonNativeHostService {
 	toggleWindowTabsBar(): Promise<void>;
 	updateTouchBar(items: ISerializableCommandAction[][]): Promise<void>;
 
-	// macOS Shell command
+	// Shell command
 	installShellCommand(): Promise<void>;
 	uninstallShellCommand(): Promise<void>;
 

--- a/src/vs/platform/native/tauri-browser/nativeHostService.ts
+++ b/src/vs/platform/native/tauri-browser/nativeHostService.ts
@@ -644,7 +644,7 @@ export class TauriNativeHostService extends Disposable implements INativeHostSer
 
 	// #endregion
 
-	// #region macOS Shell command
+	// #region Shell command
 
 	/** Installs the `codeee` shell command by creating a symlink via the Rust backend. */
 	async installShellCommand(): Promise<void> {

--- a/src/vs/workbench/tauri-browser/actions/shellCommandActions.ts
+++ b/src/vs/workbench/tauri-browser/actions/shellCommandActions.ts
@@ -1,0 +1,121 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) VS Codeee Contributors. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { localize, localize2 } from '../../../nls.js';
+import { Action2, registerAction2 } from '../../../platform/actions/common/actions.js';
+import { Categories } from '../../../platform/action/common/actionCommonCategories.js';
+import { INativeHostService } from '../../../platform/native/common/native.js';
+import { INotificationService } from '../../../platform/notification/common/notification.js';
+import { ServicesAccessor } from '../../../platform/instantiation/common/instantiation.js';
+
+// #region Shared shell command helper
+
+/**
+ * Represents the two shell command lifecycle operations that can be
+ * dispatched through the native host service.
+ */
+type ShellCommandMethod = 'installShellCommand' | 'uninstallShellCommand';
+
+/**
+ * Execute a shell command action with unified success/error notification handling.
+ * Silently returns when the user cancels the OS-level privilege prompt.
+ */
+async function executeShellCommandAction(
+	accessor: ServicesAccessor,
+	method: ShellCommandMethod,
+	successMessage: string,
+	errorMessageKey: string,
+): Promise<void> {
+	const nativeHostService = accessor.get(INativeHostService);
+	const notificationService = accessor.get(INotificationService);
+
+	try {
+		await nativeHostService[method]();
+		notificationService.info(successMessage);
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		if (message.includes('cancelled') || message.includes('canceled')) {
+			return;
+		}
+		notificationService.error(localize(errorMessageKey, "Unable to {0} 'codeee' command: {1}", method === 'installShellCommand' ? 'install' : 'uninstall', message));
+	}
+}
+
+// #endregion
+
+// #region Install Shell Command
+
+/**
+ * Action that installs the `codeee` shell command so the application
+ * can be launched from any terminal session.
+ *
+ * Registered under `workbench.action.installShellCommand` in the
+ * Developer category. Available from the Command Palette (`f1: true`).
+ */
+class InstallShellCommandAction extends Action2 {
+	constructor() {
+		super({
+			id: 'workbench.action.installShellCommand',
+			title: localize2('installShellCommand', "Shell Command: Install 'codeee' Command in PATH"),
+			category: Categories.Developer,
+			f1: true,
+		});
+	}
+
+	/**
+	 * Invoke the native host's `installShellCommand` method and show
+	 * a success notification. OS privilege prompts that are cancelled
+	 * by the user are silently ignored.
+	 */
+	async run(accessor: ServicesAccessor): Promise<void> {
+		await executeShellCommandAction(
+			accessor,
+			'installShellCommand',
+			localize('installShellCommandSuccess', "'codeee' command successfully installed in PATH. Restart your terminal for the change to take effect."),
+			'installShellCommandError',
+		);
+	}
+}
+
+registerAction2(InstallShellCommandAction);
+
+// #endregion
+
+// #region Uninstall Shell Command
+
+/**
+ * Action that removes the `codeee` shell command from the system PATH.
+ *
+ * Registered under `workbench.action.uninstallShellCommand` in the
+ * Developer category. Available from the Command Palette (`f1: true`).
+ */
+class UninstallShellCommandAction extends Action2 {
+	constructor() {
+		super({
+			id: 'workbench.action.uninstallShellCommand',
+			title: localize2('uninstallShellCommand', "Shell Command: Uninstall 'codeee' Command from PATH"),
+			category: Categories.Developer,
+			f1: true,
+		});
+	}
+
+	/**
+	 * Invoke the native host's `uninstallShellCommand` method and show
+	 * a success notification. OS privilege prompts that are cancelled
+	 * by the user are silently ignored.
+	 */
+	async run(accessor: ServicesAccessor): Promise<void> {
+		await executeShellCommandAction(
+			accessor,
+			'uninstallShellCommand',
+			localize('uninstallShellCommandSuccess', "'codeee' command successfully removed from PATH."),
+			'uninstallShellCommandError',
+		);
+	}
+}
+
+registerAction2(UninstallShellCommandAction);
+
+// #endregion

--- a/src/vs/workbench/workbench.tauri.main.ts
+++ b/src/vs/workbench/workbench.tauri.main.ts
@@ -34,6 +34,7 @@ import './tauri-browser/desktop.tauri.main.js';
 
 import './tauri-browser/actions/developerActions.js';
 import './tauri-browser/actions/nativeActions.js';
+import './tauri-browser/actions/shellCommandActions.js';
 
 //#endregion
 


### PR DESCRIPTION
## Summary

- Add `Shell Command: Install 'codeee' Command in PATH` and `Shell Command: Uninstall 'codeee' Command from PATH` actions to the command palette under the Developer category
- Add Windows support: creates a `.cmd` wrapper in `%LOCALAPPDATA%\Programs\VS Codeee\bin\` and registers the directory in the user PATH via `HKCU\Environment\Path` registry
- Extract shared macOS `osascript` helper and Windows registry helper to reduce code duplication
- Add input sanitization for shell-quoting safety (rejects paths containing `"`)
- Broadcast `WM_SETTINGCHANGE` on Windows for immediate environment variable propagation

## Changes

| File | Change |
|------|--------|
| `src/vs/workbench/tauri-browser/actions/shellCommandActions.ts` | New: `InstallShellCommandAction` and `UninstallShellCommandAction` Action2 classes |
| `src/vs/workbench/workbench.tauri.main.ts` | Import new action module |
| `src/vs/platform/native/common/native.ts` | Update comment (macOS → cross-platform) |
| `src/vs/platform/native/tauri-browser/nativeHostService.ts` | Update comment (macOS → cross-platform) |
| `src-tauri/Cargo.toml` | Add `winreg` dependency (Windows-only) |
| `src-tauri/src/commands/native_host/shell.rs` | Add Windows support, extract helpers, add input validation |

## Platform behavior

| Platform | Mechanism |
|----------|-----------|
| macOS | Symlink via `osascript` with administrator privileges |
| Linux | Direct symlink to `/usr/local/bin/codeee` |
| Windows | `.cmd` wrapper + `HKCU\Environment\Path` registry + `WM_SETTINGCHANGE` broadcast |

## Test plan

- [x] Command palette shows both Install/Uninstall commands
- [x] Install creates `/usr/local/bin/codeee` symlink (macOS)
- [x] `which codeee` resolves correctly after install
- [x] Uninstall removes the symlink
- [ ] Windows: `.cmd` wrapper created and PATH updated
- [ ] Linux: symlink creation (may require sudo)
- [ ] User cancellation of admin prompt shows no error notification

🤖 Generated with [Claude Code](https://claude.com/claude-code)