### PR TITLE
chore: release v0.1.5

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-utils/schema.json",
   "productName": "VS Codeee",
   "mainBinaryName": "codeee",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "identifier": "com.vscodeee.app",
   "build": {
     "frontendDist": "../out",


### PR DESCRIPTION
## Release v0.1.5

### Changes since v0.1.4
- **fix**: Free disk space and memory on Linux runners to prevent REH build OOM kills
  - Remove large pre-installed tools (Android SDK, .NET SDK, CodeQL, Go, Ruby, PowerShell, Chromium)
  - Prune Docker images and drop filesystem caches
  - Combined with existing 8GB swap for maximum available memory

### Version bump
- `src-tauri/tauri.conf.json`: `0.1.4` → `0.1.5`