### PR TITLE
fix: detect and remove symlink at src-tauri/node_modules before bundling

### DIFF
--- a/scripts/bundle-node-modules.mjs
+++ b/scripts/bundle-node-modules.mjs
@@ -316,6 +316,25 @@ function copyPackage(pkgName) {
 function main() {
 	console.log('[bundle-node-modules] Bundling required node_modules for Tauri build...');
 
+	// Guard: If TARGET_DIR is a symlink (e.g. -> ../node_modules created by
+	// npm install), remove it so we can create a real directory with only the
+	// curated subset of packages. Without this, Tauri would follow the symlink
+	// and bundle the entire root node_modules (~960MB) into the production app.
+	// See: https://github.com/j4rviscmd/vscodeee/issues/312
+	try {
+		const stat = fs.lstatSync(TARGET_DIR);
+		if (stat.isSymbolicLink()) {
+			const linkTarget = fs.readlinkSync(TARGET_DIR);
+			console.log(`[bundle-node-modules] Removing symlink: ${TARGET_DIR} -> ${linkTarget}`);
+			fs.unlinkSync(TARGET_DIR);
+		}
+	} catch (/** @type {any} */ e) {
+		// ENOENT is expected when the directory doesn't exist yet
+		if (e.code !== 'ENOENT') {
+			throw e;
+		}
+	}
+
 	if (clean && fs.existsSync(TARGET_DIR)) {
 		console.log(`[bundle-node-modules] Cleaning ${TARGET_DIR}`);
 		fs.rmSync(TARGET_DIR, { recursive: true });


### PR DESCRIPTION
## Summary

Fix `bundle-node-modules.mjs` to detect and remove symlink at `src-tauri/node_modules` before copying curated packages.

## Problem

When `src-tauri/node_modules` is a symlink to `../node_modules` (created by `npm install` in the main repo), Tauri follows the symlink and bundles the entire root `node_modules` (~960MB) instead of the curated subset (~91MB).

## Solution

Add an `lstatSync` guard at the top of `main()` that:
1. Checks if `TARGET_DIR` is a symlink (using `lstatSync` which doesn't follow symlinks)
2. If yes, logs the symlink target and removes it with `unlinkSync`
3. Proceeds normally to create a real directory with only needed packages

This runs before the existing `--clean` check, so it works regardless of flags.

## Measured Results (macOS aarch64)

| Metric | Before (symlink) | After (fix) |
|--------|------------------|-------------|
| `node_modules` in `.app` | ~960MB | **91MB** |
| `.app` total | ~1.5GB | **464MB** |

> CI/GitHub Actions are not affected (clean `npm ci` environment has no symlink).

## Closes

- Closes #312