### PR TITLE
fix: use template-resolved title for Tauri native window title in Alt+Tab

### DIFF
--- a/src/vs/workbench/browser/parts/titlebar/windowTitle.ts
+++ b/src/vs/workbench/browser/parts/titlebar/windowTitle.ts
@@ -39,9 +39,12 @@ const enum WindowSettingNames {
 }
 
 export const defaultWindowTitle = (() => {
-	// TODO(Phase 2): Tauri custom titlebar handles dirty indicator and app name natively
+	// Tauri behaves as native app — match upstream Electron defaults per OS
 	if (isTauri) {
-		return '${activeEditorShort}${separator}${rootName}${separator}${profileName}${separator}${remoteName}';
+		if (isMacintosh) {
+			return '${activeEditorShort}${separator}${rootName}${separator}${profileName}'; // macOS has native dirty indicator
+		}
+		return '${dirty}${activeEditorShort}${separator}${rootName}${separator}${profileName}${separator}${appName}';
 	}
 
 	if (isMacintosh && isNative) {
@@ -217,15 +220,10 @@ export class WindowTitle extends Disposable {
 
 			// Tauri: set the native window title separately for Cmd+Tab, Mission Control, etc.
 			// hiddenTitle:true prevents document.title from propagating to the native title.
-			// The native title intentionally differs from document.title (custom titlebar text)
-			// to show a concise "workspace - appName" format in the OS window switcher.
+			// Use the same template-resolved title so Alt+Tab shows the active editor/workspace.
 			if (isTauri) {
-				const workspaceName = this.workspaceName;
-				const tauriNativeTitle = workspaceName
-					? `${workspaceName} - ${this.productService.nameLong}`
-					: this.productService.nameLong;
 				// TODO(Phase 2): extract __TAURI_INTERNALS__ usage into shared tauriInvoke helper
-				(window as unknown as Record<string, { invoke: (cmd: string, args: Record<string, unknown>) => Promise<void> }>).__TAURI_INTERNALS__?.invoke('plugin:window|set_title', { value: tauriNativeTitle }).catch(() => { /* runtime error */ });
+				(window as unknown as Record<string, { invoke: (cmd: string, args: Record<string, unknown>) => Promise<void> }>).__TAURI_INTERNALS__?.invoke('plugin:window|set_title', { value: nativeTitle }).catch(() => { /* runtime error */ });
 			}
 
 			this.title = title;


### PR DESCRIPTION
## Summary

Alt+Tab / Mission Control で表示されるウィンドウタイトルが「workspace名 + VS Codeee Dev」のみ表示される問題を修正。本家 VS Code と同じテンプレート解決済みタイトル（例: `index.ts - myproject`）が表示されるようになります。

## Related Issue

N/A（ユーザーフィードバックに基づく修正）

## Changes

- `defaultWindowTitle` テンプレートを Tauri 向けに OS 別分岐（本家 Electron と同じ挙動に）
  - macOS: `${activeEditorShort}${separator}${rootName}${separator}${profileName}`（dirty/appName なし — macOS はネイティブで表示）
  - Windows/Linux: `${dirty}${activeEditorShort}${separator}${rootName}${separator}${profileName}${separator}${appName}`
- `doUpdateTitle()` の Tauri `set_title` 呼び出しで、ハードコードされた「workspace - appName」をテンプレート解決済みの `nativeTitle` に変更

## Screenshots / Recording

N/A（Alt+Tab のウィンドウタイトル変更のため、スクリーンショットでの確認が困難）

## How to Test

1. アプリをビルド・起動
2. 任意のファイルを開く
3. Alt+Tab（macOS: Cmd+Tab）でウィンドウスイッチャーを表示
4. タイトルが「ファイル名 — ワークスペース名」形式で表示されることを確認
5. ターミナルにフォーカスして同様に確認