### PR TITLE
chore: bump version to 0.1.2 for release retry

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-utils/schema.json",
   "productName": "VS Codeee",
   "mainBinaryName": "codeee",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "identifier": "com.vscodeee.app",
   "build": {
     "frontendDist": "../out",


### PR DESCRIPTION
## Summary
- Bump `src-tauri/tauri.conf.json` version from `0.1.1` to `0.1.2`
- v0.1.1 tag already exists (partial release with macOS/Linux failures), so incrementing to trigger a fresh release

## Context
PR #254 fixed the root causes (ripgrep 403 + v8 patch idempotency). This PR triggers the publish workflow with the fixes in place.