### PR TITLE
feat: replace telemetry packages with no-op stubs to reduce bundle by ~80MB

### DIFF
--- a/scripts/bundle-node-modules.mjs
+++ b/scripts/bundle-node-modules.mjs
@@ -44,6 +44,33 @@ const TARGET_DIR = path.join(REPO_ROOT, 'src-tauri', 'node_modules');
 // plain Node.js sidecar, or too large / unnecessary for production).
 const EXCLUDED_PACKAGES = new Set([
 	'mermaid',      // very large (~10MB) — skip for now
+
+	// Telemetry transitive dependencies — excluded because we replace the top-level
+	// telemetry packages with no-op stubs (see STUBBED_PACKAGES below).
+	// This eliminates ~80MB of unnecessary packages from the bundle.
+	// See: https://github.com/j4rviscmd/vscodeee/issues/274
+	'@microsoft/applicationinsights-channel-js',
+	'@microsoft/applicationinsights-common',
+	'@microsoft/applicationinsights-core-js',
+	'@microsoft/applicationinsights-shims',
+	'@microsoft/applicationinsights-web-basic',
+	'@microsoft/dynamicproto-js',
+	'@nevware21/ts-async',
+	'@nevware21/ts-utils',
+]);
+
+// Directory containing no-op stub packages that replace real implementations.
+// Stubs maintain the same API surface but have zero dependencies and minimal size.
+const STUBS_DIR = path.join(REPO_ROOT, 'scripts', 'stubs');
+
+// Packages that should be replaced with no-op stubs in the bundle.
+// Key: package name, Value: relative path within STUBS_DIR.
+// The stub is copied instead of the real package from node_modules.
+// See: https://github.com/j4rviscmd/vscodeee/issues/274
+const STUBBED_PACKAGES = new Map([
+	['@vscode/extension-telemetry', '@vscode/extension-telemetry'],
+	['@microsoft/1ds-core-js', '@microsoft/1ds-core-js'],
+	['@microsoft/1ds-post-js', '@microsoft/1ds-post-js'],
 ]);
 
 // Core platform modules used by the Extension Host process and VS Code runtime.
@@ -100,9 +127,8 @@ const CORE_MODULES = [
 	// Math rendering (Markdown preview) — full package needed for require('katex')
 	'katex/',
 
-	// Telemetry
-	'@microsoft/1ds-core-js/bundle/ms.core.min.js',
-	'@microsoft/1ds-post-js/bundle/ms.post.min.js',
+	// Telemetry — replaced with no-op stubs via STUBBED_PACKAGES (see #274).
+	// The stubs are copied in the "Stub packages" phase instead of from node_modules.
 
 	// Experimentation service — full package needed for require('tas-client')
 	'tas-client/',
@@ -328,8 +354,24 @@ function main() {
 		}
 	}
 
-	// Phase 1.5: Resolve transitive deps of CORE_MODULES (e.g. @vscode/spdlog → mkdirp)
-	console.log('[bundle-node-modules] Phase 1.5: Core module transitive deps...');
+	// Phase 1.5: Copy no-op stub packages (replaces real telemetry packages)
+	console.log('[bundle-node-modules] Phase 1.5: Stub packages...');
+	for (const [pkgName, stubRelPath] of STUBBED_PACKAGES) {
+		const stubSrc = path.join(STUBS_DIR, stubRelPath);
+		const destPath = path.join(TARGET_DIR, pkgName);
+		if (!fs.existsSync(stubSrc)) {
+			console.warn(`[bundle-node-modules] WARN: stub for ${pkgName} not found at ${stubSrc}, skipping`);
+			skipped++;
+			continue;
+		}
+		const count = copyDirRecursive(stubSrc, destPath);
+		console.log(`[bundle-node-modules]   ${pkgName}/ (${count} files) [stub]`);
+		totalFiles += count;
+		bundledPkgs.add(pkgName);
+	}
+
+	// Phase 1.6: Resolve transitive deps of CORE_MODULES (e.g. @vscode/spdlog → mkdirp)
+	console.log('[bundle-node-modules] Phase 1.6: Core module transitive deps...');
 	const coreTransitiveQueue = [...bundledPkgs];
 	const coreTransitiveSeen = new Set(bundledPkgs);
 	while (coreTransitiveQueue.length > 0) {

--- a/scripts/stubs/@microsoft/1ds-core-js/bundle/ms.core.min.js
+++ b/scripts/stubs/@microsoft/1ds-core-js/bundle/ms.core.min.js
@@ -1,0 +1,38 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) VS Codeee Contributors. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// No-op stub for @microsoft/1ds-core-js (bundle entry point)
+// Provides minimal AppInsightsCore that satisfies the IAppInsightsCore interface
+// used by src/vs/platform/telemetry/common/1dsAppender.ts
+//
+// See: https://github.com/j4rviscmd/vscodeee/issues/274
+
+(function (root, factory) {
+	if (typeof module !== 'undefined' && module.exports) {
+		module.exports = factory();
+	} else {
+		root.Microsoft = root.Microsoft || {};
+		root.Microsoft.ApplicationInsights = factory();
+	}
+}(typeof globalThis !== 'undefined' ? globalThis : typeof self !== 'undefined' ? self : this, function () {
+	'use strict';
+
+	function AppInsightsCore() {
+		this.pluginVersionString = '';
+	}
+
+	AppInsightsCore.prototype.initialize = function (_config, _extensions) { };
+	AppInsightsCore.prototype.track = function (_item) { };
+	AppInsightsCore.prototype.unload = function (_isAsync, unloadComplete) {
+		if (typeof unloadComplete === 'function') {
+			unloadComplete({});
+		}
+	};
+	AppInsightsCore.prototype.addTelemetryInitializer = function (_callback) { };
+
+	return {
+		AppInsightsCore: AppInsightsCore
+	};
+}));

--- a/scripts/stubs/@microsoft/1ds-core-js/package.json
+++ b/scripts/stubs/@microsoft/1ds-core-js/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@microsoft/1ds-core-js",
+  "description": "No-op stub — telemetry disabled for VS Codeee (Tauri fork).",
+  "version": "0.0.0-stub",
+  "main": "./bundle/ms.core.min.js",
+  "license": "MIT"
+}

--- a/scripts/stubs/@microsoft/1ds-post-js/bundle/ms.post.min.js
+++ b/scripts/stubs/@microsoft/1ds-post-js/bundle/ms.post.min.js
@@ -1,0 +1,32 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) VS Codeee Contributors. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// No-op stub for @microsoft/1ds-post-js (bundle entry point)
+// Provides minimal PostChannel that satisfies the PostChannel interface
+// used by src/vs/platform/telemetry/common/1dsAppender.ts
+//
+// See: https://github.com/j4rviscmd/vscodeee/issues/274
+
+(function (root, factory) {
+	if (typeof module !== 'undefined' && module.exports) {
+		module.exports = factory();
+	} else {
+		root.Microsoft = root.Microsoft || {};
+		root.Microsoft.ApplicationInsights = factory();
+	}
+}(typeof globalThis !== 'undefined' ? globalThis : typeof self !== 'undefined' ? self : this, function () {
+	'use strict';
+
+	function PostChannel() {
+		this.identifier = 'PostChannel';
+	}
+
+	PostChannel.prototype.initialize = function (_config, _core, _extensions) { };
+	PostChannel.prototype.processTelemetry = function (_item) { };
+
+	return {
+		PostChannel: PostChannel
+	};
+}));

--- a/scripts/stubs/@microsoft/1ds-post-js/package.json
+++ b/scripts/stubs/@microsoft/1ds-post-js/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@microsoft/1ds-post-js",
+  "description": "No-op stub — telemetry disabled for VS Codeee (Tauri fork).",
+  "version": "0.0.0-stub",
+  "main": "./bundle/ms.post.min.js",
+  "license": "MIT"
+}

--- a/scripts/stubs/@vscode/extension-telemetry/dist/browser/browser/telemetryReporter.js
+++ b/scripts/stubs/@vscode/extension-telemetry/dist/browser/browser/telemetryReporter.js
@@ -1,0 +1,32 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) VS Codeee Contributors. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// No-op stub for @vscode/extension-telemetry (browser entry point)
+// See: dist/node/node/telemetryReporter.js for the full implementation notes.
+
+'use strict';
+
+const noopEvent = Object.freeze({ dispose() { } });
+
+class TelemetryReporter {
+	constructor(_connectionString, _replacementOptions) {
+		this.telemetryLevel = 'off';
+		this.onDidChangeTelemetryLevel = noopEvent;
+	}
+
+	sendTelemetryEvent(_eventName, _properties, _measurements) { }
+	sendRawTelemetryEvent(_eventName, _properties, _measurements) { }
+	sendDangerousTelemetryEvent(_eventName, _properties, _measurements) { }
+	sendTelemetryErrorEvent(_eventName, _properties, _measurements) { }
+	sendDangerousTelemetryErrorEvent(_eventName, _properties, _measurements) { }
+
+	dispose() {
+		return Promise.resolve();
+	}
+}
+
+module.exports = TelemetryReporter;
+module.exports.default = TelemetryReporter;
+module.exports.TelemetryReporter = TelemetryReporter;

--- a/scripts/stubs/@vscode/extension-telemetry/dist/node/node/telemetryReporter.js
+++ b/scripts/stubs/@vscode/extension-telemetry/dist/node/node/telemetryReporter.js
@@ -1,0 +1,39 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) VS Codeee Contributors. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// No-op stub for @vscode/extension-telemetry
+// This stub replaces the real telemetry package in production builds to eliminate
+// ~80MB of transitive dependencies (@microsoft/applicationinsights-*, @nevware21/*)
+// while keeping all extension activation paths functional.
+//
+// See: https://github.com/j4rviscmd/vscodeee/issues/274
+
+'use strict';
+
+const noopEvent = Object.freeze({ dispose() { } });
+
+class TelemetryReporter {
+	constructor(_connectionString, _replacementOptions) {
+		this.telemetryLevel = 'off';
+		this.onDidChangeTelemetryLevel = noopEvent;
+	}
+
+	sendTelemetryEvent(_eventName, _properties, _measurements) { }
+	sendRawTelemetryEvent(_eventName, _properties, _measurements) { }
+	sendDangerousTelemetryEvent(_eventName, _properties, _measurements) { }
+	sendTelemetryErrorEvent(_eventName, _properties, _measurements) { }
+	sendDangerousTelemetryErrorEvent(_eventName, _properties, _measurements) { }
+
+	dispose() {
+		return Promise.resolve();
+	}
+}
+
+// Support both default and named exports:
+// - v0.9.x: import TelemetryReporter from '@vscode/extension-telemetry'
+// - v1.0.x: import { TelemetryReporter } from '@vscode/extension-telemetry'
+module.exports = TelemetryReporter;
+module.exports.default = TelemetryReporter;
+module.exports.TelemetryReporter = TelemetryReporter;

--- a/scripts/stubs/@vscode/extension-telemetry/dist/telemetryReporter.d.ts
+++ b/scripts/stubs/@vscode/extension-telemetry/dist/telemetryReporter.d.ts
@@ -1,0 +1,32 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+// No-op stub type definitions for @vscode/extension-telemetry
+
+export interface TelemetryEventProperties {
+	readonly [key: string]: string | import("vscode").TelemetryTrustedValue<string> | undefined;
+}
+
+export interface TelemetryEventMeasurements {
+	readonly [key: string]: number | undefined;
+}
+
+export interface ReplacementOption {
+	lookup: RegExp;
+	replacementString?: string;
+}
+
+export class TelemetryReporter {
+	constructor(connectionString: string, replacementOptions?: ReplacementOption[]);
+	telemetryLevel: 'all' | 'error' | 'crash' | 'off';
+	onDidChangeTelemetryLevel: import("vscode").Event<'all' | 'error' | 'crash' | 'off'>;
+	sendTelemetryEvent(eventName: string, properties?: TelemetryEventProperties, measurements?: TelemetryEventMeasurements): void;
+	sendRawTelemetryEvent(eventName: string, properties?: TelemetryEventProperties, measurements?: TelemetryEventMeasurements): void;
+	sendDangerousTelemetryEvent(eventName: string, properties?: TelemetryEventProperties, measurements?: TelemetryEventMeasurements): void;
+	sendTelemetryErrorEvent(eventName: string, properties?: TelemetryEventProperties, measurements?: TelemetryEventMeasurements): void;
+	sendDangerousTelemetryErrorEvent(eventName: string, properties?: TelemetryEventProperties, measurements?: TelemetryEventMeasurements): void;
+	dispose(): Promise<any>;
+}
+
+export default TelemetryReporter;

--- a/scripts/stubs/@vscode/extension-telemetry/package.json
+++ b/scripts/stubs/@vscode/extension-telemetry/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@vscode/extension-telemetry",
+  "description": "No-op stub — telemetry disabled for VS Codeee (Tauri fork).",
+  "version": "0.0.0-stub",
+  "main": "./dist/node/node/telemetryReporter.js",
+  "browser": "./dist/browser/browser/telemetryReporter.js",
+  "types": "./dist/telemetryReporter.d.ts",
+  "sideEffects": false,
+  "license": "MIT"
+}


### PR DESCRIPTION
## Summary

Replace `@vscode/extension-telemetry`, `@microsoft/1ds-core-js`, and `@microsoft/1ds-post-js` with minimal no-op stubs in the production bundle, eliminating ~80MB of unnecessary transitive dependencies.

## Changes

### `scripts/bundle-node-modules.mjs`
- Add `STUBBED_PACKAGES` map for 3 telemetry packages
- Add Phase 1.5 stub-copy phase between core modules and extension deps
- Add 8 entries to `EXCLUDED_PACKAGES` for transitive telemetry deps (`@microsoft/applicationinsights-*`, `@nevware21/*`)
- Remove `@microsoft/1ds-core-js` and `@microsoft/1ds-post-js` from `CORE_MODULES` (now handled as stubs)

### `scripts/stubs/` (new)
- `@vscode/extension-telemetry/` — No-op CJS stub with full API surface (supports both v0.9.x default export and v1.0.x named export patterns)
- `@microsoft/1ds-core-js/` — UMD stub providing `AppInsightsCore` with no-op `initialize()`, `track()`, `unload()`
- `@microsoft/1ds-post-js/` — UMD stub providing `PostChannel` with no-op `initialize()`, `processTelemetry()`

## Impact

| Metric | Before | After | Delta |
|--------|--------|-------|-------|
| Bundle size | 180.8 MB | 117.0 MB | **-63.8 MB** |
| `@microsoft/*` | ~66 MB | 16 KB (stubs) | **-99.97%** |
| `@nevware21/*` | ~15 MB | 0 | **-100%** |

## Testing

- [x] `node scripts/bundle-node-modules.mjs --clean` succeeds
- [x] All 11 telemetry-dependent extensions activate without errors
- [x] `npm run tauri:dev` — full app startup, extension host, terminal, git all functional
- [x] No telemetry-related errors in console
- [x] Clean shutdown

## Design Decisions

- **No-op stubs over tree-shaking**: Stubs maintain API contract, zero risk of runtime errors
- **UMD format for 1ds stubs**: Matches the `bundle/*.min.js` import path used by `1dsAppender.ts`
- **Both export styles**: `module.exports = X` + `module.exports.X = X` covers all extension import patterns

Closes #274