### PR TITLE
chore: release v0.1.9

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-utils/schema.json",
   "productName": "VS Codeee",
   "mainBinaryName": "codeee",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "identifier": "com.vscodeee.app",
   "build": {
     "frontendDist": "../out",


### PR DESCRIPTION
## Summary

- Bump version to v0.1.9 (patch release)
- Includes fix for NLS build error that caused all Linux REH server builds to fail (#270)

## Changes since v0.1.8

- **fix**: use literal keys in `localize()` to fix NLS build error (#270)
  - The NLS build system (`nls-analysis.ts`) uses `eval()` to resolve `localize()` arguments
  - Variable reference `errorMessageKey` → callback with literal string keys

## Expected Build Results

All platforms should now succeed:
- Tauri: macOS (arm64, x64), Windows, Linux ✅ (already passing)
- REH Server: Linux (x64, arm64, armhf), macOS (arm64, x64) ← previously failing due to NLS error