### PR TITLE
docs: use bug report template for issue link

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 > [!NOTE]
 > This project is developed and tested primarily on **macOS**. Windows and Linux builds are provided but have not been verified on those platforms.
-> If you encounter any issues, please [open an issue](https://github.com/j4rviscmd/vscodeee/issues/new).
+> If you encounter any issues, please [open an issue](https://github.com/j4rviscmd/vscodeee/issues/new?template=bug_report.md).
 
 ## Purpose
 


### PR DESCRIPTION
## Summary

Update the "open an issue" link in the platform testing note to use the `bug_report.md` template, so users are presented with a structured bug report form instead of a blank issue.

## Related Issue

Follow-up to #251.

## Changes

- Added `?template=bug_report.md` query parameter to the GitHub issue link in README.md

## How to Test

1. Click the "open an issue" link in the README preview
2. Verify the bug report template form is displayed