### PR TITLE
chore: release v0.1.10

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-utils/schema.json",
   "productName": "VS Codeee",
   "mainBinaryName": "codeee",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "identifier": "com.vscodeee.app",
   "build": {
     "frontendDist": "../out",


### PR DESCRIPTION
## Summary

- Bump version to v0.1.10 (patch release)
- Includes fixes for all REH server build failures

## Changes since v0.1.9

- **fix**: resolve 5 TypeScript compilation errors in REH server build (#272)
  - `pty-poc/terminal.ts`: Add `@ts-nocheck` for standalone PoC
  - `agentHostServerMain.ts`: Use `any` cast for dynamic test module import
  - `terminalInstance.test.ts`: Add `as any` cast for mangled private field access

## Cumulative fixes since v0.1.8 (last attempted full release)

1. **#270**: NLS build error — `localize()` with variable key → callback with literal keys
2. **#272**: 5 TypeScript compilation errors — mangler interaction with private fields, test imports, and standalone PoC files

## Expected Build Results

All platforms should now succeed:
- Tauri: macOS (arm64, x64), Windows, Linux ✅
- REH Server: Linux (x64, arm64, armhf), macOS (arm64, x64) ← should now pass