### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,54 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.0] - 2026-04-24
+
+### Fixed
+
+- Bundle all extension `node_modules` for production builds — extensions and Extension Host now activate correctly without `ERR_MODULE_NOT_FOUND` errors ([#278](https://github.com/j4rviscmd/vscodeee/pull/278))
+- Resolve transitive dependencies of core modules (e.g. `@vscode/spdlog` → `mkdirp`, `katex` → `commander`) and bundle full packages so `require()` resolution works at runtime
+- Improve Extension Host sidecar spawn error handling with early-exit detection, stderr capture, and diagnostic log files
+- Set `NODE_PATH` in sidecar to point to bundled `node_modules/`
+
+## [0.1.11] - 2026-04-23
+
+### Fixed
+
+- Switch darwin-x64 REH runner from `macos-13` to `macos-latest` to avoid runner exhaustion ([#275](https://github.com/j4rviscmd/vscodeee/pull/275))
+
+## [0.1.10] - 2026-04-23
+
+### Fixed
+
+- Fix 5 TypeScript compilation errors hidden behind prior NLS failure ([#272](https://github.com/j4rviscmd/vscodeee/pull/272))
+  - Add `@ts-nocheck` to `pty-poc/src/terminal.ts` for missing `@xterm/addon-fit`
+  - Cast `ScriptedMockAgent` destructuring to `any` in `agentHostServerMain.ts`
+  - Add `as any` casts for mangler-renamed property access in `terminalInstance.test.ts`
+
+## [0.1.9] - 2026-04-22
+
+### Fixed
+
+- Fix NLS build error: replace variable reference in `localize()` first argument with callback pattern in `shellCommandActions.ts` ([#270](https://github.com/j4rviscmd/vscodeee/pull/270))
+
+## [0.1.8] - 2026-04-22
+
+### Fixed
+
+- Limit mangler worker threads to 1 via `MANGLER_MAX_WORKERS=1` to prevent OOM during REH server builds ([#268](https://github.com/j4rviscmd/vscodeee/pull/268))
+
+## [0.1.0] - 2026-04-20
+
+### Added
+
+- Initial release of VS Codeee — VS Code fork powered by Tauri 2.0
+- Tauri desktop builds for macOS (arm64/x64), Windows (x64), Linux (x64)
+- REH (Remote Extension Host) server builds for Linux (x64/arm64/armhf) and macOS (arm64/x64)
+- Custom title bar with Tauri drag regions
+- Extension Host sidecar process management
+- IPC bridge between Tauri backend and VS Code frontend
+- Tauri-native file watcher, encryption, and window services

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.2.0] - 2026-04-24
 
+### Added
+
+- Auto-download updates for background checks — when `update.mode` is `default` or `start`, detected updates are downloaded immediately without waiting for manual action, matching original VS Code Electron behavior ([#280](https://github.com/j4rviscmd/vscodeee/pull/280), closes [#277](https://github.com/j4rviscmd/vscodeee/issues/277))
+
 ### Fixed
 
 - Bundle all extension `node_modules` for production builds — extensions and Extension Host now activate correctly without `ERR_MODULE_NOT_FOUND` errors ([#278](https://github.com/j4rviscmd/vscodeee/pull/278))

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6248,7 +6248,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vscodeee"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vscodeee"
-version = "0.1.0"
+version = "0.2.0"
 description = "VS Code fork powered by Tauri 2.0"
 authors = ["j4rviscmd"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-utils/schema.json",
   "productName": "VS Codeee",
   "mainBinaryName": "codeee",
-  "version": "0.1.11",
+  "version": "0.2.0",
   "identifier": "com.vscodeee.app",
   "build": {
     "frontendDist": "../out",


### PR DESCRIPTION
## Summary

Release v0.2.0 — version bump and CHANGELOG creation.

### Changes
- Bump `tauri.conf.json` version from `0.1.11` to `0.2.0`
- Bump `Cargo.toml` version from `0.1.0` to `0.2.0`
- Add `CHANGELOG.md` with release history (v0.1.0 through v0.2.0)

### What's new in v0.2.0
- Bundle all extension `node_modules` for production builds (PR #278)
- Resolve transitive dependencies of core modules
- Improve Extension Host sidecar error handling
- Set `NODE_PATH` in sidecar for bundled modules