### PR TITLE
fix: resolve runtime errors in Tauri production builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,8 +179,11 @@ jobs:
           persist-credentials: false
 
       # Create empty out/ directory so tauri::generate_context!() can resolve frontendDist: "../out"
+      # Create empty css-modules.json so bundle.resources validation passes
       - name: Create frontend dist stub
-        run: mkdir -p out
+        run: |
+          mkdir -p out
+          echo '[]' > src-tauri/css-modules.json
 
       - name: Install system dependencies
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ CLAUDE.md
 # Tauri
 /src-tauri/target/
 /src-tauri/gen/
+/src-tauri/css-modules.json
 
 # Worktrees
 .worktrees/

--- a/scripts/generate-css-modules.mjs
+++ b/scripts/generate-css-modules.mjs
@@ -13,14 +13,14 @@ import { readdirSync, writeFileSync } from 'fs';
 import { join, relative, sep } from 'path';
 
 function collectCssFiles(dir, root, result) {
-    for (const entry of readdirSync(dir, { withFileTypes: true })) {
-        const fullPath = join(dir, entry.name);
-        if (entry.isDirectory()) {
-            collectCssFiles(fullPath, root, result);
-        } else if (entry.name.endsWith('.css')) {
-            result.push(relative(root, fullPath).split(sep).join('/'));
-        }
-    }
+	for (const entry of readdirSync(dir, { withFileTypes: true })) {
+		const fullPath = join(dir, entry.name);
+		if (entry.isDirectory()) {
+			collectCssFiles(fullPath, root, result);
+		} else if (entry.name.endsWith('.css')) {
+			result.push(relative(root, fullPath).split(sep).join('/'));
+		}
+	}
 }
 
 const modules = [];

--- a/scripts/generate-css-modules.mjs
+++ b/scripts/generate-css-modules.mjs
@@ -1,0 +1,30 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) VS Codeee Contributors. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Generate a JSON manifest of all CSS module paths in the transpiled output.
+//
+// This is needed because Tauri embeds frontendDist assets into the binary,
+// making them inaccessible via filesystem scanning at runtime. The manifest
+// is bundled as a Tauri resource so `list_css_modules` can read it in built apps.
+
+import { readdirSync, writeFileSync } from 'fs';
+import { join, relative, sep } from 'path';
+
+function collectCssFiles(dir, root, result) {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const fullPath = join(dir, entry.name);
+        if (entry.isDirectory()) {
+            collectCssFiles(fullPath, root, result);
+        } else if (entry.name.endsWith('.css')) {
+            result.push(relative(root, fullPath).split(sep).join('/'));
+        }
+    }
+}
+
+const modules = [];
+collectCssFiles('out', 'out', modules);
+modules.sort();
+writeFileSync('src-tauri/css-modules.json', JSON.stringify(modules));
+console.log(`Generated css-modules.json with ${modules.length} entries`);

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -189,7 +189,8 @@ fn collect_css_files(dir: &Path, root: &Path, result: &mut Vec<String>) {
     }
 }
 
-/// Read product.json and package.json from the project root.
+/// Read product.json and package.json from the project root (dev) or resource
+/// directory (release).
 ///
 /// Returns both files as raw JSON values so the bootstrap script can set
 /// `globalThis._VSCODE_PRODUCT_JSON` and `globalThis._VSCODE_PACKAGE_JSON`
@@ -197,8 +198,11 @@ fn collect_css_files(dir: &Path, root: &Path, result: &mut Vec<String>) {
 /// `product.ts` checks these globals to configure services like the
 /// Extension Gallery (marketplace).
 ///
-/// The project root is resolved as `../` relative to `src-tauri/` (the
-/// Tauri process working directory during `cargo tauri dev`).
+/// In development mode, the project root is resolved as `../` relative to
+/// `src-tauri/` (the Tauri process working directory during `cargo tauri dev`).
+/// In built apps, the files are read from Tauri's resource directory where
+/// they are bundled via `tauri.conf.json` `bundle.resources`.
+/// Detection is based on whether `../product.json` exists relative to CWD.
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ProductPackageJson {
@@ -209,10 +213,34 @@ pub struct ProductPackageJson {
 }
 
 #[tauri::command]
-pub fn get_product_json() -> Result<ProductPackageJson, String> {
+pub fn get_product_json(app_handle: tauri::AppHandle) -> Result<ProductPackageJson, String> {
+    use tauri::Manager;
+
+    // Try CWD-based resolution first (works during `cargo tauri dev` where
+    // CWD is `src-tauri/` and `../product.json` exists).
+    // Fall back to Tauri's resource directory for built apps where CWD is
+    // unrelated to the project tree. Tauri preserves `../` resource paths
+    // as `_up_/` subdirectories in the resource directory.
     let project_root = std::env::current_dir()
-        .map_err(|e| format!("Failed to get cwd: {e}"))?
-        .join("..");
+        .ok()
+        .map(|cwd| cwd.join(".."))
+        .filter(|root| root.join("product.json").exists())
+        .or_else(|| {
+            let rd = app_handle.path().resource_dir().ok()?;
+            // Tauri maps `../product.json` (from bundle.resources) to `_up_/product.json`
+            let up_dir = rd.join("_up_");
+            if up_dir.join("product.json").exists() {
+                Some(up_dir)
+            } else if rd.join("product.json").exists() {
+                Some(rd)
+            } else {
+                None
+            }
+        })
+        .ok_or_else(|| {
+            "Could not determine project root: CWD fallback and resource_dir both failed"
+                .to_string()
+        })?;
 
     let product_path = project_root.join("product.json");
     let package_path = project_root.join("package.json");
@@ -237,6 +265,7 @@ pub fn get_product_json() -> Result<ProductPackageJson, String> {
 
     // Inject commit hash from git at runtime if not already set in product.json.
     // This ensures the client's commit matches the REH server built from the same tree.
+    // NOTE: Only works in dev mode where a git repository is available.
     if product
         .get("commit")
         .and_then(|v| v.as_str())
@@ -283,18 +312,43 @@ pub fn get_product_json() -> Result<ProductPackageJson, String> {
 /// paths relative to `out/` (e.g., `vs/base/browser/ui/widget.css`).
 /// The bootstrap uses these to create a CSS import map, mirroring the
 /// Electron `cssModules` mechanism.
+///
+/// During `cargo tauri dev`, scans `../out` relative to `src-tauri/` (CWD).
+/// In built apps, reads from a pre-generated `css-modules.json` manifest
+/// bundled as a Tauri resource (since frontendDist assets are embedded in
+/// the binary and not accessible via filesystem).
 #[tauri::command]
-pub fn list_css_modules() -> Vec<String> {
-    let out_dir = std::env::current_dir()
+pub fn list_css_modules(app_handle: tauri::AppHandle) -> Vec<String> {
+    use tauri::Manager;
+
+    // Try CWD-based filesystem scan first (works during `cargo tauri dev`).
+    if let Some(out_dir) = std::env::current_dir()
         .ok()
         .map(|cwd| {
             let dir = cwd.join("../out");
             dir.canonicalize().unwrap_or(dir)
         })
-        .unwrap_or_default();
+        .filter(|dir| dir.is_dir())
+    {
+        let mut modules = Vec::new();
+        collect_css_files(&out_dir, &out_dir, &mut modules);
+        if !modules.is_empty() {
+            modules.sort();
+            return modules;
+        }
+    }
 
-    let mut modules = Vec::new();
-    collect_css_files(&out_dir, &out_dir, &mut modules);
-    modules.sort();
-    modules
+    // Fall back to css-modules.json manifest in the resource directory (built apps).
+    // The manifest is generated at build time by scripts/generate-css-modules.mjs
+    // and bundled via tauri.conf.json bundle.resources.
+    if let Ok(resource_dir) = app_handle.path().resource_dir() {
+        let json_path = resource_dir.join("css-modules.json");
+        if let Ok(data) = std::fs::read_to_string(&json_path) {
+            if let Ok(modules) = serde_json::from_str::<Vec<String>>(&data) {
+                return modules;
+            }
+        }
+    }
+
+    Vec::new()
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -7,7 +7,7 @@
   "build": {
     "frontendDist": "../out",
     "beforeDevCommand": "",
-    "beforeBuildCommand": "node build/next/index.ts transpile && node build/next/index.ts transpile-extensions"
+    "beforeBuildCommand": "node build/next/index.ts transpile && node build/next/index.ts transpile-extensions && node scripts/generate-css-modules.mjs"
   },
   "app": {
     "withGlobalTauri": true,
@@ -31,7 +31,8 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; img-src 'self' data: blob: https: vscode-file:; script-src 'self' 'unsafe-eval' 'unsafe-inline' blob: vscode-file:; style-src 'self' 'unsafe-inline' vscode-file:; connect-src 'self' https: ws: wss: tauri: ipc: vscode-file:; font-src 'self' https: vscode-file:; frame-src 'self'"
+      "csp": "default-src 'self'; img-src 'self' data: blob: https: vscode-file:; script-src 'self' 'unsafe-eval' 'unsafe-inline' blob: vscode-file:; style-src 'self' 'unsafe-inline' vscode-file:; connect-src 'self' https: ws: wss: tauri: ipc: vscode-file:; font-src 'self' https: vscode-file:; frame-src 'self'",
+      "dangerousDisableAssetCspModification": true
     }
   },
   "plugins": {
@@ -49,6 +50,7 @@
     "active": true,
     "createUpdaterArtifacts": true,
     "targets": "all",
+    "resources": ["css-modules.json", "../product.json", "../package.json"],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
## Summary

Fix three critical runtime errors that occurred when running `tauri build --debug` output:

1. **product.json/package.json loading failure**: `get_product_json` used `std::env::current_dir()` which points to an unrelated location in built apps. Now uses `AppHandle` to resolve Tauri's resource directory as fallback.

2. **CSS modules not found**: `list_css_modules` scanned the filesystem for CSS files, but `frontendDist` assets are embedded in the binary. Now falls back to a pre-generated `css-modules.json` manifest bundled as a Tauri resource.

3. **CSP blocking importmap**: Tauri's automatic CSP hash replacement blocked dynamically injected `<script type="importmap">`. Disabled via `dangerousDisableAssetCspModification: true`.

## Changes

- `src-tauri/src/commands/mod.rs`: Add `AppHandle` parameter to `get_product_json` and `list_css_modules`, implement CWD→resource_dir fallback
- `src-tauri/tauri.conf.json`: Add `bundle.resources`, `beforeBuildCommand` css-modules generation, `dangerousDisableAssetCspModification`
- `scripts/generate-css-modules.mjs`: New build-time script to scan `out/` and generate `css-modules.json`
- `.gitignore`: Add `src-tauri/css-modules.json` (build artifact)

## Testing

- Built with `tauri build --debug` successfully
- Launched the built `.app` bundle and confirmed:
  - [x] CSS import map installed with 334 modules (was: "No CSS modules found")
  - [x] product.json loaded successfully (was: "Failed to load product.json")
  - [x] Workbench loaded without MIME type error (was: "'text/css' is not a valid JavaScript MIME type")