### PR TITLE
feat: bundle node_modules for production builds to fix onig.wasm 404

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,12 +181,14 @@ jobs:
       # Create empty out/ directory so tauri::generate_context!() can resolve frontendDist: "../out"
       # Create empty css-modules.json so bundle.resources validation passes
       # Create empty node sidecar stub so externalBin validation passes
+      # Create empty node_modules/ stub so bundle.resources "node_modules/" validation passes
       - name: Create build stubs
         run: |
           mkdir -p out
           echo '[]' > src-tauri/css-modules.json
           mkdir -p src-tauri/binaries
           touch src-tauri/binaries/node-x86_64-unknown-linux-gnu
+          mkdir -p src-tauri/node_modules
 
       - name: Install system dependencies
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ CLAUDE.md
 /src-tauri/gen/
 /src-tauri/css-modules.json
 /src-tauri/binaries/
+/src-tauri/node_modules/
 
 # Worktrees
 .worktrees/

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
 		"install-latest-component-explorer": "npm install @vscode/component-explorer@next @vscode/component-explorer-cli@next && cd build/rspack && npm install @vscode/component-explorer-webpack-plugin@next @vscode/component-explorer@next && cd ../vite && npm install @vscode/component-explorer-vite-plugin@next @vscode/component-explorer@next",
 		"tauri": "tauri",
 		"tauri:dev": "npm install && bash scripts/check-csp-hash.sh && node build/next/index.ts transpile && node build/next/index.ts transpile-extensions && tauri dev",
-		"tauri:build": "npm install && bash scripts/check-csp-hash.sh && node scripts/download-node.mjs && node build/next/index.ts transpile && node build/next/index.ts transpile-extensions && node build/next/index.ts package-extensions && tauri build"
+		"tauri:build": "npm install && bash scripts/check-csp-hash.sh && node scripts/download-node.mjs && node scripts/bundle-node-modules.mjs && node build/next/index.ts transpile && node build/next/index.ts transpile-extensions && node build/next/index.ts package-extensions && tauri build"
 	},
 	"dependencies": {
 		"@anthropic-ai/sandbox-runtime": "0.0.42",

--- a/scripts/bundle-node-modules.mjs
+++ b/scripts/bundle-node-modules.mjs
@@ -157,7 +157,9 @@ function main() {
 	// Compute total size
 	let totalSize = 0;
 	function sumSize(dir) {
-		if (!fs.existsSync(dir)) return;
+		if (!fs.existsSync(dir)) {
+			return;
+		}
 		for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
 			const fullPath = path.join(dir, entry.name);
 			if (entry.isDirectory()) {

--- a/scripts/bundle-node-modules.mjs
+++ b/scripts/bundle-node-modules.mjs
@@ -1,0 +1,179 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) VS Codeee Contributors. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// @ts-check
+
+/**
+ * Bundle required node_modules for the Tauri production build.
+ *
+ * VS Code dynamically imports several node_modules at runtime via
+ * `importAMDNodeModule()` and `resolveAmdNodeModulePath()`. In the Electron
+ * build, these are available from the packaged `node_modules/` directory.
+ * In our Tauri build, we use `bundle.resources` to place them in the app's
+ * `Contents/Resources/node_modules/` directory, which matches the URL path
+ * that the `vscode-file://` protocol handler resolves.
+ *
+ * This script copies only the specific files needed from the project's
+ * `node_modules/` into `src-tauri/node_modules/`, which is then bundled
+ * via the `"node_modules/"` entry in `tauri.conf.json` → `bundle.resources`.
+ *
+ * Usage:
+ *   node scripts/bundle-node-modules.mjs
+ *   node scripts/bundle-node-modules.mjs --clean   # remove staging dir first
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+const REPO_ROOT = path.resolve(import.meta.dirname, '..');
+const SOURCE_DIR = path.join(REPO_ROOT, 'node_modules');
+const TARGET_DIR = path.join(REPO_ROOT, 'src-tauri', 'node_modules');
+
+// ── Manifest of required node_modules ──────────────────────────────────
+//
+// Each entry is either:
+//   - A specific file:      "pkg/path/to/file.ext"
+//   - An entire directory:  "pkg/path/to/dir/"  (trailing slash)
+//
+// Files are loaded at runtime via importAMDNodeModule() or
+// resolveAmdNodeModulePath() in src/vs/**/*.ts.
+
+const REQUIRED_MODULES = [
+	// ── TextMate syntax highlighting (critical) ──
+	'vscode-oniguruma/release/main.js',
+	'vscode-oniguruma/release/onig.wasm',
+	'vscode-textmate/release/main.js',
+
+	// ── Text encoding ──
+	'@vscode/iconv-lite-umd/lib/iconv-lite-umd.js',
+	'jschardet/dist/jschardet.min.js',
+
+	// ── Terminal (xterm) ──
+	'@xterm/xterm/lib/xterm.js',
+	'@xterm/addon-clipboard/lib/addon-clipboard.js',
+	'@xterm/addon-image/lib/addon-image.js',
+	'@xterm/addon-ligatures/lib/addon-ligatures.js',
+	'@xterm/addon-progress/lib/addon-progress.js',
+	'@xterm/addon-search/lib/addon-search.js',
+	'@xterm/addon-serialize/lib/addon-serialize.js',
+	'@xterm/addon-unicode11/lib/addon-unicode11.js',
+	'@xterm/addon-webgl/lib/addon-webgl.js',
+
+	// ── Math rendering (Markdown preview) ──
+	'katex/dist/katex.min.js',
+	'katex/dist/katex.min.css',
+
+	// ── Telemetry ──
+	'@microsoft/1ds-core-js/bundle/ms.core.min.js',
+	'@microsoft/1ds-post-js/bundle/ms.post.min.js',
+
+	// ── Experimentation service ──
+	'tas-client/dist/tas-client.min.js',
+
+	// ── Tree-sitter (syntax parsing) ──
+	'@vscode/tree-sitter-wasm/wasm/',
+
+	// ── Language detection ──
+	'@vscode/vscode-languagedetection/dist/',
+	'@vscode/vscode-languagedetection/model/',
+];
+
+// ────────────────────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+const clean = args.includes('--clean');
+
+/**
+ * Recursively copy a directory.
+ * @param {string} src
+ * @param {string} dest
+ * @returns {number} number of files copied
+ */
+function copyDirRecursive(src, dest) {
+	if (!fs.existsSync(src)) {
+		return 0;
+	}
+	let count = 0;
+	fs.mkdirSync(dest, { recursive: true });
+	for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
+		const srcPath = path.join(src, entry.name);
+		const destPath = path.join(dest, entry.name);
+		if (entry.isDirectory()) {
+			count += copyDirRecursive(srcPath, destPath);
+		} else {
+			fs.copyFileSync(srcPath, destPath);
+			count++;
+		}
+	}
+	return count;
+}
+
+/**
+ * Copy a single file, creating parent directories as needed.
+ * @param {string} src
+ * @param {string} dest
+ */
+function copyFile(src, dest) {
+	fs.mkdirSync(path.dirname(dest), { recursive: true });
+	fs.copyFileSync(src, dest);
+}
+
+function main() {
+	console.log('[bundle-node-modules] Bundling required node_modules for Tauri build...');
+
+	if (clean && fs.existsSync(TARGET_DIR)) {
+		console.log(`[bundle-node-modules] Cleaning ${TARGET_DIR}`);
+		fs.rmSync(TARGET_DIR, { recursive: true });
+	}
+
+	let totalFiles = 0;
+	let skipped = 0;
+
+	for (const entry of REQUIRED_MODULES) {
+		const isDir = entry.endsWith('/');
+		const srcPath = path.join(SOURCE_DIR, entry);
+		const destPath = path.join(TARGET_DIR, entry);
+
+		if (!fs.existsSync(srcPath)) {
+			// Some packages may not be installed (e.g., vsda is Microsoft-internal)
+			console.warn(`[bundle-node-modules] WARN: ${entry} not found, skipping`);
+			skipped++;
+			continue;
+		}
+
+		if (isDir) {
+			const count = copyDirRecursive(srcPath, destPath);
+			console.log(`[bundle-node-modules]   ${entry} (${count} files)`);
+			totalFiles += count;
+		} else {
+			copyFile(srcPath, destPath);
+			console.log(`[bundle-node-modules]   ${entry}`);
+			totalFiles++;
+		}
+	}
+
+	// Compute total size
+	let totalSize = 0;
+	function sumSize(dir) {
+		if (!fs.existsSync(dir)) return;
+		for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+			const fullPath = path.join(dir, entry.name);
+			if (entry.isDirectory()) {
+				sumSize(fullPath);
+			} else {
+				totalSize += fs.statSync(fullPath).size;
+			}
+		}
+	}
+	sumSize(TARGET_DIR);
+
+	const sizeMB = (totalSize / (1024 * 1024)).toFixed(1);
+	console.log(`[bundle-node-modules] Done: ${totalFiles} files copied (${sizeMB} MB)`);
+	if (skipped > 0) {
+		console.log(`[bundle-node-modules] ${skipped} module(s) not found (may be optional)`);
+	}
+}
+
+main();

--- a/scripts/bundle-node-modules.mjs
+++ b/scripts/bundle-node-modules.mjs
@@ -31,7 +31,7 @@ const REPO_ROOT = path.resolve(import.meta.dirname, '..');
 const SOURCE_DIR = path.join(REPO_ROOT, 'node_modules');
 const TARGET_DIR = path.join(REPO_ROOT, 'src-tauri', 'node_modules');
 
-// ── Manifest of required node_modules ──────────────────────────────────
+// Manifest of required node_modules
 //
 // Each entry is either:
 //   - A specific file:      "pkg/path/to/file.ext"
@@ -41,16 +41,16 @@ const TARGET_DIR = path.join(REPO_ROOT, 'src-tauri', 'node_modules');
 // resolveAmdNodeModulePath() in src/vs/**/*.ts.
 
 const REQUIRED_MODULES = [
-	// ── TextMate syntax highlighting (critical) ──
+	// TextMate syntax highlighting (critical)
 	'vscode-oniguruma/release/main.js',
 	'vscode-oniguruma/release/onig.wasm',
 	'vscode-textmate/release/main.js',
 
-	// ── Text encoding ──
+	// Text encoding
 	'@vscode/iconv-lite-umd/lib/iconv-lite-umd.js',
 	'jschardet/dist/jschardet.min.js',
 
-	// ── Terminal (xterm) ──
+	// Terminal (xterm)
 	'@xterm/xterm/lib/xterm.js',
 	'@xterm/addon-clipboard/lib/addon-clipboard.js',
 	'@xterm/addon-image/lib/addon-image.js',
@@ -61,26 +61,24 @@ const REQUIRED_MODULES = [
 	'@xterm/addon-unicode11/lib/addon-unicode11.js',
 	'@xterm/addon-webgl/lib/addon-webgl.js',
 
-	// ── Math rendering (Markdown preview) ──
+	// Math rendering (Markdown preview)
 	'katex/dist/katex.min.js',
 	'katex/dist/katex.min.css',
 
-	// ── Telemetry ──
+	// Telemetry
 	'@microsoft/1ds-core-js/bundle/ms.core.min.js',
 	'@microsoft/1ds-post-js/bundle/ms.post.min.js',
 
-	// ── Experimentation service ──
+	// Experimentation service
 	'tas-client/dist/tas-client.min.js',
 
-	// ── Tree-sitter (syntax parsing) ──
+	// Tree-sitter (syntax parsing)
 	'@vscode/tree-sitter-wasm/wasm/',
 
-	// ── Language detection ──
+	// Language detection
 	'@vscode/vscode-languagedetection/dist/',
 	'@vscode/vscode-languagedetection/model/',
 ];
-
-// ────────────────────────────────────────────────────────────────────────
 
 const args = process.argv.slice(2);
 const clean = args.includes('--clean');

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -116,17 +116,33 @@ pub async fn get_window_configuration(
         .map(|p| p.to_string_lossy().to_string())
         .unwrap_or_default();
 
-    // In dev mode, frontendDist is "../out" relative to src-tauri/.
-    // This matches tauri.conf.json and is where transpiled output lives.
+    // Resolve frontendDist: the absolute path to the `out/` directory where
+    // transpiled VS Code modules live. Module IDs like
+    // `vs/../../node_modules/vscode-oniguruma/release/onig.wasm` are resolved
+    // relative to this path.
+    //
+    // Development: CWD is src-tauri/, so `../out` resolves to the repo's out/ dir.
+    // Production: CWD is typically `/` (macOS Finder launch), so `../out` doesn't
+    //   exist. Fall back to `resource_dir/out` — a virtual path. The actual `out/`
+    //   assets are embedded in the binary via frontendDist, but the TypeScript side
+    //   needs a path containing `/out/` for vscode-file:// URI construction.
+    //   Paths like `resource_dir/out/vs/../../node_modules/...` are normalized by
+    //   the protocol handler's `normalize_dot_segments()` before canonicalization.
     let frontend_dist = std::env::current_dir()
         .ok()
-        .map(|cwd| {
+        .and_then(|cwd| {
             let dist = cwd.join("../out");
-            dist.canonicalize()
-                .unwrap_or(dist)
-                .to_string_lossy()
-                .to_string()
+            dist.canonicalize().ok()
         })
+        .or_else(|| {
+            // Production fallback: use resource_dir/out as a virtual path.
+            app_handle
+                .path()
+                .resource_dir()
+                .ok()
+                .map(|rd| rd.join("out"))
+        })
+        .map(|p| p.to_string_lossy().to_string())
         .unwrap_or_default();
 
     // Application data directory for user settings/state.

--- a/src-tauri/src/protocol/uri.rs
+++ b/src-tauri/src/protocol/uri.rs
@@ -9,7 +9,7 @@
 //! into canonicalized [`PathBuf`]s. Handles percent-decoding and path normalization
 //! to prevent traversal attacks (e.g. `..` components).
 
-use std::path::PathBuf;
+use std::path::{Component, Path, PathBuf};
 
 use super::error::ProtocolError;
 
@@ -59,12 +59,30 @@ pub fn parse_vscode_file_uri(raw_uri: &str) -> Result<PathBuf, ProtocolError> {
         )));
     }
 
-    // Canonicalize to resolve symlinks and `..` components.
-    let canonical = std::fs::canonicalize(&decoded).map_err(|e| match e.kind() {
+    // Normalize `..` and `.` segments logically before calling canonicalize().
+    //
+    // In production builds, `frontendDist` assets (e.g. `out/`) are embedded in
+    // the binary and don't exist on disk. However, module paths like
+    // `<resource_dir>/out/vs/../../node_modules/vscode-oniguruma/release/onig.wasm`
+    // traverse through these non-existent intermediate directories via `..`.
+    // `std::fs::canonicalize()` fails because it requires every path component
+    // to exist. By resolving `..` first, the path becomes
+    // `<resource_dir>/node_modules/vscode-oniguruma/release/onig.wasm` which
+    // does exist on disk (bundled via `bundle.resources`).
+    //
+    // Security: canonicalize() is still called on the normalized path to resolve
+    // symlinks and verify the final path exists, and roots validation follows.
+    let normalized = normalize_dot_segments(&decoded);
+
+    // Canonicalize to resolve symlinks and verify the path exists.
+    let canonical = std::fs::canonicalize(&normalized).map_err(|e| match e.kind() {
         std::io::ErrorKind::NotFound => {
-            ProtocolError::NotFound(format!("path does not exist: {decoded}"))
+            ProtocolError::NotFound(format!("path does not exist: {}", normalized.display()))
         }
-        _ => ProtocolError::Internal(format!("canonicalize failed for {decoded}: {e}")),
+        _ => ProtocolError::Internal(format!(
+            "canonicalize failed for {}: {e}",
+            normalized.display()
+        )),
     })?;
 
     Ok(canonical)
@@ -99,6 +117,36 @@ pub fn parse_vscode_file_uri_raw(raw_uri: &str) -> Result<String, ProtocolError>
     }
 
     Ok(decoded)
+}
+
+/// Normalize `.` and `..` path segments without touching the filesystem.
+///
+/// Unlike [`std::fs::canonicalize`], this does NOT require intermediate
+/// directories to exist. It purely resolves `.` and `..` based on the
+/// string representation, similar to POSIX `realpath -m` (logical mode).
+///
+/// This is critical for production builds where `frontendDist` (e.g. `out/`)
+/// is embedded in the binary and doesn't exist on disk, but paths traverse
+/// through it via `..` to reach bundled resources like `node_modules/`.
+fn normalize_dot_segments(path: &str) -> PathBuf {
+    let mut result = PathBuf::new();
+    for component in Path::new(path).components() {
+        match component {
+            Component::ParentDir => {
+                // Pop the last component (go up one directory).
+                // If we're at root, this is a no-op (can't go above root).
+                result.pop();
+            }
+            Component::CurDir => {
+                // Skip `.` — it refers to the current directory.
+            }
+            other => {
+                // RootDir, Prefix, or Normal — push as-is.
+                result.push(other);
+            }
+        }
+    }
+    result
 }
 
 /// Simple percent-decoding for URI path components.
@@ -270,5 +318,49 @@ mod tests {
         let result = parse_vscode_file_uri_raw("vscode-file://vscode-apprelative/path");
         assert!(result.is_err());
         assert_eq!(result.unwrap_err().status_code(), 400);
+    }
+
+    // ── normalize_dot_segments tests ──
+
+    #[test]
+    fn normalize_resolves_parent_dir() {
+        let result = normalize_dot_segments("/a/b/c/../../d");
+        assert_eq!(result, PathBuf::from("/a/d"));
+    }
+
+    #[test]
+    fn normalize_resolves_current_dir() {
+        let result = normalize_dot_segments("/a/./b/./c");
+        assert_eq!(result, PathBuf::from("/a/b/c"));
+    }
+
+    #[test]
+    fn normalize_node_modules_traversal() {
+        // Simulates: <resource_dir>/out/vs/../../node_modules/vscode-oniguruma/release/onig.wasm
+        let result = normalize_dot_segments(
+            "/Applications/VS Codeee.app/Contents/Resources/out/vs/../../node_modules/vscode-oniguruma/release/onig.wasm"
+        );
+        assert_eq!(
+            result,
+            PathBuf::from("/Applications/VS Codeee.app/Contents/Resources/node_modules/vscode-oniguruma/release/onig.wasm")
+        );
+    }
+
+    #[test]
+    fn normalize_does_not_go_above_root() {
+        let result = normalize_dot_segments("/a/../../b");
+        assert_eq!(result, PathBuf::from("/b"));
+    }
+
+    #[test]
+    fn normalize_preserves_root() {
+        let result = normalize_dot_segments("/");
+        assert_eq!(result, PathBuf::from("/"));
+    }
+
+    #[test]
+    fn normalize_simple_path_unchanged() {
+        let result = normalize_dot_segments("/a/b/c");
+        assert_eq!(result, PathBuf::from("/a/b/c"));
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -7,7 +7,7 @@
   "build": {
     "frontendDist": "../out",
     "beforeDevCommand": "",
-    "beforeBuildCommand": "node scripts/download-node.mjs && node build/next/index.ts transpile && node build/next/index.ts transpile-extensions && node build/next/index.ts package-extensions && node scripts/generate-css-modules.mjs"
+    "beforeBuildCommand": "node scripts/download-node.mjs && node scripts/bundle-node-modules.mjs && node build/next/index.ts transpile && node build/next/index.ts transpile-extensions && node build/next/index.ts package-extensions && node scripts/generate-css-modules.mjs"
   },
   "app": {
     "withGlobalTauri": true,
@@ -51,7 +51,7 @@
     "createUpdaterArtifacts": true,
     "targets": "all",
     "externalBin": ["binaries/node"],
-    "resources": ["css-modules.json", "../product.json", "../package.json", "../out", "../.build/extensions"],
+    "resources": ["css-modules.json", "../product.json", "../package.json", "../out", "../.build/extensions", "node_modules/"],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
## Summary

Fix `onig.wasm` and `vscode-textmate/main.js` 404 errors in production builds that prevented TextMate syntax highlighting from working.

## Root Cause

VS Code's `importAMDNodeModule()` resolves `node_modules` paths relative to `frontendDist` (the `out/` directory). In production Tauri builds:

1. `frontendDist` assets are **embedded in the binary** — the `out/` directory doesn't physically exist on disk
2. The `vscode-file://` protocol handler called `std::fs::canonicalize()` which requires **all intermediate directories to exist**
3. Paths like `Resources/out/vs/../../node_modules/onig.wasm` failed because `Resources/out/` doesn't exist
4. Additionally, `get_window_configuration()` lacked a production fallback for `frontendDist`, resulting in an invalid path (`/../out`) when CWD is `/` (macOS Finder launch)

## Changes

### 1. `scripts/bundle-node-modules.mjs` (new)
Copies 44 required files (25 MB) from `node_modules/` to `src-tauri/node_modules/` for Tauri resource bundling. Includes vscode-oniguruma, vscode-textmate, xterm addons, katex, tree-sitter-wasm, etc.

### 2. `src-tauri/src/protocol/uri.rs`
Add `normalize_dot_segments()` to logically resolve `..`/`.` path segments **before** calling `canonicalize()`. This allows paths traversing through non-existent embedded directories to resolve correctly to bundled resources.

### 3. `src-tauri/src/commands/mod.rs`
Add production fallback for `frontendDist` in `get_window_configuration()`: when `CWD/../out` doesn't exist (production), fall back to `resource_dir/out`.

### 4. `src-tauri/tauri.conf.json`
- Add `"node_modules/"` to `bundle.resources`
- Add `bundle-node-modules.mjs` to `beforeBuildCommand`

### 5. Supporting changes
- `package.json`: Add bundle script to `tauri:build`
- `.gitignore`: Exclude `/src-tauri/node_modules/`
- `.github/workflows/ci.yml`: Add `mkdir -p src-tauri/node_modules` stub for Backend Lint

## Testing

- [x] `cargo test -- protocol::uri` — All 21 tests pass (including 6 new normalize_dot_segments tests)
- [x] `npm run tauri:build` — Build succeeds
- [x] Manual verification — Syntax highlighting works in production app, onig.wasm/main.js 404 errors resolved