### PR TITLE
fix: use streaming TextDecoder to prevent UTF-8 split at PTY buffer boundaries

### DIFF
--- a/src/vs/workbench/contrib/terminal/tauri-browser/tauriPty.ts
+++ b/src/vs/workbench/contrib/terminal/tauri-browser/tauriPty.ts
@@ -110,6 +110,20 @@ export class TauriPty extends Disposable implements ITerminalChildProcess {
 	// Dimensions tracking
 	private _lastDimensions: { cols: number; rows: number } = { cols: -1, rows: -1 };
 
+	/**
+	 * Persistent TextDecoder for streaming UTF-8 decoding.
+	 *
+	 * PTY output arrives in arbitrary-sized chunks (up to 8192 bytes from the
+	 * Rust reader thread) that may split multi-byte UTF-8 sequences across chunk
+	 * boundaries. Using `{ stream: true }` in each `decode()` call tells the
+	 * decoder to buffer any incomplete trailing bytes and prepend them to the
+	 * next chunk, preventing U+FFFD replacement characters from appearing.
+	 *
+	 * This mirrors how node-pty handles UTF-8 internally — the PTY backend
+	 * reads raw bytes, and the consumer side is responsible for correct decoding.
+	 */
+	private readonly _decoder = new TextDecoder('utf-8', { fatal: false });
+
 	// Events
 	private readonly _onProcessData = this._register(new Emitter<IProcessDataEvent | string>());
 	readonly onProcessData = this._onProcessData.event;
@@ -168,14 +182,18 @@ export class TauriPty extends Disposable implements ITerminalChildProcess {
 			// Phase 2: Register event listeners BEFORE activating the reader
 			// Listen for output data from the Rust PTY
 			this._unlistenOutput = await tauriListen(`pty-output-${this._ptyId}`, (payload: unknown) => {
-				// Payload is Vec<u8> from Rust, arrives as number[] in JS
+				// Payload is Vec<u8> from Rust, arrives as number[] in JS.
+				// Use the persistent decoder with { stream: true } so that
+				// multi-byte UTF-8 sequences split across chunk boundaries are
+				// buffered and correctly decoded on the next call, instead of
+				// being replaced with U+FFFD replacement characters.
 				let data: string;
 				if (payload instanceof Uint8Array) {
-					data = new TextDecoder().decode(payload);
+					data = this._decoder.decode(payload, { stream: true });
 				} else if (typeof payload === 'string') {
 					data = payload;
 				} else if (Array.isArray(payload)) {
-					data = new TextDecoder().decode(new Uint8Array(payload as number[]));
+					data = this._decoder.decode(new Uint8Array(payload as number[]), { stream: true });
 				} else {
 					data = String(payload);
 				}


### PR DESCRIPTION
## Summary

Fix garbled characters (U+FFFD replacement characters displayed as "???") appearing in the terminal during display refresh/redraw.

## Root Cause

The Rust PTY reader thread reads output in 8192-byte chunks. Multi-byte UTF-8 sequences (e.g., emoji and CJK characters from Starship prompts like 🔥🌿📁) can be split across chunk boundaries. The previous implementation created a new `TextDecoder` for each chunk without `{ stream: true }`, causing incomplete trailing bytes to be replaced with U+FFFD.

## Changes

- **`src/vs/workbench/contrib/terminal/tauri-browser/tauriPty.ts`**:
  - Add a persistent `TextDecoder` instance (`_decoder`) as a class field
  - Use `{ stream: true }` option in `decode()` calls to buffer incomplete trailing bytes across chunks

This mirrors how node-pty handles UTF-8 internally — the PTY backend reads raw bytes, and the consumer side is responsible for correct streaming decoding.

## Testing

- Open a terminal with Starship prompt (or any prompt using multi-byte Unicode characters)
- Trigger display refresh/redraw
- Verify no garbled "???" characters appear at separator line boundaries