### PR TITLE
fix: replace macos-13 with macos-latest for darwin-x64 REH build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -232,7 +232,7 @@ jobs:
             runner: macos-latest
           - os: darwin
             arch: x64
-            runner: macos-13
+            runner: macos-latest
 
     runs-on: ${{ matrix.runner }}
     steps:


### PR DESCRIPTION
## Summary

- Replace `macos-13` runner with `macos-latest` for the darwin-x64 REH server build
- `macos-13` (Intel) runners have extremely limited availability, causing the job to stay queued for 5+ hours
- `macos-latest` (arm64) can cross-build for darwin-x64 target

## Context

In the v0.1.10 release build, all 10 other jobs completed successfully, but `Build REH Server (darwin-x64)` remained queued for 5+ hours waiting for a `macos-13` runner.