### PR TITLE
fix: guard against undefined header info in Linux preinstall patch

### DIFF
--- a/build/npm/preinstall.ts
+++ b/build/npm/preinstall.ts
@@ -150,15 +150,19 @@ function installHeaders() {
 		const homedir = os.homedir();
 		const cachePath = process.env.XDG_CACHE_HOME || path.join(homedir, '.cache');
 		const nodeGypCache = path.join(cachePath, 'node-gyp');
-		const localHeaderPath = path.join(nodeGypCache, local!.target, 'include', 'node');
-		if (fs.existsSync(localHeaderPath)) {
-			console.log('Applying v8-source-location.patch to', localHeaderPath);
-			try {
-				child_process.execFileSync('patch', ['-p0', '-i', path.join(import.meta.dirname, 'gyp', 'custom-headers', 'v8-source-location.patch')], {
-					cwd: localHeaderPath
-				});
-			} catch (error) {
-				throw new Error(`Error applying v8-source-location.patch: ${(error as Error).message}`);
+		const patchFile = path.join(import.meta.dirname, 'gyp', 'custom-headers', 'v8-source-location.patch');
+		const targets = [local, remote].filter((h): h is { disturl: string; target: string } => h !== undefined);
+		for (const header of targets) {
+			const headerPath = path.join(nodeGypCache, header.target, 'include', 'node');
+			if (fs.existsSync(headerPath)) {
+				console.log('Applying v8-source-location.patch to', headerPath);
+				try {
+					child_process.execFileSync('patch', ['-p0', '-i', patchFile], {
+						cwd: headerPath
+					});
+				} catch (error) {
+					throw new Error(`Error applying v8-source-location.patch: ${(error as Error).message}`);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Fix `TypeError: Cannot read properties of undefined (reading 'target')` that crashes the Linux build during `npm install` (preinstall script).

## Problem

`build/npm/preinstall.ts` applies a v8-source-location patch on Linux to downloaded node-gyp headers. The code used `local!.target` (non-null assertion) without checking whether `getHeaderInfo()` returned `undefined`. In our Tauri fork, `.npmrc` has no `disturl`/`target` entries (Electron headers are removed), so `local` is `undefined` and the assertion crashes.

## Fix

- Replace the non-null assertion with a filtered array: `[local, remote].filter(h => h !== undefined)`
- Iterate only over defined header entries, safely skipping when neither local nor remote headers are configured
- As a side benefit, the patch now also applies to remote headers (previously only local was patched)

## Testing

- This code path only executes on `process.platform === 'linux'`, so it cannot be verified locally on macOS
- Will be verified by the CI Linux build job in the v0.1.0 release workflow