### PR TITLE
feat: enable ad-hoc code signing for macOS builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,12 @@ Architectural differences between Electron (bundled Chromium) and Tauri (native 
 | Linux                 | [`.AppImage`](https://github.com/j4rviscmd/vscodeee/releases/latest/download/VSCodeee_Linux_x64.AppImage) / [`.deb`](https://github.com/j4rviscmd/vscodeee/releases/latest/download/VSCodeee_Linux_x64.deb) |
 | Windows               | [`.exe`](https://github.com/j4rviscmd/vscodeee/releases/latest/download/VSCodeee_Windows_x64-setup.exe)                                                                                                     |
 
+> [!NOTE]
+> macOS builds use ad-hoc code signing (not Apple-notarized). On first launch, go to **System Settings > Privacy & Security** and click **Open Anyway**. Alternatively, run:
+> ```bash
+> xattr -dr com.apple.quarantine "/Applications/VS Codeee.app"
+> ```
+
 ## Contributing
 
 Issues and PRs are welcome.<br>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -55,7 +55,8 @@
       "icons/128x128@2x.png"
     ],
     "macOS": {
-      "bundleName": "VS Codeee"
+      "bundleName": "VS Codeee",
+      "signingIdentity": "-"
     }
   }
 }


### PR DESCRIPTION
## Summary

Enable ad-hoc code signing for macOS builds to improve user onboarding experience. Previously, unsigned macOS builds required users to run terminal commands (`xattr`) to bypass Gatekeeper. With ad-hoc signing, users can now open the app via **System Settings > Privacy & Security > Open Anyway** using the GUI.

## Changes

- Add `"signingIdentity": "-"` to `tauri.conf.json` macOS bundle config
- Add user-facing note in README.md with instructions for first launch on macOS

## How to Test

1. Build the app on macOS: `cd src-tauri && cargo tauri build`
2. Open the built `.app` — macOS should show a Gatekeeper dialog
3. Verify that **System Settings > Privacy & Security** shows an "Open Anyway" button
4. Alternatively, verify the `xattr` command from README still works as a fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)