### PR TITLE
chore: exclude unused built-in extensions to reduce bundle size

### DIFF
--- a/build/gulpfile.extensions.ts
+++ b/build/gulpfile.extensions.ts
@@ -78,14 +78,14 @@ const compilations = [
 	'extensions/merge-conflict/tsconfig.json',
 	'extensions/mermaid-chat-features/tsconfig.json',
 	'extensions/terminal-suggest/tsconfig.json',
-	'extensions/microsoft-authentication/tsconfig.json',
+
 	'extensions/notebook-renderers/tsconfig.json',
 	'extensions/npm/tsconfig.json',
 	'extensions/php-language-features/tsconfig.json',
 	'extensions/references-view/tsconfig.json',
 	'extensions/search-result/tsconfig.json',
 	'extensions/simple-browser/tsconfig.json',
-	'extensions/tunnel-forwarding/tsconfig.json',
+
 	'extensions/typescript-language-features/web/tsconfig.json',
 	'extensions/typescript-language-features/tsconfig.json',
 	'extensions/vscode-api-tests/tsconfig.json',

--- a/build/lib/extensions.ts
+++ b/build/lib/extensions.ts
@@ -298,7 +298,6 @@ export function fromGithub({ name, version, repo, sha256, metadata }: IExtension
  */
 const nativeExtensions = [
 	'git',
-	'microsoft-authentication',
 ];
 
 const excludedExtensions = [
@@ -308,6 +307,9 @@ const excludedExtensions = [
 	'vscode-test-resolver',
 	'ms-vscode.node-debug',
 	'ms-vscode.node-debug2',
+	// TODO(Phase 1): Excluded for Tauri fork - SettingsSync/RemoteTunnel not supported
+	'microsoft-authentication',
+	'tunnel-forwarding',
 ];
 
 const marketplaceWebExtensionsExclude = new Set([

--- a/build/lib/mangle/index.ts
+++ b/build/lib/mangle/index.ts
@@ -329,7 +329,6 @@ const skippedExportMangledProjects = [
 
 	// These projects use webpack to dynamically rewrite imports, which messes up our mangling
 	'configuration-editing',
-	'microsoft-authentication',
 	'github-authentication',
 	'html-language-features/server',
 ];

--- a/build/next/index.ts
+++ b/build/next/index.ts
@@ -976,6 +976,9 @@ const EXCLUDED_EXTENSIONS = new Set([
 	'vscode-colorize-tests',
 	'vscode-colorize-perf-tests',
 	'vscode-test-resolver',
+	// TODO(Phase 1): Excluded for Tauri fork - SettingsSync/RemoteTunnel not supported
+	'microsoft-authentication',
+	'tunnel-forwarding',
 ]);
 
 /**

--- a/build/npm/dirs.ts
+++ b/build/npm/dirs.ts
@@ -38,14 +38,14 @@ export const dirs = [
 	'extensions/media-preview',
 	'extensions/merge-conflict',
 	'extensions/mermaid-chat-features',
-	'extensions/microsoft-authentication',
+
 	'extensions/notebook-renderers',
 	'extensions/npm',
 	'extensions/php-language-features',
 	'extensions/references-view',
 	'extensions/search-result',
 	'extensions/simple-browser',
-	'extensions/tunnel-forwarding',
+
 	'extensions/terminal-suggest',
 	'extensions/typescript-language-features',
 	'extensions/vscode-api-tests',

--- a/product.json
+++ b/product.json
@@ -1,55 +1,6 @@
 {
   "applicationName": "vscodeee",
-  "builtInExtensions": [
-    {
-      "metadata": {
-        "id": "99cb0b7f-7354-4278-b8da-6cc79972169d",
-        "publisherDisplayName": "Microsoft",
-        "publisherId": {
-          "displayName": "Microsoft",
-          "flags": "verified",
-          "publisherId": "5f5636e7-69ed-4afe-b5d6-8d231fb3d3ee",
-          "publisherName": "ms-vscode"
-        }
-      },
-      "name": "ms-vscode.js-debug-companion",
-      "repo": "https://github.com/microsoft/vscode-js-debug-companion",
-      "sha256": "7380a890787452f14b2db7835dfa94de538caf358ebc263f9d46dd68ac52de93",
-      "version": "1.1.3"
-    },
-    {
-      "metadata": {
-        "id": "25629058-ddac-4e17-abba-74678e126c5d",
-        "publisherDisplayName": "Microsoft",
-        "publisherId": {
-          "displayName": "Microsoft",
-          "flags": "verified",
-          "publisherId": "5f5636e7-69ed-4afe-b5d6-8d231fb3d3ee",
-          "publisherName": "ms-vscode"
-        }
-      },
-      "name": "ms-vscode.js-debug",
-      "repo": "https://github.com/microsoft/vscode-js-debug",
-      "sha256": "c24322931434940938f8cf76ebc3dac1e95a5539b9625b165b6672d7f7eafea8",
-      "version": "1.112.0"
-    },
-    {
-      "metadata": {
-        "id": "7e52b41b-71ad-457b-ab7e-0620f1fc4feb",
-        "publisherDisplayName": "Microsoft",
-        "publisherId": {
-          "displayName": "Microsoft",
-          "flags": "verified",
-          "publisherId": "5f5636e7-69ed-4afe-b5d6-8d231fb3d3ee",
-          "publisherName": "ms-vscode"
-        }
-      },
-      "name": "ms-vscode.vscode-js-profile-table",
-      "repo": "https://github.com/microsoft/vscode-js-profile-visualizer",
-      "sha256": "7361748ddf9fd09d8a2ed1f2a2d7376a2cf9aae708692820b799708385c38e08",
-      "version": "1.0.10"
-    }
-  ],
+  "builtInExtensions": [],
   "commit": "f2c30b4418ff642e63244f0865a9b4143f944dc4",
   "darwinBundleIdentifier": "com.vscodeee.app",
   "darwinProfilePayloadUUID": "CF808BE7-53F3-46C6-A7E2-7EDB98A5E959",

--- a/src-tauri/node_modules
+++ b/src-tauri/node_modules
@@ -1,1 +1,0 @@
-../node_modules

--- a/src-tauri/node_modules
+++ b/src-tauri/node_modules
@@ -1,0 +1,1 @@
+../node_modules

--- a/src/vs/workbench/api/browser/mainThreadMessageService.ts
+++ b/src/vs/workbench/api/browser/mainThreadMessageService.ts
@@ -22,7 +22,6 @@ export class MainThreadMessageService implements MainThreadMessageServiceShape {
 
 	private static readonly URGENT_NOTIFICATION_SOURCES = [
 		'vscode.github-authentication',
-		'vscode.microsoft-authentication'
 	];
 
 	constructor(

--- a/src/vs/workbench/api/browser/mainThreadProgress.ts
+++ b/src/vs/workbench/api/browser/mainThreadProgress.ts
@@ -17,7 +17,6 @@ export class MainThreadProgress implements MainThreadProgressShape {
 
 	private static readonly URGENT_PROGRESS_SOURCES = [
 		'vscode.github-authentication',
-		'vscode.microsoft-authentication'
 	];
 
 	private readonly _progressService: IProgressService;


### PR DESCRIPTION
## Summary

Exclude unused built-in extensions from the build to reduce bundle size (~155MB savings).

Closes #291

## Changes

### Excluded extensions

| Extension | Size | Reason |
|---|---|---|
| `microsoft-authentication` | 152MB | SettingsSync and RemoteTunnel are not supported in this Tauri fork |
| `tunnel-forwarding` | 2.7MB | RemoteTunnel is not supported |
| `ms-vscode.js-debug` | (marketplace DL) | Available from marketplace on demand |
| `ms-vscode.js-debug-companion` | (marketplace DL) | Available from marketplace on demand |
| `ms-vscode.vscode-js-profile-table` | (marketplace DL) | Available from marketplace on demand |

### Modified files

- `build/next/index.ts` — Added to `EXCLUDED_EXTENSIONS`
- `build/lib/extensions.ts` — Added to `excludedExtensions`, removed from `nativeExtensions`
- `product.json` — Emptied `builtInExtensions` array
- `build/lib/mangle/index.ts` — Removed from `skippedExportMangledProjects`
- `build/npm/dirs.ts` — Removed directory references
- `build/gulpfile.extensions.ts` — Removed tsconfig references
- `src/vs/workbench/api/browser/mainThreadProgress.ts` — Removed from `URGENT_PROGRESS_SOURCES`
- `src/vs/workbench/api/browser/mainThreadMessageService.ts` — Removed from `URGENT_NOTIFICATION_SOURCES`

## Verification

- [x] TypeScript compile check passes (`npm run compile-check-ts-native`)
- [x] No new build errors (existing `gulpfile.reh.ts` error is pre-existing)
- [x] App launches normally with 95 built-in extensions
- [x] Extension host starts successfully (2 instances)
- [x] GitHub authentication (Copilot) works unaffected
- [x] No runtime errors related to removed extensions

## Impact

- **GitHub auth**: Unaffected — uses `github-authentication` (separate extension)
- **Copilot**: Unaffected — authenticates via GitHub OAuth, not Microsoft auth
- **JS debugging**: Not available by default — can be installed from marketplace
- **Port forwarding**: Not available — intentionally removed (RemoteTunnel not supported)