### PR TITLE
chore: release v0.1.1

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-utils/schema.json",
   "productName": "VS Codeee",
   "mainBinaryName": "codeee",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "identifier": "com.vscodeee.app",
   "build": {
     "frontendDist": "../out",


### PR DESCRIPTION
## Release v0.1.1

Patch release to fix build failures on Linux and Windows that prevented v0.1.0 from completing all platform builds.

### Fixed
- Guard against undefined header info in Linux preinstall patch (#248)
- Add icon.ico and icon.icns for Windows/macOS builds (#250)

### Changes
- `src-tauri/tauri.conf.json`: version bump 0.1.0 → 0.1.1