### PR TITLE
feat: bundle Node.js binary as Tauri sidecar for production builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,10 +180,13 @@ jobs:
 
       # Create empty out/ directory so tauri::generate_context!() can resolve frontendDist: "../out"
       # Create empty css-modules.json so bundle.resources validation passes
-      - name: Create frontend dist stub
+      # Create empty node sidecar stub so externalBin validation passes
+      - name: Create build stubs
         run: |
           mkdir -p out
           echo '[]' > src-tauri/css-modules.json
+          mkdir -p src-tauri/binaries
+          touch src-tauri/binaries/node-x86_64-unknown-linux-gnu
 
       - name: Install system dependencies
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -178,6 +178,16 @@ jobs:
           ELECTRON_SKIP_BINARY_DOWNLOAD: 1
         run: npm ci --ignore-scripts
 
+      - name: Download Node.js sidecar binary
+        shell: bash
+        run: |
+          # Extract --target value from args; fall back to host triple for native builds
+          TARGET=$(echo "${{ matrix.args }}" | sed -n 's/.*--target \([^ ]*\).*/\1/p')
+          if [ -z "$TARGET" ]; then
+            TARGET=$(rustc --print host-tuple)
+          fi
+          node scripts/download-node.mjs --target "$TARGET"
+
       - name: Build and publish with Tauri
         uses: tauri-apps/tauri-action@v0
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ CLAUDE.md
 /src-tauri/target/
 /src-tauri/gen/
 /src-tauri/css-modules.json
+/src-tauri/binaries/
 
 # Worktrees
 .worktrees/

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
 		"install-latest-component-explorer": "npm install @vscode/component-explorer@next @vscode/component-explorer-cli@next && cd build/rspack && npm install @vscode/component-explorer-webpack-plugin@next @vscode/component-explorer@next && cd ../vite && npm install @vscode/component-explorer-vite-plugin@next @vscode/component-explorer@next",
 		"tauri": "tauri",
 		"tauri:dev": "npm install && bash scripts/check-csp-hash.sh && node build/next/index.ts transpile && node build/next/index.ts transpile-extensions && tauri dev",
-		"tauri:build": "npm install && bash scripts/check-csp-hash.sh && node build/next/index.ts transpile && node build/next/index.ts transpile-extensions && node build/next/index.ts package-extensions && tauri build"
+		"tauri:build": "npm install && bash scripts/check-csp-hash.sh && node scripts/download-node.mjs && node build/next/index.ts transpile && node build/next/index.ts transpile-extensions && node build/next/index.ts package-extensions && tauri build"
 	},
 	"dependencies": {
 		"@anthropic-ai/sandbox-runtime": "0.0.42",

--- a/scripts/download-node.mjs
+++ b/scripts/download-node.mjs
@@ -1,0 +1,253 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) VS Codeee Contributors. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// @ts-check
+
+/**
+ * Download a Node.js binary for the current (or specified) platform and place it
+ * into `src-tauri/binaries/` with the Tauri sidecar naming convention:
+ *
+ *   node-<target-triple>[.exe]
+ *
+ * Usage:
+ *   node scripts/download-node.mjs                    # auto-detect platform
+ *   node scripts/download-node.mjs --target aarch64-apple-darwin
+ *   node scripts/download-node.mjs --node-version 22.22.1
+ *
+ * The Node.js version defaults to the value in `.nvmrc` (trimmed).
+ */
+
+import { execSync } from 'child_process';
+import fs from 'fs';
+import https from 'https';
+import path from 'path';
+import { createGunzip } from 'zlib';
+import { pipeline } from 'stream/promises';
+import { createHash } from 'crypto';
+
+const REPO_ROOT = path.resolve(import.meta.dirname, '..');
+const BINARIES_DIR = path.join(REPO_ROOT, 'src-tauri', 'binaries');
+
+/**
+ * Map from Rust target triple to Node.js download platform/arch.
+ * @type {Record<string, { platform: string; arch: string }>}
+ */
+const TARGET_MAP = {
+	'aarch64-apple-darwin': { platform: 'darwin', arch: 'arm64' },
+	'x86_64-apple-darwin': { platform: 'darwin', arch: 'x64' },
+	'x86_64-unknown-linux-gnu': { platform: 'linux', arch: 'x64' },
+	'aarch64-unknown-linux-gnu': { platform: 'linux', arch: 'arm64' },
+	'armv7-unknown-linux-gnueabihf': { platform: 'linux', arch: 'armv7l' },
+	'x86_64-pc-windows-msvc': { platform: 'win', arch: 'x64' },
+	'aarch64-pc-windows-msvc': { platform: 'win', arch: 'arm64' },
+};
+
+/**
+ * Detect the Rust target triple for the current host.
+ * Prefers `TAURI_ENV_TARGET_TRIPLE` (set by Tauri CLI during cross-compilation)
+ * over the host triple from `rustc`.
+ * @returns {string}
+ */
+function detectTargetTriple() {
+	// Tauri CLI sets this during `tauri build --target <triple>` for cross-compilation.
+	// The beforeBuildCommand inherits this env var, ensuring the correct binary is downloaded.
+	const tauriTarget = process.env.TAURI_ENV_TARGET_TRIPLE;
+	if (tauriTarget) {
+		console.log(`[download-node] Using TAURI_ENV_TARGET_TRIPLE: ${tauriTarget}`);
+		return tauriTarget;
+	}
+	return execSync('rustc --print host-tuple').toString().trim();
+}
+
+/**
+ * Read the Node.js version from `.nvmrc`.
+ * @returns {string}
+ */
+function readNodeVersion() {
+	const nvmrcPath = path.join(REPO_ROOT, '.nvmrc');
+	return fs.readFileSync(nvmrcPath, 'utf-8').trim().replace(/^v/, '');
+}
+
+/**
+ * Download a file from a URL, following redirects.
+ * @param {string} url
+ * @returns {Promise<import('http').IncomingMessage>}
+ */
+function download(url) {
+	return new Promise((resolve, reject) => {
+		https.get(url, (res) => {
+			if (res.statusCode === 302 || res.statusCode === 301) {
+				const location = res.headers.location;
+				if (!location) {
+					reject(new Error(`Redirect without Location header from ${url}`));
+					return;
+				}
+				resolve(download(location));
+				return;
+			}
+			if (res.statusCode !== 200) {
+				reject(new Error(`HTTP ${res.statusCode} for ${url}`));
+				return;
+			}
+			resolve(res);
+		}).on('error', reject);
+	});
+}
+
+/**
+ * Extract the `node` binary from a `.tar.gz` archive stream.
+ *
+ * We use a simple tar parser since we only need one file (`bin/node`).
+ * The tar format has 512-byte headers followed by data blocks.
+ *
+ * @param {import('stream').Readable} stream - Gunzipped tar stream
+ * @param {string} destPath - Where to write the extracted binary
+ * @returns {Promise<void>}
+ */
+async function extractNodeFromTarGz(stream, destPath) {
+	const gunzip = createGunzip();
+	const chunks = /** @type {Buffer[]} */ ([]);
+
+	// Collect the entire gunzipped tar into memory (~65MB)
+	// This is simpler than streaming tar parsing and acceptable for a build script
+	await pipeline(stream, gunzip, async function* (source) {
+		for await (const chunk of source) {
+			chunks.push(Buffer.from(chunk));
+		}
+	});
+
+	const tar = Buffer.concat(chunks);
+	let offset = 0;
+
+	while (offset < tar.length - 512) {
+		// Read tar header (512 bytes)
+		const header = tar.subarray(offset, offset + 512);
+
+		// Check for end-of-archive (two consecutive zero blocks)
+		if (header.every((b) => b === 0)) {
+			break;
+		}
+
+		// Extract filename (bytes 0-99, null-terminated)
+		const nameEnd = header.indexOf(0, 0);
+		const name = header.subarray(0, Math.min(nameEnd, 100)).toString('utf-8');
+
+		// Extract file size (bytes 124-135, octal, null/space-terminated)
+		const sizeStr = header.subarray(124, 136).toString('utf-8').trim();
+		const size = parseInt(sizeStr, 8) || 0;
+
+		offset += 512; // Move past header
+
+		// Check if this is the node binary (e.g., "node-v22.22.1-darwin-arm64/bin/node")
+		if (name.endsWith('/bin/node') || name === 'bin/node') {
+			const data = tar.subarray(offset, offset + size);
+			await fs.promises.writeFile(destPath, data);
+			await fs.promises.chmod(destPath, 0o755);
+			console.log(`[download-node] Extracted ${name} (${(size / 1024 / 1024).toFixed(1)} MB)`);
+			return;
+		}
+
+		// Skip to next header (data is padded to 512-byte blocks)
+		offset += Math.ceil(size / 512) * 512;
+	}
+
+	throw new Error('Could not find bin/node in the tar archive');
+}
+
+/**
+ * Download and extract Node.js for Windows (zip archive).
+ * @param {string} url
+ * @param {string} destPath
+ * @returns {Promise<void>}
+ */
+async function downloadWindowsNode(url, destPath) {
+	// For Windows, we download the .zip and extract node.exe
+	// Using a simpler approach: download the standalone node.exe directly
+	const exeUrl = url.replace('.zip', '').replace(/node-v[\d.]+-win-\w+/, '') + '/node.exe';
+
+	// Actually, let's download the node.exe directly from the dist
+	const version = url.match(/v([\d.]+)/)?.[1];
+	const arch = url.includes('x64') ? 'x64' : 'arm64';
+	const directUrl = `https://nodejs.org/dist/v${version}/win-${arch}/node.exe`;
+
+	console.log(`[download-node] Downloading ${directUrl}`);
+	const res = await download(directUrl);
+	const writeStream = fs.createWriteStream(destPath);
+	await pipeline(res, writeStream);
+	console.log(`[download-node] Saved ${destPath}`);
+}
+
+async function main() {
+	const args = process.argv.slice(2);
+	let targetTriple = '';
+	let nodeVersion = '';
+
+	// Parse CLI arguments
+	for (let i = 0; i < args.length; i++) {
+		if (args[i] === '--target' && args[i + 1]) {
+			targetTriple = args[++i];
+		} else if (args[i] === '--node-version' && args[i + 1]) {
+			nodeVersion = args[++i];
+		}
+	}
+
+	if (!targetTriple) {
+		targetTriple = detectTargetTriple();
+	}
+	if (!nodeVersion) {
+		nodeVersion = readNodeVersion();
+	}
+
+	const mapping = TARGET_MAP[targetTriple];
+	if (!mapping) {
+		console.error(`[download-node] Unsupported target triple: ${targetTriple}`);
+		console.error(`[download-node] Supported: ${Object.keys(TARGET_MAP).join(', ')}`);
+		process.exit(1);
+	}
+
+	const { platform, arch } = mapping;
+	const isWindows = platform === 'win';
+	const ext = isWindows ? '.exe' : '';
+	const destPath = path.join(BINARIES_DIR, `node-${targetTriple}${ext}`);
+
+	// Check if already downloaded
+	if (fs.existsSync(destPath)) {
+		const stat = fs.statSync(destPath);
+		console.log(`[download-node] Node.js binary already exists: ${destPath} (${(stat.size / 1024 / 1024).toFixed(1)} MB)`);
+		console.log(`[download-node] Delete it to re-download.`);
+		return;
+	}
+
+	// Ensure binaries directory exists
+	await fs.promises.mkdir(BINARIES_DIR, { recursive: true });
+
+	if (isWindows) {
+		const url = `https://nodejs.org/dist/v${nodeVersion}/node-v${nodeVersion}-win-${arch}.zip`;
+		await downloadWindowsNode(url, destPath);
+	} else {
+		const archiveName = `node-v${nodeVersion}-${platform}-${arch}.tar.gz`;
+		const url = `https://nodejs.org/dist/v${nodeVersion}/${archiveName}`;
+
+		console.log(`[download-node] Downloading ${url}`);
+		const res = await download(url);
+		await extractNodeFromTarGz(res, destPath);
+	}
+
+	// Verify the binary works
+	try {
+		const version = execSync(`"${destPath}" --version`).toString().trim();
+		console.log(`[download-node] Verified: ${version}`);
+	} catch {
+		console.warn(`[download-node] Warning: Could not verify binary (cross-compilation target?)`);
+	}
+
+	const stat = fs.statSync(destPath);
+	console.log(`[download-node] Done: ${destPath} (${(stat.size / 1024 / 1024).toFixed(1)} MB)`);
+}
+
+main().catch((err) => {
+	console.error(`[download-node] Fatal: ${err.message}`);
+	process.exit(1);
+});

--- a/src-tauri/src/exthost/sidecar.rs
+++ b/src-tauri/src/exthost/sidecar.rs
@@ -25,6 +25,56 @@ use tokio::process::{Child, Command};
 
 use super::ExtHostError;
 
+/// Resolve the Node.js binary path for the Extension Host process.
+///
+/// Resolution order:
+/// 1. `VSCODEEE_NODE_PATH` environment variable (explicit override)
+/// 2. Bundled sidecar binary next to the current executable (production builds)
+/// 3. System `node` from PATH (development)
+///
+/// In production, `tauri build` bundles Node.js via `externalBin` into the same
+/// directory as the main executable. Tauri strips the target-triple suffix during
+/// bundling, so the binary is named simply `node` (or `node.exe` on Windows).
+fn resolve_node_binary() -> String {
+    // 1. Explicit override via environment variable
+    if let Ok(path) = std::env::var("VSCODEEE_NODE_PATH") {
+        log::info!(
+            target: "vscodeee::exthost::sidecar",
+            "Using Node.js from VSCODEEE_NODE_PATH: {path}"
+        );
+        return path;
+    }
+
+    // 2. Bundled sidecar binary (production Tauri build)
+    // Tauri's externalBin strips the target-triple suffix when bundling,
+    // so `binaries/node-aarch64-apple-darwin` becomes `Contents/MacOS/node`.
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(exe_dir) = exe.parent() {
+            let sidecar_name = if cfg!(target_os = "windows") {
+                "node.exe"
+            } else {
+                "node"
+            };
+            let sidecar_path = exe_dir.join(sidecar_name);
+            if sidecar_path.exists() {
+                log::info!(
+                    target: "vscodeee::exthost::sidecar",
+                    "Using bundled Node.js sidecar: {}",
+                    sidecar_path.display()
+                );
+                return sidecar_path.to_string_lossy().to_string();
+            }
+        }
+    }
+
+    // 3. System node (development fallback)
+    log::info!(
+        target: "vscodeee::exthost::sidecar",
+        "Using system Node.js from PATH"
+    );
+    "node".to_string()
+}
+
 /// Build an enriched PATH for the Extension Host child process.
 ///
 /// macOS app bundles inherit a minimal PATH (`/usr/bin:/bin:/usr/sbin:/sbin`)
@@ -305,13 +355,9 @@ async fn spawn_and_connect(
     listener: &UnixListener,
     augmented: Option<(std::path::PathBuf, String)>,
 ) -> Result<(ExtHostSidecar, tokio::net::UnixStream), ExtHostError> {
-    // Mirrors extensionHostConnection.ts:272-288
-    // Allow overriding the Node.js binary via VSCODEEE_NODE_PATH env var.
-    // This is useful when the system default `node` version has issues
-    // (e.g., Node.js v22 has a TCP routing bug on macOS causing EHOSTUNREACH
-    // for LAN connections) and a different version needs to be used for the
-    // Extension Host process.
-    let node_bin = std::env::var("VSCODEEE_NODE_PATH").unwrap_or_else(|_| "node".to_string());
+    // Resolve the Node.js binary: bundled sidecar in production, system node in dev.
+    // See resolve_node_binary() for the full resolution order.
+    let node_bin = resolve_node_binary();
 
     // Enrich PATH so child processes (e.g., `git` extension calling `which git`)
     // can find tools installed in non-default locations. This is critical on

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -7,7 +7,7 @@
   "build": {
     "frontendDist": "../out",
     "beforeDevCommand": "",
-    "beforeBuildCommand": "node build/next/index.ts transpile && node build/next/index.ts transpile-extensions && node build/next/index.ts package-extensions && node scripts/generate-css-modules.mjs"
+    "beforeBuildCommand": "node scripts/download-node.mjs && node build/next/index.ts transpile && node build/next/index.ts transpile-extensions && node build/next/index.ts package-extensions && node scripts/generate-css-modules.mjs"
   },
   "app": {
     "withGlobalTauri": true,
@@ -50,6 +50,7 @@
     "active": true,
     "createUpdaterArtifacts": true,
     "targets": "all",
+    "externalBin": ["binaries/node"],
     "resources": ["css-modules.json", "../product.json", "../package.json", "../out", "../.build/extensions"],
     "icon": [
       "icons/32x32.png",


### PR DESCRIPTION
## Summary

The Extension Host failed to start in production builds with `ExtHost spawn failed: Node.js spawn failed: No such file or directory (os error 2)` because Node.js was not bundled with the app. This PR adds a download script and Tauri `externalBin` configuration to bundle Node.js as a sidecar binary.

## Changes

- **`scripts/download-node.mjs`** (new): Downloads the correct Node.js binary for the target platform into `src-tauri/binaries/node-<target-triple>`. Supports `TAURI_ENV_TARGET_TRIPLE` for cross-compilation and `--target` CLI flag.
- **`src-tauri/tauri.conf.json`**: Added `externalBin: ["binaries/node"]` to bundle config and `download-node.mjs` to `beforeBuildCommand`.
- **`src-tauri/src/exthost/sidecar.rs`**: Added `resolve_node_binary()` that checks for the bundled sidecar next to the executable (production), `VSCODEEE_NODE_PATH` env var (override), or system `node` (development fallback).
- **`package.json`**: Added `download-node.mjs` to `tauri:build` script.
- **`.github/workflows/publish.yml`**: Added explicit "Download Node.js sidecar binary" step with cross-compilation support (extracts `--target` from matrix args).
- **`.gitignore`**: Added `/src-tauri/binaries/` to prevent committing downloaded binaries.

## How it works

```
Build time:
  download-node.mjs → src-tauri/binaries/node-<target-triple> (107 MB)
  tauri build → externalBin bundles it → Contents/MacOS/node

Runtime:
  resolve_node_binary()
    1. VSCODEEE_NODE_PATH env var (override)
    2. exe_dir/node (bundled sidecar) ← production
    3. system "node" ← development
```

## Testing

- [x] `cargo clippy` — no warnings
- [x] `npm run tauri:build` — builds successfully, Node.js binary signed and bundled
- [x] Production app launch — ExtHost spawn error resolved, extension host starts successfully
- [x] `download-node.mjs` — downloads and extracts correct binary (verified v22.22.1)

## App size impact

| Component | Size |
|-----------|------|
| Main binary (codeee) | 49 MB |
| Node.js sidecar | 112 MB |
| Total app | ~200 MB |

This is comparable to VS Code's ~400 MB and acceptable for a desktop IDE.