### PR TITLE
feat: add embedded asset fallback and production build fixes for vscode-file:// protocol

### DIFF
--- a/src-tauri/src/commands/spawn_exthost.rs
+++ b/src-tauri/src/commands/spawn_exthost.rs
@@ -472,8 +472,9 @@ async fn spawn_and_handshake(
 /// Resolve the VS Code repository root (where `out/` and `product.json` live).
 ///
 /// Searches up to 5 parent directories from the Tauri resource directory,
-/// then falls back to the current working directory. Returns the first
-/// directory that contains `out/bootstrap-fork.js`.
+/// then falls back to the current working directory, and finally checks
+/// Tauri's `_up_` resource mapping for production builds.
+/// Returns the first directory that contains `out/bootstrap-fork.js`.
 fn resolve_app_root(app_handle: &tauri::AppHandle) -> Result<PathBuf, String> {
     use tauri::Manager;
 
@@ -496,9 +497,18 @@ fn resolve_app_root(app_handle: &tauri::AppHandle) -> Result<PathBuf, String> {
     }
 
     // Fallback: try current working directory
-    let cwd = std::env::current_dir().map_err(|e| format!("No CWD: {e}"))?;
-    if cwd.join("out/bootstrap-fork.js").exists() {
-        return Ok(cwd);
+    if let Ok(cwd) = std::env::current_dir() {
+        if cwd.join("out/bootstrap-fork.js").exists() {
+            return Ok(cwd);
+        }
+    }
+
+    // Production fallback: Tauri maps `../out` (from bundle.resources) to
+    // `_up_/out` inside the resource directory. The "app root" is then
+    // `{resource_dir}/_up_/` since `out/bootstrap-fork.js` lives under it.
+    let up_dir = resource_dir.join("_up_");
+    if up_dir.join("out/bootstrap-fork.js").exists() {
+        return Ok(up_dir);
     }
 
     Err(format!(

--- a/src-tauri/src/commands/window.rs
+++ b/src-tauri/src/commands/window.rs
@@ -65,9 +65,21 @@ pub async fn get_extended_window_configuration(
 
     let frontend_dist = std::env::current_dir()
         .ok()
-        .map(|cwd| {
+        .and_then(|cwd| {
+            // Development: CWD is src-tauri/, so ../out resolves to the repo's out/ dir
             let dist = cwd.join("../out");
-            dist.canonicalize().unwrap_or(dist)
+            dist.canonicalize().ok()
+        })
+        .or_else(|| {
+            // Production fallback: use resource_dir/out as a virtual path.
+            // The actual files are embedded via frontendDist, but the TypeScript
+            // side needs a path containing "/out/" so that the vscode-file://
+            // protocol handler can extract the asset key for embedded asset lookup.
+            app_handle
+                .path()
+                .resource_dir()
+                .ok()
+                .map(|rd| rd.join("out"))
         })
         .map(|p| p.to_string_lossy().to_string())
         .unwrap_or_default();

--- a/src-tauri/src/protocol/mod.rs
+++ b/src-tauri/src/protocol/mod.rs
@@ -110,11 +110,14 @@ pub fn init_protocol_state(app: &tauri::App) -> Arc<ProtocolState> {
 /// 1. Parses and canonicalizes the URI.
 /// 2. Validates the path against registered roots + extension whitelist.
 /// 3. Reads the file and returns it with appropriate security headers.
+/// 4. If the file is not found on disk, falls back to Tauri's embedded
+///    asset resolver (for production builds where `frontendDist` assets
+///    are bundled into the binary).
 pub fn handle_vscode_file_protocol<R: tauri::Runtime>(
     state: Arc<ProtocolState>,
 ) -> impl Fn(UriSchemeContext<'_, R>, Request<Vec<u8>>) -> Response<Vec<u8>> + Send + Sync + 'static
 {
-    move |_ctx: UriSchemeContext<'_, R>, request: Request<Vec<u8>>| {
+    move |ctx: UriSchemeContext<'_, R>, request: Request<Vec<u8>>| {
         let raw_uri = request.uri().to_string();
         let request_origin = request
             .headers()
@@ -124,6 +127,34 @@ pub fn handle_vscode_file_protocol<R: tauri::Runtime>(
 
         match serve_file(&state, &raw_uri, request_origin.as_deref()) {
             Ok(response) => response,
+            Err(ProtocolError::NotFound(_)) => {
+                // File not found on disk — try embedded asset fallback.
+                // In production builds, frontendDist assets are embedded in the
+                // binary and not available on the filesystem.
+                log::debug!(
+                    target: "vscodeee::protocol",
+                    "File not found on disk, trying embedded asset: {raw_uri}"
+                );
+                match serve_embedded_asset(
+                    ctx.app_handle(),
+                    &raw_uri,
+                    request_origin.as_deref(),
+                    state.is_dev,
+                ) {
+                    Ok(response) => response,
+                    Err(fallback_err) => {
+                        log::warn!(
+                            target: "vscodeee::protocol",
+                            "Embedded asset fallback also failed: {fallback_err}"
+                        );
+                        error_response(
+                            fallback_err.status_code(),
+                            fallback_err.reason().as_bytes(),
+                            request_origin.as_deref(),
+                        )
+                    }
+                }
+            }
             Err(e) => {
                 log::error!(target: "vscodeee::protocol", "{e}");
                 error_response(
@@ -177,6 +208,82 @@ fn serve_file(
 
     builder
         .body(content)
+        .map_err(|e| ProtocolError::Internal(format!("failed to build response: {e}")))
+}
+
+/// Extract the Tauri embedded asset key from a decoded URI path.
+///
+/// The `frontendDist` config is `"../out"`, so assets are keyed by their
+/// relative path within the `out/` directory. For example:
+///   `/Users/foo/work/vscodeee/out/vs/code/foo.js` → `"vs/code/foo.js"`
+///   `/Applications/VS Codeee.app/Contents/Resources/out/vs/base/worker/...` → `"vs/base/worker/..."`
+///
+/// Returns `None` if the path does not contain `/out/`.
+fn extract_asset_key(decoded_path: &str) -> Option<&str> {
+    // Find the last occurrence of "/out/" to handle paths like
+    // `/foo/checkout/out/vs/...` or `/app/Resources/out/vs/...`
+    if let Some(idx) = decoded_path.rfind("/out/") {
+        let key = &decoded_path[idx + 5..]; // skip "/out/"
+        if !key.is_empty() {
+            return Some(key);
+        }
+    }
+    None
+}
+
+/// Serve a file from Tauri's embedded asset resolver.
+///
+/// This is the fallback path for production builds where `frontendDist` assets
+/// are compiled into the binary and not present on the filesystem. The function:
+///
+/// 1. Parses the raw URI without canonicalization (the file doesn't exist on disk).
+/// 2. Extracts the asset key (relative path after `/out/`).
+/// 3. Resolves the asset via `AppHandle::asset_resolver().get()`.
+/// 4. Returns the response with correct MIME type and security headers.
+fn serve_embedded_asset<R: tauri::Runtime>(
+    app_handle: &tauri::AppHandle<R>,
+    raw_uri: &str,
+    request_origin: Option<&str>,
+    is_dev: bool,
+) -> Result<Response<Vec<u8>>, ProtocolError> {
+    // 1. Parse URI without filesystem canonicalization
+    let decoded_path = uri::parse_vscode_file_uri_raw(raw_uri)?;
+
+    // 2. Extract asset key: relative path after "/out/"
+    let asset_key = extract_asset_key(&decoded_path).ok_or_else(|| {
+        ProtocolError::NotFound(format!(
+            "no embedded asset path (missing /out/ segment): {decoded_path}"
+        ))
+    })?;
+
+    // 3. Resolve from Tauri's embedded assets
+    let asset = app_handle
+        .asset_resolver()
+        .get(asset_key.to_string())
+        .ok_or_else(|| ProtocolError::NotFound(format!("embedded asset not found: {asset_key}")))?;
+
+    log::info!(
+        target: "vscodeee::protocol",
+        "Serving embedded asset: {asset_key} (mime: {})",
+        asset.mime_type()
+    );
+
+    // 4. Build response with security headers
+    // Use a synthetic path for header computation so COOP/COEP etc. are applied correctly
+    let path = std::path::PathBuf::from(asset_key);
+    let mime_type = mime::mime_from_path(&path);
+    let security_headers = headers::headers_for_path(&path, is_dev, request_origin);
+
+    let mut builder = Response::builder()
+        .status(200)
+        .header("Content-Type", mime_type);
+
+    for (key, value) in &security_headers {
+        builder = builder.header(key.as_str(), value.as_str());
+    }
+
+    builder
+        .body(asset.bytes().to_vec())
         .map_err(|e| ProtocolError::Internal(format!("failed to build response: {e}")))
 }
 
@@ -336,5 +443,55 @@ mod tests {
             .to_str()
             .unwrap();
         assert_eq!(cors, "http://127.0.0.1:1430");
+    }
+
+    // ── extract_asset_key tests ──
+
+    #[test]
+    fn extract_asset_key_from_typical_path() {
+        let path = "/Users/foo/work/vscodeee/out/vs/code/foo.js";
+        assert_eq!(extract_asset_key(path), Some("vs/code/foo.js"));
+    }
+
+    #[test]
+    fn extract_asset_key_from_production_path() {
+        let path = "/Applications/VS Codeee.app/Contents/Resources/out/vs/base/common/lifecycle.js";
+        assert_eq!(extract_asset_key(path), Some("vs/base/common/lifecycle.js"));
+    }
+
+    #[test]
+    fn extract_asset_key_bootstrap_fork() {
+        let path = "/some/path/out/bootstrap-fork.js";
+        assert_eq!(extract_asset_key(path), Some("bootstrap-fork.js"));
+    }
+
+    #[test]
+    fn extract_asset_key_uses_last_out_segment() {
+        // If path contains multiple /out/ segments, use the last one
+        let path = "/checkout/out/build/out/vs/code/foo.js";
+        assert_eq!(extract_asset_key(path), Some("vs/code/foo.js"));
+    }
+
+    #[test]
+    fn extract_asset_key_no_out_segment() {
+        let path = "/Users/foo/work/vscodeee/src/vs/code/foo.js";
+        assert_eq!(extract_asset_key(path), None);
+    }
+
+    #[test]
+    fn extract_asset_key_out_at_end() {
+        // "/out/" at end with nothing after it
+        let path = "/some/path/out/";
+        assert_eq!(extract_asset_key(path), None);
+    }
+
+    #[test]
+    fn extract_asset_key_html_with_query() {
+        // Query should already be stripped by URI parser, but test the key extraction
+        let path = "/some/path/out/vs/code/tauri-browser/workbench/workbench-tauri.html";
+        assert_eq!(
+            extract_asset_key(path),
+            Some("vs/code/tauri-browser/workbench/workbench-tauri.html")
+        );
     }
 }

--- a/src-tauri/src/protocol/uri.rs
+++ b/src-tauri/src/protocol/uri.rs
@@ -70,6 +70,37 @@ pub fn parse_vscode_file_uri(raw_uri: &str) -> Result<PathBuf, ProtocolError> {
     Ok(canonical)
 }
 
+/// Parse a `vscode-file://vscode-app/<path>` URI into a decoded path **without**
+/// filesystem canonicalization.
+///
+/// Used for embedded asset lookup when the file doesn't exist on disk (production
+/// builds where assets are bundled into the binary via `frontendDist`).
+/// Returns the percent-decoded absolute path string.
+pub fn parse_vscode_file_uri_raw(raw_uri: &str) -> Result<String, ProtocolError> {
+    let encoded_path = raw_uri
+        .strip_prefix(URI_PREFIX)
+        .or_else(|| raw_uri.strip_prefix("/"))
+        .unwrap_or(raw_uri);
+
+    // Strip query string and fragment
+    let encoded_path = encoded_path.split('?').next().unwrap_or(encoded_path);
+    let encoded_path = encoded_path.split('#').next().unwrap_or(encoded_path);
+
+    if encoded_path.is_empty() {
+        return Err(ProtocolError::BadUri("empty path".into()));
+    }
+
+    let decoded = percent_decode(encoded_path);
+
+    if !decoded.starts_with('/') {
+        return Err(ProtocolError::BadUri(format!(
+            "path is not absolute: {decoded}"
+        )));
+    }
+
+    Ok(decoded)
+}
+
 /// Simple percent-decoding for URI path components.
 ///
 /// Decodes `%XX` sequences where `XX` is a two-digit hex value.
@@ -198,5 +229,46 @@ mod tests {
         let result = parse_vscode_file_uri("vscode-file://vscode-app/tmp?id=test-id#section");
         assert!(result.is_ok());
         assert!(result.unwrap().is_absolute());
+    }
+
+    // ── parse_vscode_file_uri_raw tests ──
+
+    #[test]
+    fn raw_parse_returns_decoded_path_without_canonicalize() {
+        // This path doesn't exist on disk, but raw parse should succeed
+        let uri = "vscode-file://vscode-app/nonexistent/path/to/out/vs/code/foo.js";
+        let result = parse_vscode_file_uri_raw(uri);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "/nonexistent/path/to/out/vs/code/foo.js");
+    }
+
+    #[test]
+    fn raw_parse_decodes_percent_encoding() {
+        let uri = "vscode-file://vscode-app/path%20with%20spaces/out/file.js";
+        let result = parse_vscode_file_uri_raw(uri);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "/path with spaces/out/file.js");
+    }
+
+    #[test]
+    fn raw_parse_strips_query_and_fragment() {
+        let uri = "vscode-file://vscode-app/some/path?id=test#section";
+        let result = parse_vscode_file_uri_raw(uri);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "/some/path");
+    }
+
+    #[test]
+    fn raw_parse_rejects_empty_path() {
+        let result = parse_vscode_file_uri_raw("vscode-file://vscode-app");
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().status_code(), 400);
+    }
+
+    #[test]
+    fn raw_parse_rejects_relative_path() {
+        let result = parse_vscode_file_uri_raw("vscode-file://vscode-apprelative/path");
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().status_code(), 400);
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -50,7 +50,7 @@
     "active": true,
     "createUpdaterArtifacts": true,
     "targets": "all",
-    "resources": ["css-modules.json", "../product.json", "../package.json"],
+    "resources": ["css-modules.json", "../product.json", "../package.json", "../out"],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
## Summary

Continuation of #237 and #239. Resolves remaining runtime errors in Tauri production builds (`tauri build --debug`) by addressing:

- **Category A** (Asset 404s): Webview assets served via `vscode-file://` protocol return 404 in production because files are embedded in the binary, not on the filesystem.
- **Category B** (Extension Host): `resolve_app_root()` fails to find `out/bootstrap-fork.js` in production builds.

## Changes

### Embedded Asset Fallback (`protocol/mod.rs`)
- When `serve_file()` returns `NotFound`, the handler now falls back to Tauri's `AssetResolver` API to serve assets from the embedded binary.
- New `serve_embedded_asset()` function extracts the asset key from the URI path (everything after `/out/`) and resolves it via `app_handle.asset_resolver().get()`.
- New `extract_asset_key()` helper with comprehensive tests.

### URI Parsing (`protocol/uri.rs`)
- New `parse_vscode_file_uri_raw()` function: parses URIs without filesystem canonicalization, needed for paths that don't exist on disk in production.
- Full test coverage for the new function.

### Production `frontend_dist` Fix (`commands/window.rs`)
- `frontend_dist` now falls back to `resource_dir/out` in production instead of relying on CWD-based path resolution which fails when CWD is unrelated to the project tree.

### Extension Host Production Fix (`commands/spawn_exthost.rs`)
- `resolve_app_root()` now checks `{resource_dir}/_up_/out/bootstrap-fork.js` as a final fallback, matching Tauri's resource path mapping convention.

### Bundle Resources (`tauri.conf.json`)
- Added `"../out"` to `bundle.resources` so the Node.js extension host can access `bootstrap-fork.js` and other files on the filesystem in production builds.

## Testing

- All 57 protocol tests pass (including 12 new tests)
- `cargo clippy -- -D warnings` passes
- `cargo fmt --check` passes