### PR TITLE
fix: reduce REH build heap size to 4GB to prevent OOM on GitHub runners

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -306,8 +306,11 @@ jobs:
           touch .github/copilot-instructions.md
           npm ci
 
+      # Use 4GB heap instead of the default 8GB (from package.json "gulp" script)
+      # to fit within GitHub-hosted runner memory limits (15GB RAM + 8GB swap).
+      # The 8GB heap + native memory overhead exceeds 23GB on Linux runners.
       - name: Build REH server
-        run: npm run gulp -- vscode-reh-${{ matrix.os }}-${{ matrix.arch }}-min
+        run: node --max-old-space-size=4096 ./node_modules/gulp/bin/gulp.js vscode-reh-${{ matrix.os }}-${{ matrix.arch }}-min
 
       # For Linux ARM, replace host-compiled native modules with target-arch ones
       - name: Cross-compile remote dependencies (Linux ARM)


### PR DESCRIPTION
## Summary

- Reduce V8 heap size from 8GB to 4GB for the REH server build step
- Invoke `node` directly with `--max-old-space-size=4096` instead of using the `npm run gulp` script (which hardcodes 8GB)

## Problem

The REH server build (`gulp vscode-reh-*-min`) consistently gets OOM-killed on all 3 Linux GitHub-hosted runners (ubuntu-22.04). Even with:
- 15GB RAM (runner spec)
- 8GB swap (added in PR #259)
- Disk cleanup freeing ~3-4GB of cache pressure (added in PR #261)

The total 23GB virtual memory is still insufficient because the 8GB V8 heap + native memory (TypeScript compiler, mangler, etc.) exceeds the available memory.

## Solution

Replace `npm run gulp` (which uses `--max-old-space-size=8192`) with a direct `node` invocation using `--max-old-space-size=4096`. This halves the V8 heap limit, significantly reducing total process memory usage.

**Risk**: If 4GB is insufficient for the V8 heap, the build will fail with "JavaScript heap out of memory" instead of OOM kill. This is a safer failure mode since it produces a clear error message.

## Affected jobs
- Build REH Server (linux-x64)
- Build REH Server (linux-arm64)
- Build REH Server (linux-armhf)
- Build REH Server (darwin-arm64) — may also benefit
- Build REH Server (darwin-x64) — may also benefit