### PR TITLE
chore: release v0.1.4

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-utils/schema.json",
   "productName": "VS Codeee",
   "mainBinaryName": "codeee",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "identifier": "com.vscodeee.app",
   "build": {
     "frontendDist": "../out",


### PR DESCRIPTION
## Summary

Version bump to v0.1.4 for release.

## Changes since v0.1.3

- fix: add swap space for Linux runners to prevent OOM during REH build (#259)

## Context

v0.1.3 had successful publish-tauri builds but all 3 Linux REH server builds failed due to OOM (Out of Memory). The `--max-old-space-size=8192` (8GB) exceeds the 7GB RAM available on ubuntu-22.04 runners. This release includes the swap space fix that provides sufficient virtual memory for the gulp compilation step.