### PR TITLE
fix: give main process 6GB heap while limiting workers to 4GB

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -306,15 +306,22 @@ jobs:
           touch .github/copilot-instructions.md
           npm ci
 
-      # The gulp build spawns 4 worker threads (mangler) each with their own V8 heap.
+      # The mangler spawns 4 worker threads (minWorkers: 'max', maxWorkers: 4).
       # With --max-old-space-size=8192 (package.json default), that's 5×8GB = 40GB total,
       # far exceeding the 23GB available (15GB RAM + 8GB swap).
-      # NODE_OPTIONS applies to ALL processes including workers, limiting each to 4GB.
-      # Total: 5×4GB = 20GB < 23GB available.
+      #
+      # NODE_OPTIONS limits ALL processes (main + workers) to 4GB each.
+      # However, the main process needs >4GB for TypeScript compilation after mangling
+      # (mangler alone uses ~3GB, then compilation pushes it over 4GB).
+      #
+      # Solution: CLI flag overrides NODE_OPTIONS for the main process only.
+      # - Main process: 6GB (CLI flag --max-old-space-size=6144)
+      # - Worker threads: 4GB each (NODE_OPTIONS)
+      # - Peak total: 6 + 4×4 = 22GB < 23GB available
       - name: Build REH server
         env:
           NODE_OPTIONS: --max-old-space-size=4096
-        run: node ./node_modules/gulp/bin/gulp.js vscode-reh-${{ matrix.os }}-${{ matrix.arch }}-min
+        run: node --max-old-space-size=6144 ./node_modules/gulp/bin/gulp.js vscode-reh-${{ matrix.os }}-${{ matrix.arch }}-min
 
       # For Linux ARM, replace host-compiled native modules with target-arch ones
       - name: Cross-compile remote dependencies (Linux ARM)


### PR DESCRIPTION
## Summary

- Give the main gulp process 6GB heap via CLI flag (`--max-old-space-size=6144`) to prevent OOM during TypeScript compilation after mangling
- Keep `NODE_OPTIONS=--max-old-space-size=4096` to limit mangler worker threads to 4GB each
- Peak total memory: 6GB (main) + 4×4GB (workers) = 22GB < 23GB available on runners

## Problem

The previous fix (PR #265) used only `NODE_OPTIONS=--max-old-space-size=4096` which limited ALL processes to 4GB. However, the main process needs >4GB for TypeScript compilation after mangling (mangler alone uses ~3GB heap, then compilation pushes it over the 4GB limit).

Build log evidence from v0.1.6 run:
```
[mangler] Done: memory-usage: {"used_heap_size":2911223496 (2.9GB),...}
...
Mark-Compact 4025.6 (4128.1) -> 4004.4 (4128.6) MB
FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
```

## Solution

CLI flag `--max-old-space-size=6144` overrides `NODE_OPTIONS` for the main process only, giving it 6GB. Worker threads still read `NODE_OPTIONS` and get 4GB each.