### PR TITLE
fix: harden release workflow reliability

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ on:
     branches: [main]
 
 concurrency:
-  group: release-${{ github.sha }}
+  group: release
   cancel-in-progress: false
 
 jobs:
@@ -176,7 +176,10 @@ jobs:
         env:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
           ELECTRON_SKIP_BINARY_DOWNLOAD: 1
-        run: npm ci --ignore-scripts
+        run: |
+          # Create placeholder to prevent postinstall symlink error
+          touch .github/copilot-instructions.md
+          npm ci
 
       - name: Download Node.js sidecar binary
         shell: bash
@@ -284,7 +287,7 @@ jobs:
               apt-get install -y --no-install-recommends \
                 libxkbfile-dev libkrb5-dev libsecret-1-dev python3 make g++ && \
               rm -rf node_modules && \
-              npm install --production
+              npm install --omit=dev
             "
 
           # Copy cross-compiled modules into the package


### PR DESCRIPTION
## Summary

Fix three reliability issues in the release workflow (`publish.yml`) that could cause build failures or unexpected behavior.

## Changes

### 1. Fix concurrency group (prevents duplicate releases)
- **Before**: `release-${{ github.sha }}` — unique per commit, so rapid pushes to main would run multiple release builds in parallel
- **After**: `release` — fixed group ensures only one release build runs at a time

### 2. Enable postinstall hooks (prevents build failure)
- **Before**: `npm ci --ignore-scripts` — skipped VS Code's postinstall hooks, meaning `build/`, `remote/`, and `extensions/` dependencies were not installed
- **After**: `npm ci` with `copilot-instructions.md` placeholder — postinstall hooks run properly, installing all required dependencies for `tauri build`

### 3. Replace deprecated npm flag
- **Before**: `npm install --production` in the REH Docker cross-compilation step
- **After**: `npm install --omit=dev` — the modern equivalent (deprecated since npm v7)