### PR TITLE
fix: prefer source extensions/ over .build/extensions/ in dev mode

### DIFF
--- a/src-tauri/src/commands/extensions.rs
+++ b/src-tauri/src/commands/extensions.rs
@@ -57,20 +57,25 @@ fn resolve_extensions_dir(app_handle: &tauri::AppHandle) -> Option<PathBuf> {
     use tauri::Manager;
 
     // Try CWD-based resolution first (works during `cargo tauri dev`).
-    // During development, the packaged extensions live in .build/extensions/.
-    // Fall back to the raw extensions/ source directory if .build/ doesn't exist
-    // (e.g., before `package-extensions` has been run).
+    // During development, prefer the source `extensions/` directory over
+    // `.build/extensions/` because the source directory contains `node_modules/`
+    // required by Language Server extensions (markdown, css, etc.) to fork
+    // child processes. `.build/extensions/` only has compiled JS but lacks
+    // `node_modules/`, causing Language Server processes to crash immediately.
+    // See: https://github.com/j4rviscmd/vscodeee/issues/283
     if let Some(dir) = std::env::current_dir()
         .ok()
-        .map(|cwd| cwd.join("../.build/extensions"))
+        .map(|cwd| cwd.join("../extensions"))
         .and_then(|p| p.canonicalize().ok())
         .filter(|p| p.is_dir())
     {
         return Some(dir);
     }
+    // Fall back to .build/extensions/ if source directory is not available
+    // (e.g., in CI or stripped source environments).
     if let Some(dir) = std::env::current_dir()
         .ok()
-        .map(|cwd| cwd.join("../extensions"))
+        .map(|cwd| cwd.join("../.build/extensions"))
         .and_then(|p| p.canonicalize().ok())
         .filter(|p| p.is_dir())
     {


### PR DESCRIPTION
## Summary

During development (`cargo tauri dev`), `resolve_extensions_dir()` now prioritizes the source `extensions/` directory over `.build/extensions/`. The source directory contains `node_modules/` required by Language Server extensions to fork child processes, while `.build/extensions/` only has compiled JS without `node_modules/`.

## Root Cause

`.build/extensions/` lacks `node_modules/` directories. When Extension Host loads extensions from `.build/extensions/`, Language Server processes (markdown, css, etc.) crash immediately because they cannot resolve their `serverModule` paths via `context.asAbsolutePath()`.

**Error chain:**
1. `list_builtin_extensions` scans `.build/extensions/`
2. Extension Host loads extension from `.build/extensions/markdown-language-features/`
3. `extension.ts` resolves `serverModule` to `.build/extensions/.../node_modules/vscode-markdown-languageserver/...`
4. Path does not exist → `child_process.fork()` crashes
5. `LanguageClient` detects close → "Pending response rejected since connection got disposed"

## Changes

- `src-tauri/src/commands/extensions.rs`: Swapped priority order in `resolve_extensions_dir()` — `extensions/` (source) is now checked before `.build/extensions/` during CWD-based resolution (dev mode only)
- Production builds are unaffected (they use the resource directory fallback)

## Verification

Tested with `npm run tauri:dev` — error log reduced from 958 lines to 87 lines:
- Language Server "connection disposed" errors: **eliminated**
- Extension activation failures: **eliminated**
- npm `find-yarn-workspace-root` errors: **eliminated**
- GitHub extension ESM import errors: **eliminated**

Closes #283
Closes #284
Closes #285