### PR TITLE
fix: add missing protected modifiers to prevent mangler build failure

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugEditor.ts
@@ -300,7 +300,7 @@ export class ChatDebugEditor extends EditorPane {
 		}
 	}
 
-	override setEditorVisible(visible: boolean): void {
+	protected override setEditorVisible(visible: boolean): void {
 		super.setEditorVisible(visible);
 		if (visible) {
 			this.telemetryService.publicLog2<{}, ChatDebugPanelOpenedClassification>('chatDebugPanelOpened');

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalConfirmationTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalConfirmationTool.ts
@@ -64,7 +64,7 @@ export const ConfirmTerminalCommandToolData: IToolData = {
 };
 
 export class ConfirmTerminalCommandTool extends RunInTerminalTool {
-	override get _enableCommandLineSandboxRewriting() {
+	protected override get _enableCommandLineSandboxRewriting() {
 		return false;
 	}
 


### PR DESCRIPTION
## Summary

Fix REH server build failure on all platforms caused by the mangler detecting protected fields being exposed as public.

## Changes

- Add `protected` modifier to `ChatDebugEditor.setEditorVisible()` override (parent: `EditorPane`)
- Add `protected` modifier to `ConfirmTerminalCommandTool._enableCommandLineSandboxRewriting` override (parent: `RunInTerminalTool`)

## Context

The VS Code mangler (`build/lib/mangle/index.ts`) checks that protected/private fields are not accidentally exposed as public, which would hurt minification. Two subclass overrides were missing the `protected` keyword, causing `npm run gulp -- vscode-reh-{os}-{arch}-min` to fail with:

```
[mangler] ERROR: Protected fields have been made PUBLIC. This hurts minification and is therefore not allowed.
```

This blocked all 5 REH server builds (linux-x64, linux-arm64, linux-armhf, darwin-arm64, darwin-x64) in the v0.1.2 release workflow.