### PR TITLE
chore: reset package version to 0.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "code-oss-dev",
-	"version": "1.115.0",
+	"version": "0.0.0",
 	"distro": "7b60af3ce53ae18d76f52e3d0e94f25dd02a13a4",
 	"author": {
 		"name": "Microsoft Corporation"

--- a/scripts/download-node.mjs
+++ b/scripts/download-node.mjs
@@ -227,7 +227,7 @@ async function main() {
 			return;
 		}
 
-		// File exists but is too small – remove and re-download
+		// File exists but is too small - remove and re-download
 		console.log(`[download-node] Existing binary is too small (${sizeMB.toFixed(1)} MB), re-downloading...`);
 		fs.unlinkSync(destPath);
 	}


### PR DESCRIPTION
## Summary
- Reset `package.json` version from `1.115.0` to `0.0.0` for the fork project

## Test plan
- [ ] Verify `package.json` version field shows `0.0.0`
- [ ] Verify build process still works with the reset version

🤖 Generated with [Claude Code](https://claude.com/claude-code)