### PR TITLE
fix: use NODE_OPTIONS to limit V8 heap for all processes including worker threads

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -306,11 +306,15 @@ jobs:
           touch .github/copilot-instructions.md
           npm ci
 
-      # Use 4GB heap instead of the default 8GB (from package.json "gulp" script)
-      # to fit within GitHub-hosted runner memory limits (15GB RAM + 8GB swap).
-      # The 8GB heap + native memory overhead exceeds 23GB on Linux runners.
+      # The gulp build spawns 4 worker threads (mangler) each with their own V8 heap.
+      # With --max-old-space-size=8192 (package.json default), that's 5×8GB = 40GB total,
+      # far exceeding the 23GB available (15GB RAM + 8GB swap).
+      # NODE_OPTIONS applies to ALL processes including workers, limiting each to 4GB.
+      # Total: 5×4GB = 20GB < 23GB available.
       - name: Build REH server
-        run: node --max-old-space-size=4096 ./node_modules/gulp/bin/gulp.js vscode-reh-${{ matrix.os }}-${{ matrix.arch }}-min
+        env:
+          NODE_OPTIONS: --max-old-space-size=4096
+        run: node ./node_modules/gulp/bin/gulp.js vscode-reh-${{ matrix.os }}-${{ matrix.arch }}-min
 
       # For Linux ARM, replace host-compiled native modules with target-arch ones
       - name: Cross-compile remote dependencies (Linux ARM)


### PR DESCRIPTION
## Summary

- Use `NODE_OPTIONS=--max-old-space-size=4096` environment variable instead of CLI flag
- This limits V8 heap for **all** Node.js processes including worker threads spawned by the mangler

## Root Cause Analysis

The mangler (`build/lib/mangle/index.ts:430`) spawns 4 worker threads with `maxWorkers: 4, minWorkers: 'max'`. Each worker thread gets its own V8 heap.

**Previous approach** (CLI flag `--max-old-space-size`):
- Only limits the **main process** heap
- Workers inherit the system default or package.json setting (8GB)
- Total memory: 1 main × 4GB + 4 workers × 8GB = **36GB** → exceeds 23GB available

**New approach** (NODE_OPTIONS env var):
- Applies to **all** Node.js processes including workers
- Each process limited to 4GB
- Total memory: 5 × 4GB = **20GB** < 23GB available (15GB RAM + 8GB swap)

## Previous Attempts

| Version | Approach | Result |
|---------|----------|--------|
| v0.1.3 | 8GB swap added | OOM kill (8GB heap × 5 = 40GB) |
| v0.1.4 | Disk cleanup + swap | OOM kill (same root cause) |
| v0.1.5 | 4GB heap via CLI flag | JS heap OOM (workers still at 8GB) |
| v0.1.6 | 4GB heap via CLI flag | JS heap OOM (workers still at 8GB) |
| **v0.1.7** | **NODE_OPTIONS=4GB** | **Should work: 5×4GB = 20GB < 23GB** |