### PR TITLE
feat: auto-download updates for background checks

### DIFF
--- a/src/vs/platform/agentHost/node/agentHostServerMain.ts
+++ b/src/vs/platform/agentHost/node/agentHostServerMain.ts
@@ -178,7 +178,7 @@ async function main(): Promise<void> {
 		// Dynamic import to avoid bundling test code in production.
 		// Use `any` cast because the mangler renames exported class names,
 		// making destructured imports from test modules fail at build time.
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		import('../test/node/mockAgent.js').then((mod: any) => {
 			const mockAgent = disposables.add(new mod.ScriptedMockAgent());
 			agentService.registerProvider(mockAgent);

--- a/src/vs/platform/agentHost/node/agentHostServerMain.ts
+++ b/src/vs/platform/agentHost/node/agentHostServerMain.ts
@@ -178,6 +178,7 @@ async function main(): Promise<void> {
 		// Dynamic import to avoid bundling test code in production.
 		// Use `any` cast because the mangler renames exported class names,
 		// making destructured imports from test modules fail at build time.
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		import('../test/node/mockAgent.js').then((mod: any) => {
 			const mockAgent = disposables.add(new mod.ScriptedMockAgent());
 			agentService.registerProvider(mockAgent);

--- a/src/vs/workbench/contrib/terminal/test/browser/terminalInstance.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/terminalInstance.test.ts
@@ -204,8 +204,8 @@ suite('Workbench - TerminalInstance', () => {
 
 		test('custom key event handler should handle commands in DEFAULT_COMMANDS_TO_SKIP_SHELL in VS Code and not xterm when sendKeybindingsToShell is disabled', async () => {
 			const instance = await createTerminalInstance();
+			// eslint-disable-next-line local/code-no-any-casts
 			const keybindingService = (instance as any)['_keybindingService'];
-				// eslint-disable-next-line local/code-no-any-casts
 			const originalSoftDispatch = keybindingService.softDispatch;
 			keybindingService.softDispatch = () => ({ kind: ResultKind.KbFound, commandId: 'workbench.action.zoomIn', commandArgs: undefined, isBubble: false });
 
@@ -230,8 +230,8 @@ suite('Workbench - TerminalInstance', () => {
 
 		test('custom key event handler should intercept Meta-modified keys that resolve to a command when sendKeybindingsToShell is disabled', async () => {
 			const instance = await createTerminalInstance();
+			// eslint-disable-next-line local/code-no-any-casts
 			const keybindingService = (instance as any)['_keybindingService'];
-				// eslint-disable-next-line local/code-no-any-casts
 			const originalSoftDispatch = keybindingService.softDispatch;
 			strictEqual(DEFAULT_COMMANDS_TO_SKIP_SHELL.includes('test.metaKeyInterceptCommand'), false);
 			keybindingService.softDispatch = () => ({ kind: ResultKind.KbFound, commandId: 'test.metaKeyInterceptCommand', commandArgs: undefined, isBubble: false });

--- a/src/vs/workbench/contrib/terminal/test/browser/terminalInstance.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/terminalInstance.test.ts
@@ -205,6 +205,7 @@ suite('Workbench - TerminalInstance', () => {
 		test('custom key event handler should handle commands in DEFAULT_COMMANDS_TO_SKIP_SHELL in VS Code and not xterm when sendKeybindingsToShell is disabled', async () => {
 			const instance = await createTerminalInstance();
 			const keybindingService = (instance as any)['_keybindingService'];
+				// eslint-disable-next-line local/code-no-any-casts
 			const originalSoftDispatch = keybindingService.softDispatch;
 			keybindingService.softDispatch = () => ({ kind: ResultKind.KbFound, commandId: 'workbench.action.zoomIn', commandArgs: undefined, isBubble: false });
 
@@ -230,6 +231,7 @@ suite('Workbench - TerminalInstance', () => {
 		test('custom key event handler should intercept Meta-modified keys that resolve to a command when sendKeybindingsToShell is disabled', async () => {
 			const instance = await createTerminalInstance();
 			const keybindingService = (instance as any)['_keybindingService'];
+				// eslint-disable-next-line local/code-no-any-casts
 			const originalSoftDispatch = keybindingService.softDispatch;
 			strictEqual(DEFAULT_COMMANDS_TO_SKIP_SHELL.includes('test.metaKeyInterceptCommand'), false);
 			keybindingService.softDispatch = () => ({ kind: ResultKind.KbFound, commandId: 'test.metaKeyInterceptCommand', commandArgs: undefined, isBubble: false });

--- a/src/vs/workbench/services/update/tauri-browser/updateService.ts
+++ b/src/vs/workbench/services/update/tauri-browser/updateService.ts
@@ -13,16 +13,41 @@ import { invoke, createChannel } from '../../../../platform/tauri/common/tauriAp
 
 // -- Types matching the Rust `commands/updater/commands.rs` structs ---------
 
+/**
+ * Update metadata returned by the Rust updater backend.
+ *
+ * Mirrors the `UpdateInfo` struct in `commands/updater/commands.rs`.
+ * Only `version` and `currentVersion` are guaranteed; `date` and `body`
+ * are populated from the release notes payload when available.
+ */
 interface UpdateInfo {
+  /** Semver string of the available update (e.g. `"1.95.0"`). */
   version: string;
+  /** Semver string of the currently running version. */
   currentVersion: string;
+  /** ISO-8601 release date of the update, if provided by the endpoint. */
   date?: string;
+  /** Markdown release notes body, if provided by the endpoint. */
   body?: string;
 }
 
+/**
+ * Byte-level download progress event emitted over a Tauri {@link Channel}
+ * during `download_and_install`.
+ *
+ * The `phase` field indicates the lifecycle stage:
+ * - `'started'` — the download has begun (`downloadedBytes` is `0`).
+ * - `'progress'` — intermediate progress (`totalBytes` may be `undefined` when
+ *   the server does not advertise a `Content-Length`).
+ * - `'finished'` — the download is complete; `downloadedBytes` equals the
+ *   final size.
+ */
 interface DownloadProgress {
+  /** Current lifecycle phase of the download operation. */
   phase: 'started' | 'progress' | 'finished';
+  /** Number of bytes received so far. */
   downloadedBytes: number;
+  /** Total expected size in bytes. `undefined` when the server omits `Content-Length`. */
   totalBytes?: number;
 }
 
@@ -48,18 +73,43 @@ export class TauriUpdateService extends Disposable implements IUpdateService {
 
   declare readonly _serviceBrand: undefined;
 
+  /** Emitter that fires whenever the update state machine transitions. */
   private _onStateChange = this._register(new Emitter<State>());
+  /** Event listeners can subscribe here to observe state transitions. */
   readonly onStateChange: Event<State> = this._onStateChange.event;
 
+  /** Backing field for the {@link state} property. Defaults to `Disabled(NotBuilt)`. */
   private _state: State = State.Disabled(DisablementReason.NotBuilt);
+  /**
+   * Current state of the update state machine.
+   *
+   * Setting this property fires the {@link onStateChange} event, allowing
+   * UI components and other services to react to transitions.
+   */
   get state(): State { return this._state; }
   set state(state: State) {
     this._state = state;
     this._onStateChange.fire(state);
   }
 
+  /**
+   * Cached update metadata from the most recent successful check.
+   *
+   * Populated by {@link checkForUpdates} when the Rust backend reports an
+   * available update. Consumed by {@link downloadUpdate}, {@link applyUpdate},
+   * and {@link quitAndInstall} to avoid redundant IPC calls.
+   */
   private cachedUpdateInfo: UpdateInfo | undefined;
+
+  /** Handle for the periodic background-check `setTimeout` timer. */
   private periodicCheckTimer: ReturnType<typeof setTimeout> | undefined;
+
+  /**
+   * Disposable wrapper for the periodic check timer.
+   *
+   * Automatically cleaned up when this service is disposed, ensuring no
+   * orphaned timers survive after the service lifecycle ends.
+   */
   private readonly periodicCheckDisposable = this._register(new MutableDisposable());
 
   constructor(
@@ -213,6 +263,10 @@ export class TauriUpdateService extends Disposable implements IUpdateService {
         this.cachedUpdateInfo = update;
         this.logService.info(`Update available: ${update.version}`);
         this.state = State.AvailableForDownload(this.mapToUpdate(update));
+        // Auto-download for background checks (start and default modes).
+        if (!explicit) {
+          this.downloadUpdate(false);
+        }
       } else {
         this.state = State.Idle(UpdateType.Archive, undefined, explicit ? false : undefined);
       }
@@ -371,9 +425,12 @@ export class TauriUpdateService extends Disposable implements IUpdateService {
     const CHECK_INTERVAL = 6 * 60 * 60 * 1000; // 6 hours
 
     const check = async () => {
+      // Guard: only proceed if the user hasn't switched away from 'default'
+      // mode since the timer was scheduled.
       if (this.getUpdateMode() === 'default') {
         await this.checkForUpdates(false);
       }
+      // Re-schedule regardless — the next tick will re-evaluate the mode.
       this.periodicCheckTimer = setTimeout(check, CHECK_INTERVAL);
     };
 
@@ -388,4 +445,8 @@ export class TauriUpdateService extends Disposable implements IUpdateService {
   }
 }
 
+// Register as an eager singleton so the updater is initialized at startup
+// regardless of whether any consumer has injected IUpdateService yet.
+// This ensures the initial update check fires immediately when `update.mode`
+// is `start` or `default`.
 registerSingleton(IUpdateService, TauriUpdateService, InstantiationType.Eager);


### PR DESCRIPTION
## Summary

When an update is detected via automatic check (`update.mode: start` or `default`), automatically trigger the download instead of stopping at `AvailableForDownload` and waiting for manual user action. This matches the original VS Code Electron behavior where the auto-updater downloads immediately after detecting a new version.

## Related Issue

Closes #277

## Changes

- Added auto-download trigger in `TauriUpdateService.checkForUpdates()`: when `!explicit` (background check), `downloadUpdate(false)` is called immediately after transitioning to `AvailableForDownload`
- Added JSDoc documentation to interfaces and fields in `updateService.ts`

## How to Test

1. Set `"update.enabled": true` in settings (dev build)
2. Ensure `update.mode` is `default` (or `start`)
3. Launch the app — after the update check detects a new version, the download should start automatically
4. Verify the activity bar badge shows the downloading progress, then transitions to "Restart to Update"
5. Set `update.mode` to `manual` — verify that manual "Check for Updates" does NOT auto-download