### PR TITLE
feat: add system font enumeration for editor.fontFamily suggestions

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -896,14 +896,38 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core-graphics"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
+ "core-graphics-types 0.1.3",
+ "foreign-types",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
  "bitflags 2.11.1",
  "core-foundation 0.10.1",
- "core-graphics-types",
+ "core-graphics-types 0.2.0",
  "foreign-types",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics-types"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
  "libc",
 ]
 
@@ -915,6 +939,18 @@ checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.11.1",
  "core-foundation 0.10.1",
+ "libc",
+]
+
+[[package]]
+name = "core-text"
+version = "20.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9d2790b5c08465d49f8dc05c8bcae9fea467855947db39b0f8145c091aaced5"
+dependencies = [
+ "core-foundation 0.9.4",
+ "core-graphics 0.23.2",
+ "foreign-types",
  "libc",
 ]
 
@@ -5331,7 +5367,7 @@ dependencies = [
  "bitflags 2.11.1",
  "block2 0.6.2",
  "core-foundation 0.10.1",
- "core-graphics",
+ "core-graphics 0.25.0",
  "crossbeam-channel",
  "dispatch2",
  "dlopen2",
@@ -6579,6 +6615,7 @@ dependencies = [
  "clap_complete",
  "core-foundation 0.10.1",
  "core-foundation-sys",
+ "core-text",
  "dirs",
  "futures-util",
  "globset",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -60,6 +60,7 @@ security-framework = "3"
 security-framework-sys = "2"
 core-foundation = "0.10"
 core-foundation-sys = "0.8"
+core-text = "20"
 
 # Windows shell command install — creates .cmd wrapper and updates user PATH.
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/src-tauri/src/commands/native_host/misc.rs
+++ b/src-tauri/src/commands/native_host/misc.rs
@@ -11,9 +11,14 @@ use serde::{Deserialize, Serialize};
 use super::error::NativeHostError;
 
 /// File entry for zip creation.
+///
+/// Each entry represents a file to be included in the resulting zip archive,
+/// specified by its relative path within the archive and its text contents.
 #[derive(Deserialize)]
 pub struct ZipFileEntry {
+    /// Relative path of the file within the zip archive (e.g., `"src/index.ts"`).
     pub path: String,
+    /// Text contents to write for this file entry.
     pub contents: String,
 }
 
@@ -50,8 +55,11 @@ pub async fn create_zip_file(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ToastOptions {
+    /// Optional title for the notification. Falls back to `"VS Codeee"` if omitted.
     pub title: Option<String>,
+    /// Body text displayed in the notification.
     pub body: String,
+    /// Optional identifier for the notification, used for later dismissal.
     #[serde(default)]
     // TODO(Phase 3): Remove allow(dead_code) when this is wired up
     #[allow(dead_code)]
@@ -61,7 +69,10 @@ pub struct ToastOptions {
 /// Toast notification result returned to TypeScript.
 #[derive(Serialize)]
 pub struct ToastResult {
+    /// `true` if the desktop notification was successfully displayed.
     pub supported: bool,
+    /// `true` if the user clicked the notification. Always `false` because
+    /// `notify-rust` does not support async click tracking.
     pub clicked: bool,
 }
 
@@ -158,5 +169,124 @@ pub async fn write_elevated(
         Err(NativeHostError::Unsupported(
             "Elevated write on Windows is not yet supported".to_string(),
         ))
+    }
+}
+
+// ── Font enumeration ──────────────────────────────────────────────────
+
+/// Enumerate all available font family names on the system.
+///
+/// Returns a sorted, deduplicated list of font family names suitable for
+/// editor font selection.
+#[tauri::command]
+pub fn enumerate_fonts() -> Vec<String> {
+    #[cfg(target_os = "macos")]
+    {
+        enumerate_fonts_macos()
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        enumerate_fonts_windows()
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        enumerate_fonts_linux()
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
+    {
+        Vec::new()
+    }
+}
+
+/// Enumerate font families on macOS using Core Text.
+///
+/// Queries `CTFontManagerCopyAvailableFontFamilyNames` and returns a
+/// sorted, deduplicated list of font family names.
+#[cfg(target_os = "macos")]
+fn enumerate_fonts_macos() -> Vec<String> {
+    use core_text::font_manager;
+
+    let family_names = font_manager::copy_available_font_family_names();
+    let mut families: Vec<String> = family_names.iter().map(|name| name.to_string()).collect();
+    families.sort();
+    families.dedup();
+    families
+}
+
+/// Enumerate font families on Windows by reading the system font registry.
+///
+/// Reads from both `HKLM` and `HKCU` under
+/// `SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts`, extracts the
+/// family name portion (stripping style suffixes like "(TrueType)"), and
+/// returns a sorted, deduplicated list.
+///
+/// **Note:** This approach may miss some user-installed fonts. A future
+/// phase will use DirectWrite for complete enumeration.
+#[cfg(target_os = "windows")]
+fn enumerate_fonts_windows() -> Vec<String> {
+    // TODO(Phase 2): Use DirectWrite for complete font enumeration
+    // Currently reads from registry which may miss some user-installed fonts.
+    let mut families = Vec::new();
+
+    let subkey = "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts";
+    let hklm = winreg::RegKey::predef(winreg::enums::HKEY_LOCAL_MACHINE).open_subkey(subkey);
+    let hkcu = winreg::RegKey::predef(winreg::enums::HKEY_CURRENT_USER).open_subkey(subkey);
+
+    for reg_key in hklm.into_iter().chain(hkcu.into_iter()) {
+        collect_font_families_from_registry(&reg_key, &mut families);
+    }
+
+    families.sort();
+    families.dedup();
+    families
+}
+
+/// Extract font family names from a Windows registry key containing font entries.
+///
+/// Registry value names are typically in the form `"Segoe UI (TrueType)"`.
+/// This function strips the parenthesized style suffix and trims whitespace
+/// to produce a clean family name. Empty entries are silently discarded.
+#[cfg(target_os = "windows")]
+fn collect_font_families_from_registry(reg_key: &winreg::RegKey, families: &mut Vec<String>) {
+    for result in reg_key.enum_values() {
+        if let Ok((name, _)) = result {
+            let family = name.split(" (").next().unwrap_or(&name).trim().to_string();
+            if !family.is_empty() {
+                families.push(family);
+            }
+        }
+    }
+}
+
+/// Enumerate font families on Linux using `fc-list`.
+///
+/// Runs `fc-list --format=%{family}\\n` and parses the output into a
+/// sorted, deduplicated list of non-empty family names. If `fc-list`
+/// is unavailable or fails, logs a warning and returns an empty list.
+#[cfg(target_os = "linux")]
+fn enumerate_fonts_linux() -> Vec<String> {
+    let output = std::process::Command::new("fc-list")
+        .args(["--format=%{family}\\n"])
+        .output();
+
+    match output {
+        Ok(output) if output.status.success() => {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let mut families: Vec<String> = stdout
+                .lines()
+                .map(|line| line.trim().to_string())
+                .filter(|line| !line.is_empty())
+                .collect();
+            families.sort();
+            families.dedup();
+            families
+        }
+        _ => {
+            log::warn!(target: "vscodeee::fonts", "fc-list command failed; no fonts enumerated");
+            Vec::new()
+        }
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -308,6 +308,7 @@ pub fn run(gui_args: Option<cli::dispatch::ParsedGuiArgs>) {
             commands::native_host::clear_toast,
             commands::native_host::clear_toasts,
             commands::native_host::write_elevated,
+            commands::native_host::enumerate_fonts,
             // ── macOS metadata commands ──
             commands::native_host::set_represented_filename,
             commands::native_host::set_document_edited,

--- a/src/vs/base/browser/fonts.ts
+++ b/src/vs/base/browser/fonts.ts
@@ -5,7 +5,7 @@
 
 import { mainWindow } from './window.js';
 import type { IJSONSchemaSnippet } from '../common/jsonSchema.js';
-import { isElectron, isMacintosh, isWindows } from '../common/platform.js';
+import { isMacintosh, isTauri, isWindows } from '../common/platform.js';
 
 /**
  * The best font-family to be used in CSS based on the platform:
@@ -18,16 +18,45 @@ import { isElectron, isMacintosh, isWindows } from '../common/platform.js';
 export const DEFAULT_FONT_FAMILY = isWindows ? '"Segoe WPC", "Segoe UI", sans-serif' : isMacintosh ? '-apple-system, BlinkMacSystemFont, sans-serif' : 'system-ui, "Ubuntu", "Droid Sans", sans-serif';
 
 interface FontData {
+	/** Font family name as reported by the browser or system API. */
 	readonly family: string;
 }
 
+/** Minimal shape of the Tauri `core` API used for font enumeration. */
+interface ITauriCore {
+	invoke<T>(cmd: string, args?: Record<string, unknown>): Promise<T>;
+}
+
+/**
+ * Retrieve all available font family names from the system.
+ *
+ * In Tauri environments, invokes the `enumerate_fonts` Tauri command which
+ * delegates to platform-specific APIs (Core Text on macOS, registry on
+ * Windows, `fc-list` on Linux). In Electron environments, falls back to
+ * `window.queryLocalFonts()`.
+ *
+ * Returns an empty array if the platform does not support font enumeration
+ * or if an error occurs.
+ *
+ * @returns A promise that resolves to an array of font family name strings.
+ */
 export const getFonts = async (): Promise<string[]> => {
+	if (isTauri) {
+		try {
+			const tauri = (globalThis as Record<string, unknown>).__TAURI__ as { core: ITauriCore } | undefined;
+			if (tauri?.core) {
+				return await tauri.core.invoke<string[]>('enumerate_fonts');
+			}
+		} catch (error) {
+			console.error(`Failed to enumerate fonts via Tauri: ${error}`);
+		}
+		return [];
+	}
+
 	try {
 		// @ts-ignore
 		const fonts = await mainWindow.queryLocalFonts() as FontData[];
-		const fontsArray = [...fonts];
-		const families = fontsArray.map(font => font.family);
-		return families;
+		return [...fonts].map(font => font.family);
 	} catch (error) {
 		console.error(`Failed to query fonts: ${error}`);
 		return [];
@@ -35,15 +64,15 @@ export const getFonts = async (): Promise<string[]> => {
 };
 
 
+/**
+ * Retrieve all available font family names as JSON schema snippet objects.
+ *
+ * Each snippet has a `body` property set to the font family name, suitable
+ * for use in completion widgets or settings schemas.
+ *
+ * @returns A promise that resolves to an array of `IJSONSchemaSnippet` objects.
+ */
 export const getFontSnippets = async (): Promise<IJSONSchemaSnippet[]> => {
-	if (!isElectron) {
-		return [];
-	}
 	const fonts = await getFonts();
-	const snippets: IJSONSchemaSnippet[] = fonts.map(font => {
-		return {
-			body: `${font}`
-		};
-	});
-	return snippets;
+	return fonts.map(font => ({ body: font }));
 };


### PR DESCRIPTION
## Summary

- Add Tauri backend command `enumerate_fonts` that uses platform-native APIs (Core Text on macOS, registry on Windows, fc-list on Linux) to enumerate installed font families
- Replace the Electron-only `isElectron` guard in `fonts.ts` with Tauri invoke, enabling font suggestions in `editor.fontFamily` setting under Tauri
- Add `core-text` crate as macOS-only dependency for Core Text font enumeration

## Test plan

- [ ] Open settings.json and type `editor.fontFamily` — verify that installed system fonts appear as suggestions
- [ ] Select a font from the suggestions — verify it applies correctly to the editor
- [ ] Verify no console errors related to font enumeration

🤖 Generated with [Claude Code](https://claude.com/claude-code)