### PR TITLE
chore: add j4rviscmd to contributors in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,12 @@
 	"author": {
 		"name": "Microsoft Corporation"
 	},
+	"contributors": [
+		{
+			"name": "j4rviscmd",
+			"url": "https://github.com/j4rviscmd"
+		}
+	],
 	"license": "MIT",
 	"main": "./out/main.js",
 	"type": "module",


### PR DESCRIPTION
## Summary
- Add j4rviscmd as a contributor to package.json while keeping Microsoft Corporation as the original author
- Follows the same pattern as other VS Code forks (e.g., VSCodium) where the upstream author is preserved

## Changes
- Added `contributors` field with j4rviscmd entry (name + GitHub URL)
- No functional/runtime/build impact — pure metadata change