### PR TITLE
chore: release v0.1.11

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-utils/schema.json",
   "productName": "VS Codeee",
   "mainBinaryName": "codeee",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "identifier": "com.vscodeee.app",
   "build": {
     "frontendDist": "../out",


### PR DESCRIPTION
## Summary

- Bump version to v0.1.11 (patch release)
- Replaces v0.1.10 which was incomplete (darwin-x64 REH never ran due to macos-13 runner unavailability)

## Changes since v0.1.10

- **fix**: Replace `macos-13` with `macos-latest` for darwin-x64 REH build (#275)

## All fixes included (since v0.1.8)

1. **#270**: NLS build error — `localize()` with variable key → callback with literal keys
2. **#272**: 5 TypeScript compilation errors — mangler interaction fixes
3. **#275**: Replace `macos-13` runner with `macos-latest` for darwin-x64 REH