### PR TITLE
chore: release v0.1.8

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-utils/schema.json",
   "productName": "VS Codeee",
   "mainBinaryName": "codeee",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "identifier": "com.vscodeee.app",
   "build": {
     "frontendDist": "../out",


### PR DESCRIPTION
## Release v0.1.8

Version bump to v0.1.8 to trigger a clean release with the mangler worker limit fix (PR #268).

### Changes since v0.1.7
- **PR #267**: Give main process 6GB heap via CLI flag
- **PR #268**: Add `MANGLER_MAX_WORKERS` env var to limit worker threads (set to 1 in CI)

### Memory budget on GitHub runners (ubuntu-22.04: 15GB + 8GB swap = 23GB)
- Main process: 6GB (`--max-old-space-size=6144`)
- Worker thread: 1 × ~6GB
- **Peak total: ~12GB << 23GB** ✓