### PR TITLE
fix: add swap space for Linux runners to prevent OOM during REH build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -251,6 +251,18 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libxkbfile-dev pkg-config libkrb5-dev libsecret-1-dev
 
+      # The gulp compilation step requires ~8GB memory (--max-old-space-size=8192)
+      # but GitHub-hosted ubuntu runners only have 7GB RAM. Add swap to prevent OOM kills.
+      - name: Setup swap space (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo swapoff -a
+          sudo fallocate -l 8G /swapfile
+          sudo chmod 600 /swapfile
+          sudo mkswap /swapfile
+          sudo swapon /swapfile
+          echo "Swap enabled: $(swapon --show)"
+
       - name: Set up QEMU (Linux ARM cross-compilation)
         if: matrix.os == 'linux' && matrix.arch != 'x64'
         uses: docker/setup-qemu-action@v4


### PR DESCRIPTION
## Summary

Fix Build REH Server OOM (Out of Memory) failure on all Linux runners.

## Changes

- Add 8GB swap space setup step before the build phase on Linux runners

## Context

The gulp compilation step uses `--max-old-space-size=8192` (8GB) but GitHub-hosted `ubuntu-22.04` runners only have 7GB RAM. After the mangler fix (#257), the compilation now proceeds past the mangler check but the subsequent TypeScript compilation phase exceeds available physical memory, causing the Linux kernel OOM killer to send SIGKILL.

Adding 8GB swap provides sufficient virtual memory for the compilation to complete.

**Affected jobs**: linux-x64, linux-arm64, linux-armhf (all 3 Linux REH builds)
**Not affected**: darwin-arm64 (14GB RAM), darwin-x64 (14GB RAM)