### PR TITLE
fix: re-download Node.js sidecar when existing binary is too small

### DIFF
--- a/scripts/download-node.mjs
+++ b/scripts/download-node.mjs
@@ -213,11 +213,23 @@ async function main() {
 	const destPath = path.join(BINARIES_DIR, `node-${targetTriple}${ext}`);
 
 	// Check if already downloaded
+	// A valid Node.js binary is at least 10 MB. Anything smaller is likely a
+	// stub / placeholder (e.g. created by `touch` in CI) and should be replaced.
+	const MIN_VALID_SIZE = 10 * 1024 * 1024; // 10 MB
+
 	if (fs.existsSync(destPath)) {
 		const stat = fs.statSync(destPath);
-		console.log(`[download-node] Node.js binary already exists: ${destPath} (${(stat.size / 1024 / 1024).toFixed(1)} MB)`);
-		console.log(`[download-node] Delete it to re-download.`);
-		return;
+		const sizeMB = stat.size / 1024 / 1024;
+
+		if (stat.size >= MIN_VALID_SIZE) {
+			console.log(`[download-node] Node.js binary already exists: ${destPath} (${sizeMB.toFixed(1)} MB)`);
+			console.log(`[download-node] Delete it to re-download.`);
+			return;
+		}
+
+		// File exists but is too small – remove and re-download
+		console.log(`[download-node] Existing binary is too small (${sizeMB.toFixed(1)} MB), re-downloading...`);
+		fs.unlinkSync(destPath);
 	}
 
 	// Ensure binaries directory exists


### PR DESCRIPTION
## Summary

Fix `download-node.mjs` to detect and replace undersized (e.g. 0-byte stub) Node.js sidecar binaries instead of silently skipping them.

## Problem

The `download-node.mjs` script checked only for file existence at the destination path, not file size. When a 0-byte stub file existed (e.g. created by `touch` in CI, or left over from an incomplete download), the script would log "already exists (0.0 MB)" and skip the download. This caused the Tauri sidecar to bundle an empty binary, leading to `Permission denied (os error 13)` when the extension host tried to spawn Node.js at runtime.

## Solution

Add a minimum size check (10 MB threshold) to the existing file validation:
- If the file exists **and** is >= 10 MB → skip (existing behavior)
- If the file exists but is < 10 MB → delete and re-download
- If the file doesn't exist → download (existing behavior)

A valid Node.js binary is typically 80-110 MB, so 10 MB is a conservative threshold that catches all stub/placeholder files.

## Testing

Verified both scenarios:
1. **0-byte stub** → Detected as too small, deleted, re-downloaded successfully (107.7 MB)
2. **Valid binary (107.7 MB)** → Correctly skipped with "already exists" message

## Changes

- `scripts/download-node.mjs`: Add `MIN_VALID_SIZE` check before skipping download