### PR TITLE
chore: release v0.1.7

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-utils/schema.json",
   "productName": "VS Codeee",
   "mainBinaryName": "codeee",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "identifier": "com.vscodeee.app",
   "build": {
     "frontendDist": "../out",


### PR DESCRIPTION
## Release v0.1.7

### Changes since v0.1.6
- **fix**: Use NODE_OPTIONS to limit V8 heap for all processes including worker threads (PR #265)
  - Root cause: mangler spawns 4 workers × 8GB heap = 40GB total, exceeding 23GB runner memory
  - Fix: NODE_OPTIONS=--max-old-space-size=4096 applies to all processes (5×4GB = 20GB)

### Version bump
- `src-tauri/tauri.conf.json`: `0.1.6` → `0.1.7`