### PR TITLE
chore: release v0.1.3

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-utils/schema.json",
   "productName": "VS Codeee",
   "mainBinaryName": "codeee",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "identifier": "com.vscodeee.app",
   "build": {
     "frontendDist": "../out",


### PR DESCRIPTION
## Summary

Version bump to v0.1.3 for release.

## Changes since v0.1.2

- fix: add missing protected modifiers to prevent mangler build failure (#257)

## Context

v0.1.2 had successful publish-tauri builds (all 4 platforms) but all 5 REH server builds failed due to a mangler error. This release includes the fix and should complete the full build pipeline including REH server tarball generation.