### PR TITLE
🚀 Release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2026-04-27
+
+### Fixed
+
+- Use template-resolved title for Tauri native window title in Alt+Tab — fixes window title not reflecting the active editor name when switching windows via OS window switcher ([#306](https://github.com/j4rviscmd/vscodeee/pull/306))
+
 ## [0.3.0] - 2026-04-26
 
 ### Added

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-utils/schema.json",
   "productName": "VS Codeee",
   "mainBinaryName": "codeee",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "identifier": "com.vscodeee.app",
   "build": {
     "frontendDist": "../out",


### PR DESCRIPTION
## Summary

Patch release with a window title fix for Alt+Tab behavior on Tauri.

## Changes

- Fix Tauri native window title not reflecting the active editor name when switching windows via OS window switcher ([#306](https://github.com/j4rviscmd/vscodeee/pull/306))

## Related Issue

Closes #306

## How to Test

1. Open multiple editor tabs with different file names
2. Switch between editors to change the active file
3. Use Alt+Tab (or Cmd+Tab on macOS) to switch windows
4. Verify the window title in the OS switcher shows the correct active editor name

🤖 Generated with [Claude Code](https://claude.com/claude-code)