### PR TITLE
chore: release v0.1.6

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-utils/schema.json",
   "productName": "VS Codeee",
   "mainBinaryName": "codeee",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "identifier": "com.vscodeee.app",
   "build": {
     "frontendDist": "../out",


### PR DESCRIPTION
## Release v0.1.6

### Changes since v0.1.5
- **fix**: Reduce REH build heap size to 4GB to prevent OOM on GitHub runners (PR #263)

### Version bump
- `src-tauri/tauri.conf.json`: `0.1.5` → `0.1.6`