### PR TITLE
fix: limit mangler worker threads to prevent OOM on CI runners

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -306,21 +306,21 @@ jobs:
           touch .github/copilot-instructions.md
           npm ci
 
-      # The mangler spawns 4 worker threads (minWorkers: 'max', maxWorkers: 4).
-      # With --max-old-space-size=8192 (package.json default), that's 5×8GB = 40GB total,
-      # far exceeding the 23GB available (15GB RAM + 8GB swap).
+      # The mangler spawns worker threads (default 4) each inheriting the main
+      # process's V8 heap limit. On GitHub-hosted ubuntu-22.04 (15GB RAM + 8GB swap),
+      # 4 workers × 6GB + main 6GB = 30GB total, far exceeding the 23GB available.
       #
-      # NODE_OPTIONS limits ALL processes (main + workers) to 4GB each.
-      # However, the main process needs >4GB for TypeScript compilation after mangling
-      # (mangler alone uses ~3GB, then compilation pushes it over 4GB).
+      # NODE_OPTIONS does NOT limit worker_threads heap — they inherit the parent's
+      # V8 isolate settings. Only resourceLimits or reducing worker count helps.
       #
-      # Solution: CLI flag overrides NODE_OPTIONS for the main process only.
+      # Solution: MANGLER_MAX_WORKERS=1 reduces to 1 worker thread.
       # - Main process: 6GB (CLI flag --max-old-space-size=6144)
-      # - Worker threads: 4GB each (NODE_OPTIONS)
-      # - Peak total: 6 + 4×4 = 22GB < 23GB available
+      # - Worker thread: 1 × ~6GB (inherits main's limit)
+      # - Peak total: ~12GB << 23GB available
+      # On 2-vCPU runners, 1 worker is optimal anyway (no context switching overhead).
       - name: Build REH server
         env:
-          NODE_OPTIONS: --max-old-space-size=4096
+          MANGLER_MAX_WORKERS: "1"
         run: node --max-old-space-size=6144 ./node_modules/gulp/bin/gulp.js vscode-reh-${{ matrix.os }}-${{ matrix.arch }}-min
 
       # For Linux ARM, replace host-compiled native modules with target-arch ones

--- a/build/lib/mangle/index.ts
+++ b/build/lib/mangle/index.ts
@@ -426,9 +426,15 @@ export class Mangler {
 		this.log = log;
 		this.config = config;
 
+		// Allow CI to reduce worker count to fit memory-constrained runners.
+		// GitHub-hosted ubuntu-22.04 has 15GB RAM + 8GB swap = 23GB total.
+		// Each worker thread inherits the main process's V8 heap limit (~6GB),
+		// so 4 workers + main = 5×6GB = 30GB which exceeds 23GB.
+		// Setting MANGLER_MAX_WORKERS=1 → 1×6GB + 6GB main = 12GB, fits easily.
+		const maxWorkers = parseInt(process.env['MANGLER_MAX_WORKERS'] || '4', 10);
 		this.renameWorkerPool = workerpool.pool(path.join(import.meta.dirname, 'renameWorker.ts'), {
-			maxWorkers: 4,
-			minWorkers: 'max'
+			maxWorkers,
+			minWorkers: maxWorkers
 		});
 	}
 


### PR DESCRIPTION
## Summary

- Add `MANGLER_MAX_WORKERS` env var to control mangler worker thread count (default: 4)
- Set `MANGLER_MAX_WORKERS=1` in `publish.yml` for REH builds on GitHub runners
- Remove ineffective `NODE_OPTIONS` (doesn't limit worker_threads V8 heap)

## Root Cause Analysis

Previous fixes tried to limit worker memory via:
1. **PR #265**: `NODE_OPTIONS=--max-old-space-size=4096` — **doesn't work** because worker_threads inherit the parent's V8 isolate settings, not NODE_OPTIONS
2. **PR #267**: CLI flag `--max-old-space-size=6144` + NODE_OPTIONS — workers still inherit the 6GB CLI flag

The actual memory usage was: main (6GB) + 4 workers × 6GB = **30GB** >> 23GB available → OOM kill

## Solution

Reduce worker count via configurable env var:
- `MANGLER_MAX_WORKERS=1` → main (6GB) + 1 worker (6GB) = **12GB** << 23GB ✓
- On 2-vCPU GitHub runners, 1 worker is optimal anyway (avoids context switching overhead with 4 threads on 2 cores)

## Changes

| File | Change |
|------|--------|
| `build/lib/mangle/index.ts` | Read `MANGLER_MAX_WORKERS` env var, default to 4 |
| `.github/workflows/publish.yml` | Set `MANGLER_MAX_WORKERS=1`, remove NODE_OPTIONS |