### PR TITLE
chore: add Cargo release profile for binary size optimization

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -65,3 +65,16 @@ core-text = "20"
 # Windows shell command install — creates .cmd wrapper and updates user PATH.
 [target.'cfg(target_os = "windows")'.dependencies]
 winreg = "0.55"
+
+# --- Build profiles for binary size optimization ---
+# Reference: https://tauri.app/concept/size/
+
+[profile.dev]
+incremental = true # Compile in smaller steps for faster iteration.
+
+[profile.release]
+codegen-units = 1 # Allows LLVM to perform better optimization.
+lto = true         # Enables link-time-optimizations.
+opt-level = "s"    # Prioritizes small binary size. Use `3` if you prefer speed.
+panic = "abort"    # Higher performance by disabling panic handlers.
+strip = true       # Ensures debug symbols are removed.


### PR DESCRIPTION
## Summary

Add `[profile.release]` and `[profile.dev]` sections to `src-tauri/Cargo.toml` following [Tauri's official size optimization guide](https://tauri.app/concept/size/).

## Changes

- `codegen-units = 1` — enables better LLVM optimization
- `lto = true` — enables link-time optimizations for dead code elimination
- `opt-level = "s"` — prioritizes small binary size over speed
- `panic = "abort"` — removes panic handler overhead
- `strip = true` — removes debug symbols
- `incremental = true` (dev only) — faster dev builds

## Measured Results (macOS aarch64)

| Metric | Before | After | Reduction |
|--------|--------|-------|-----------|
| `codeee` binary | **55 MB** | **34 MB** | **-21 MB (38%)** |

> Note: Only the Rust binary (`codeee`) is affected. The Node.js sidecar and JS/extension resources are unchanged.

## Related

- Closes #291
- Related: #312 (local build symlink issue — separate fix)