### PR TITLE
fix: pass GITHUB_TOKEN to npm ci and make v8 patch idempotent

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -176,6 +176,7 @@ jobs:
         env:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
           ELECTRON_SKIP_BINARY_DOWNLOAD: 1
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Create placeholder to prevent postinstall symlink error
           touch .github/copilot-instructions.md
@@ -258,6 +259,7 @@ jobs:
         env:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
           ELECTRON_SKIP_BINARY_DOWNLOAD: 1
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Create placeholder to prevent postinstall symlink error
           touch .github/copilot-instructions.md

--- a/build/npm/preinstall.ts
+++ b/build/npm/preinstall.ts
@@ -156,12 +156,19 @@ function installHeaders() {
 			const headerPath = path.join(nodeGypCache, header.target, 'include', 'node');
 			if (fs.existsSync(headerPath)) {
 				console.log('Applying v8-source-location.patch to', headerPath);
-				try {
-					child_process.execFileSync('patch', ['-p0', '-i', patchFile], {
-						cwd: headerPath
-					});
-				} catch (error) {
-					throw new Error(`Error applying v8-source-location.patch: ${(error as Error).message}`);
+				// Use -N (--forward) to skip already-applied patches gracefully.
+				// Node.js >= 22.x ships V8 headers that already include this fix,
+				// so the patch may have nothing to do.
+				const result = child_process.spawnSync('patch', ['-p0', '-N', '-i', patchFile], {
+					cwd: headerPath
+				});
+				if (result.status !== 0) {
+					const output = (result.stdout?.toString() ?? '') + (result.stderr?.toString() ?? '');
+					if (/already applied|Reversed.*patch detected|previously applied/i.test(output)) {
+						console.log('Patch already applied, skipping.');
+					} else {
+						throw new Error(`Error applying v8-source-location.patch: ${output}`);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## Summary
- Add `GITHUB_TOKEN` env to `Install frontend dependencies` steps in `publish.yml` (both `publish-tauri` and `build-reh` jobs) so `@vscode/ripgrep` postinstall can authenticate GitHub API requests and avoid 403 rate limiting
- Switch `v8-source-location.patch` application from `execFileSync` to `spawnSync` with `-N` (--forward) flag so that already-applied patches (e.g. Node.js >= 22.x V8 headers) are gracefully skipped instead of throwing a fatal error

## Problem
- **macOS arm64/x64**: `npm ci` fails because `@vscode/ripgrep` tries to download from GitHub API without auth, hitting rate limits (HTTP 403)
- **Linux**: `preinstall.ts` fails applying `v8-source-location.patch` because Node.js v22.22.1 headers already include the V8 fix upstream

## Changes
| File | Change |
|------|--------|
| `.github/workflows/publish.yml` | Add `GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` to npm ci env (2 steps) |
| `build/npm/preinstall.ts` | Use `spawnSync` with `-N` flag, detect already-applied patches gracefully |