### PR TITLE
feat: add zoom status bar indicator with per-window zoom support

### DIFF
--- a/src/vs/platform/window/common/window.ts
+++ b/src/vs/platform/window/common/window.ts
@@ -211,6 +211,7 @@ export interface IWindowSettings {
 	readonly newWindowProfile: string;
 	readonly density: IDensitySettings;
 	readonly border: 'off' | 'default' | 'system' | string /* color in RGB or other formats */;
+	readonly zoomPerWindow: boolean;
 }
 
 export interface IDensitySettings {

--- a/src/vs/platform/window/tauri-browser/zoom.ts
+++ b/src/vs/platform/window/tauri-browser/zoom.ts
@@ -1,0 +1,34 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) VS Codeee Contributors. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { setZoomFactor, setZoomLevel } from '../../../base/browser/browser.js';
+import { mainWindow } from '../../../base/browser/window.js';
+import { invoke } from '../../tauri/common/tauriApi.js';
+import { zoomLevelToZoomFactor } from '../common/window.js';
+
+/** Maximum allowed zoom level (inclusive). */
+export const MAX_ZOOM_LEVEL = 8;
+/** Minimum allowed zoom level (inclusive). */
+export const MIN_ZOOM_LEVEL = -8;
+
+/**
+ * Apply a zoom level to the given window via Tauri's native WebView zoom.
+ *
+ * The requested zoom level is clamped to {@link MIN_ZOOM_LEVEL} and {@link MAX_ZOOM_LEVEL}
+ * before being converted to a zoom factor and applied. This updates both the in-memory
+ * WindowManager state and the native webview simultaneously.
+ *
+ * @param zoomLevel - The desired zoom level (integer). Will be clamped to the valid range.
+ * @param targetWindow - The browser window to apply the zoom to. Defaults to the main window.
+ * @returns A promise that resolves when the native zoom has been applied.
+ */
+export async function applyZoom(zoomLevel: number, targetWindow: Window = mainWindow): Promise<void> {
+	const clampedLevel = Math.min(Math.max(zoomLevel, MIN_ZOOM_LEVEL), MAX_ZOOM_LEVEL);
+	const factor = zoomLevelToZoomFactor(clampedLevel);
+
+	await invoke('set_webview_zoom', { scaleFactor: factor });
+	setZoomFactor(factor, targetWindow);
+	setZoomLevel(clampedLevel, targetWindow);
+}

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -943,6 +943,12 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 				'maximum': 24,
 				'markdownDescription': localize('zoomLevel', "Adjust the zoom level of the window. The original size is 0 and each increment above (e.g. 1) or below (e.g. -1) represents zooming 20% larger or smaller respectively. You can also enter decimals for a finer zoom level."),
 				'scope': ConfigurationScope.APPLICATION
+			},
+			'window.zoomPerWindow': {
+				'type': 'boolean',
+				'default': true,
+				'markdownDescription': localize('zoomPerWindow', "Controls whether the zoom level applies per window or globally. When enabled, zoom changes only affect the active window and do not modify the `{0}` setting.", '`#window.zoomLevel#`'),
+				'scope': ConfigurationScope.APPLICATION
 			}
 		}
 	});

--- a/src/vs/workbench/services/zoom/browser/zoom.contribution.ts
+++ b/src/vs/workbench/services/zoom/browser/zoom.contribution.ts
@@ -1,0 +1,11 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) VS Codeee Contributors. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
+import { IWindowZoomService } from '../common/zoom.js';
+import { WindowZoomService } from './zoomService.js';
+
+// Register WindowZoomService as a delayed singleton so it is only instantiated on first use.
+registerSingleton(IWindowZoomService, WindowZoomService, InstantiationType.Delayed);

--- a/src/vs/workbench/services/zoom/browser/zoomService.ts
+++ b/src/vs/workbench/services/zoom/browser/zoomService.ts
@@ -1,0 +1,153 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) VS Codeee Contributors. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Emitter, Event } from '../../../../base/common/event.js';
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { mainWindow } from '../../../../base/browser/window.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
+import { IWorkbenchLayoutService } from '../../layout/browser/layoutService.js';
+import { applyZoom, MAX_ZOOM_LEVEL, MIN_ZOOM_LEVEL } from '../../../../platform/window/tauri-browser/zoom.js';
+import { getZoomLevel } from '../../../../base/browser/browser.js';
+import { IWindowZoomService } from '../common/zoom.js';
+
+const ZOOM_PER_WINDOW_STORAGE_KEY = 'window.perWindowZoomLevel';
+
+/**
+ * Implementation of {@link IWindowZoomService} for the Tauri platform.
+ *
+ * Manages zoom state by reacting to configuration changes for `window.zoomLevel`
+ * and `window.zoomPerWindow`. When per-window zoom is active, per-window zoom
+ * levels are persisted to {@link ZOOM_PER_WINDOW_STORAGE_KEY} in application storage
+ * so they survive restarts without polluting user settings.
+ */
+export class WindowZoomService extends Disposable implements IWindowZoomService {
+	declare readonly _serviceBrand: undefined;
+
+	private readonly _onDidChangeZoom = this._register(new Emitter<void>());
+	readonly onDidChangeZoom: Event<void> = this._onDidChangeZoom.event;
+
+	private _configuredZoomLevel: number;
+
+	constructor(
+		@IConfigurationService private readonly configurationService: IConfigurationService,
+		@IStorageService private readonly storageService: IStorageService,
+		@IWorkbenchLayoutService private readonly layoutService: IWorkbenchLayoutService,
+	) {
+		super();
+
+		this._configuredZoomLevel = this.resolveConfiguredZoomLevel();
+
+		this._register(configurationService.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration('window.zoomLevel') || e.affectsConfiguration('window.zoomPerWindow')) {
+				this._configuredZoomLevel = this.resolveConfiguredZoomLevel();
+				let handled = false;
+
+				if (e.affectsConfiguration('window.zoomLevel') && !this.zoomPerWindow) {
+					this.applyConfiguredZoom();
+					handled = true;
+				}
+
+				if (e.affectsConfiguration('window.zoomPerWindow') && !this.zoomPerWindow) {
+					this.applyConfiguredZoom();
+					this.storageService.remove(ZOOM_PER_WINDOW_STORAGE_KEY, StorageScope.APPLICATION);
+					handled = true;
+				}
+
+				if (!handled) {
+					this._onDidChangeZoom.fire();
+				}
+			}
+		}));
+	}
+
+	get configuredZoomLevel(): number {
+		return this._configuredZoomLevel;
+	}
+
+	get zoomPerWindow(): boolean {
+		return this.configurationService.getValue<boolean>('window.zoomPerWindow') !== false;
+	}
+
+	getZoomLevel(): number {
+		return getZoomLevel(mainWindow);
+	}
+
+	async applyZoomDelta(delta: number): Promise<void> {
+		const currentLevel = this.zoomPerWindow ? getZoomLevel(mainWindow) : this._configuredZoomLevel;
+		const newLevel = Math.round(currentLevel + delta);
+		if (newLevel > MAX_ZOOM_LEVEL || newLevel < MIN_ZOOM_LEVEL) {
+			return;
+		}
+
+		if (this.zoomPerWindow) {
+			await applyZoom(newLevel, mainWindow);
+			this.layoutService.layout();
+			this.persistPerWindowZoom(newLevel);
+			this._onDidChangeZoom.fire();
+		} else {
+			await this.configurationService.updateValue('window.zoomLevel', newLevel);
+		}
+	}
+
+	async resetZoom(): Promise<void> {
+		if (this.zoomPerWindow) {
+			await applyZoom(this._configuredZoomLevel, mainWindow);
+			this.layoutService.layout();
+			this.storageService.remove(ZOOM_PER_WINDOW_STORAGE_KEY, StorageScope.APPLICATION);
+			this._onDidChangeZoom.fire();
+		} else {
+			await this.configurationService.updateValue('window.zoomLevel', this._configuredZoomLevel);
+		}
+	}
+
+	async restoreZoom(): Promise<void> {
+		let targetLevel = this._configuredZoomLevel;
+		let notify = false;
+
+		if (this.zoomPerWindow) {
+			const storedLevel = this.storageService.getNumber(ZOOM_PER_WINDOW_STORAGE_KEY, StorageScope.APPLICATION);
+			if (typeof storedLevel === 'number' && storedLevel !== this._configuredZoomLevel) {
+				targetLevel = storedLevel;
+				notify = true;
+			}
+		}
+
+		await applyZoom(targetLevel, mainWindow);
+		this.layoutService.layout();
+		if (notify) {
+			this._onDidChangeZoom.fire();
+		}
+	}
+
+	/** Resolve the current `window.zoomLevel` setting, defaulting to 0 if unset. */
+	private resolveConfiguredZoomLevel(): number {
+		const windowZoomLevel = this.configurationService.getValue<number>('window.zoomLevel');
+		return typeof windowZoomLevel === 'number' ? windowZoomLevel : 0;
+	}
+
+	/** Apply the configured (global) zoom level and trigger a layout recalculation. */
+	private async applyConfiguredZoom(): Promise<void> {
+		await applyZoom(this._configuredZoomLevel, mainWindow);
+		this.layoutService.layout();
+		this._onDidChangeZoom.fire();
+	}
+
+	/**
+	 * Persist a per-window zoom level to application storage.
+	 *
+	 * If the given level matches the configured (global) zoom level, the storage
+	 * entry is removed to avoid redundancy.
+	 *
+	 * @param level - The per-window zoom level to persist.
+	 */
+	private persistPerWindowZoom(level: number): void {
+		if (level === this._configuredZoomLevel) {
+			this.storageService.remove(ZOOM_PER_WINDOW_STORAGE_KEY, StorageScope.APPLICATION);
+		} else {
+			this.storageService.store(ZOOM_PER_WINDOW_STORAGE_KEY, level, StorageScope.APPLICATION, StorageTarget.MACHINE);
+		}
+	}
+}

--- a/src/vs/workbench/services/zoom/common/zoom.ts
+++ b/src/vs/workbench/services/zoom/common/zoom.ts
@@ -1,0 +1,48 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) VS Codeee Contributors. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Event } from '../../../../base/common/event.js';
+import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
+
+/** Service identifier for {@link IWindowZoomService}. */
+export const IWindowZoomService = createDecorator<IWindowZoomService>('windowZoomService');
+
+/**
+ * Service for managing window zoom levels in the workbench.
+ *
+ * Supports two modes controlled by the `window.zoomPerWindow` setting:
+ * - **Global mode** (`zoomPerWindow = false`): Zoom changes are written to
+ *   `window.zoomLevel` in user settings and apply to all windows.
+ * - **Per-window mode** (`zoomPerWindow = true`): Zoom changes apply only to
+ *   the current window and are persisted in application storage.
+ */
+export interface IWindowZoomService {
+	readonly _serviceBrand: undefined;
+
+	/** The configured (global) zoom level from window.zoomLevel setting. */
+	readonly configuredZoomLevel: number;
+
+	/** Whether per-window zoom is enabled. */
+	readonly zoomPerWindow: boolean;
+
+	/** Fires when the effective zoom changes (per-window or global). */
+	readonly onDidChangeZoom: Event<void>;
+
+	/** Get the current effective zoom level for the main window. */
+	getZoomLevel(): number;
+
+	/**
+	 * Apply a zoom delta to the active window.
+	 * When zoomPerWindow is true: applies in-memory only, persists to storage.
+	 * When zoomPerWindow is false: writes to window.zoomLevel config.
+	 */
+	applyZoomDelta(delta: number): Promise<void>;
+
+	/** Reset zoom to the configured level. */
+	resetZoom(): Promise<void>;
+
+	/** Restore persisted per-window zoom on startup. */
+	restoreZoom(): Promise<void>;
+}

--- a/src/vs/workbench/tauri-browser/actions/nativeActions.ts
+++ b/src/vs/workbench/tauri-browser/actions/nativeActions.ts
@@ -10,7 +10,6 @@ import { KeybindingWeight } from '../../../platform/keybinding/common/keybinding
 import { KeyCode, KeyMod } from '../../../base/common/keyCodes.js';
 import { INativeHostService } from '../../../platform/native/common/native.js';
 import { ServicesAccessor } from '../../../platform/instantiation/common/instantiation.js';
-import { IConfigurationService } from '../../../platform/configuration/common/configuration.js';
 
 // #region Quit
 
@@ -153,6 +152,8 @@ registerAction2(ToggleMaximizedWindowAction);
 
 // #region Zoom
 
+import { IWindowZoomService } from '../../services/zoom/common/zoom.js';
+
 /** Increases the workbench zoom level by 1. */
 class ZoomInAction extends Action2 {
   constructor() {
@@ -169,9 +170,8 @@ class ZoomInAction extends Action2 {
   }
 
   async run(accessor: ServicesAccessor): Promise<void> {
-    const configurationService = accessor.get(IConfigurationService);
-    const currentZoom = configurationService.getValue<number>('window.zoomLevel') ?? 0;
-    await configurationService.updateValue('window.zoomLevel', currentZoom + 1);
+    const windowZoomService = accessor.get(IWindowZoomService);
+    await windowZoomService.applyZoomDelta(1);
   }
 }
 
@@ -193,15 +193,14 @@ class ZoomOutAction extends Action2 {
   }
 
   async run(accessor: ServicesAccessor): Promise<void> {
-    const configurationService = accessor.get(IConfigurationService);
-    const currentZoom = configurationService.getValue<number>('window.zoomLevel') ?? 0;
-    await configurationService.updateValue('window.zoomLevel', currentZoom - 1);
+    const windowZoomService = accessor.get(IWindowZoomService);
+    await windowZoomService.applyZoomDelta(-1);
   }
 }
 
 registerAction2(ZoomOutAction);
 
-/** Resets the workbench zoom level to the default (0). */
+/** Resets the workbench zoom level to the default. */
 class ZoomResetAction extends Action2 {
   constructor() {
     super({
@@ -218,8 +217,8 @@ class ZoomResetAction extends Action2 {
   }
 
   async run(accessor: ServicesAccessor): Promise<void> {
-    const configurationService = accessor.get(IConfigurationService);
-    await configurationService.updateValue('window.zoomLevel', 0);
+    const windowZoomService = accessor.get(IWindowZoomService);
+    await windowZoomService.resetZoom();
   }
 }
 

--- a/src/vs/workbench/tauri-browser/contrib/zoomStatusEntry.ts
+++ b/src/vs/workbench/tauri-browser/contrib/zoomStatusEntry.ts
@@ -1,0 +1,179 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) VS Codeee Contributors. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { localize } from '../../../nls.js';
+import { Action } from '../../../base/common/actions.js';
+import { Codicon } from '../../../base/common/codicons.js';
+import { Disposable, DisposableStore, MutableDisposable, toDisposable } from '../../../base/common/lifecycle.js';
+import { ThemeIcon } from '../../../base/common/themables.js';
+import { $ } from '../../../base/browser/dom.js';
+import { ActionBar } from '../../../base/browser/ui/actionbar/actionbar.js';
+import { nativeHoverDelegate } from '../../../platform/hover/browser/hover.js';
+import { ICommandService } from '../../../platform/commands/common/commands.js';
+import { IKeybindingService } from '../../../platform/keybinding/common/keybinding.js';
+import { IStatusbarService, ShowTooltipCommand, StatusbarAlignment } from '../../services/statusbar/browser/statusbar.js';
+import { IWindowZoomService } from '../../services/zoom/common/zoom.js';
+import { getZoomFactor, getZoomLevel } from '../../../base/browser/browser.js';
+import { mainWindow } from '../../../base/browser/window.js';
+import { registerWorkbenchContribution2, WorkbenchPhase, IWorkbenchContribution } from '../../common/contributions.js';
+
+/**
+ * Manages a zoom indicator entry in the status bar.
+ *
+ * When visible, the entry displays an inline tooltip with zoom-in, zoom-out,
+ * reset, and settings actions. The current zoom level label and its percentage
+ * equivalent are shown in the tooltip bar.
+ *
+ * The entry is shown only when the effective zoom level differs from the
+ * configured zoom level, and is automatically hidden when they match.
+ */
+class ZoomStatusEntry extends Disposable {
+
+	private readonly disposable = this._register(new MutableDisposable<DisposableStore>());
+	private zoomLevelLabel: Action | undefined = undefined;
+	private currentText: string | undefined;
+
+	constructor(
+		@IStatusbarService private readonly statusbarService: IStatusbarService,
+		@ICommandService private readonly commandService: ICommandService,
+		@IKeybindingService private readonly keybindingService: IKeybindingService,
+	) {
+		super();
+	}
+
+	/**
+	 * Show, hide, or update the zoom status bar entry.
+	 *
+	 * @param visibleOrText - The status bar text (e.g. `'$(zoom-in)'` or `'$(zoom-out)'`)
+	 *   to display, or `false` to hide the entry entirely.
+	 */
+	updateZoomEntry(visibleOrText: false | string): void {
+		if (typeof visibleOrText === 'string') {
+			if (!this.disposable.value || this.currentText !== visibleOrText) {
+				this.createZoomEntry(visibleOrText);
+				this.currentText = visibleOrText;
+			}
+
+			this.updateZoomLevelLabel();
+		} else {
+			this.disposable.clear();
+			this.currentText = undefined;
+		}
+	}
+
+	/**
+	 * Create (or recreate) the status bar entry with the given display text.
+	 *
+	 * Builds two action bars:
+	 * - **Left**: Zoom Out button, zoom level label, Zoom In button.
+	 * - **Right**: Reset label, Settings gear button.
+	 *
+	 * Each action is wired to its corresponding command via {@link ICommandService}.
+	 * Keybindings are resolved via {@link IKeybindingService} and shown in tooltips.
+	 *
+	 * @param visibleOrText - The status bar text to display for the entry.
+	 */
+	private createZoomEntry(visibleOrText: string): void {
+		const disposables = new DisposableStore();
+		this.disposable.value = disposables;
+
+		const container = $('.zoom-status');
+
+		const left = $('.zoom-status-left');
+		container.appendChild(left);
+
+		const zoomOutAction: Action = disposables.add(new Action('workbench.action.zoomOut', localize('zoomOut', "Zoom Out"), ThemeIcon.asClassName(Codicon.remove), true, () => this.commandService.executeCommand(zoomOutAction.id)));
+		const zoomInAction: Action = disposables.add(new Action('workbench.action.zoomIn', localize('zoomIn', "Zoom In"), ThemeIcon.asClassName(Codicon.plus), true, () => this.commandService.executeCommand(zoomInAction.id)));
+		const zoomResetAction: Action = disposables.add(new Action('workbench.action.zoomReset', localize('zoomReset', "Reset"), undefined, true, () => this.commandService.executeCommand(zoomResetAction.id)));
+		zoomResetAction.tooltip = this.keybindingService.appendKeybinding(zoomResetAction.label, zoomResetAction.id) ?? zoomResetAction.label;
+		const zoomSettingsAction: Action = disposables.add(new Action('workbench.action.openSettings', localize('zoomSettings', "Settings"), ThemeIcon.asClassName(Codicon.settingsGear), true, () => this.commandService.executeCommand(zoomSettingsAction.id, 'window.zoom')));
+		const zoomLevelLabel = disposables.add(new Action('zoomLabel', undefined, undefined, false));
+
+		this.zoomLevelLabel = zoomLevelLabel;
+		disposables.add(toDisposable(() => this.zoomLevelLabel = undefined));
+
+		const actionBarLeft = disposables.add(new ActionBar(left, { hoverDelegate: nativeHoverDelegate }));
+		actionBarLeft.push(zoomOutAction, { icon: true, label: false, keybinding: this.keybindingService.lookupKeybinding(zoomOutAction.id)?.getLabel() });
+		actionBarLeft.push(this.zoomLevelLabel, { icon: false, label: true });
+		actionBarLeft.push(zoomInAction, { icon: true, label: false, keybinding: this.keybindingService.lookupKeybinding(zoomInAction.id)?.getLabel() });
+
+		const right = $('.zoom-status-right');
+		container.appendChild(right);
+
+		const actionBarRight = disposables.add(new ActionBar(right, { hoverDelegate: nativeHoverDelegate }));
+		actionBarRight.push(zoomResetAction, { icon: false, label: true });
+		actionBarRight.push(zoomSettingsAction, { icon: true, label: false, keybinding: this.keybindingService.lookupKeybinding(zoomSettingsAction.id)?.getLabel() });
+
+		const name = localize('status.windowZoom', "Window Zoom");
+		disposables.add(this.statusbarService.addEntry({
+			name,
+			text: visibleOrText,
+			tooltip: container,
+			ariaLabel: name,
+			command: ShowTooltipCommand,
+			kind: 'prominent'
+		}, 'status.windowZoom', StatusbarAlignment.RIGHT, 102));
+	}
+
+	/** Update the zoom level label text and tooltip to reflect the current effective zoom. */
+	private updateZoomLevelLabel(): void {
+		if (this.zoomLevelLabel) {
+			const zoomFactor = Math.round(getZoomFactor(mainWindow) * 100);
+			const zoomLevel = getZoomLevel(mainWindow);
+
+			this.zoomLevelLabel.label = `${zoomLevel}`;
+			this.zoomLevelLabel.tooltip = localize('zoomNumber', "Zoom Level: {0} ({1}%)", zoomLevel, zoomFactor);
+		}
+	}
+}
+
+/**
+ * Workbench contribution that drives the zoom status bar entry.
+ *
+ * Listens to {@link IWindowZoomService.onDidChangeZoom} and shows a zoom indicator
+ * in the status bar whenever the effective zoom level diverges from the configured
+ * zoom level. The indicator uses `$(zoom-in)` when zoomed in and `$(zoom-out)` when
+ * zoomed out.
+ */
+export class ZoomStatusEntryContribution extends Disposable implements IWorkbenchContribution {
+
+	static readonly ID = 'tauri.zoomStatusEntry';
+
+	private readonly zoomStatusEntry: ZoomStatusEntry;
+
+	constructor(
+		@IWindowZoomService private readonly windowZoomService: IWindowZoomService,
+		@IStatusbarService statusbarService: IStatusbarService,
+		@ICommandService commandService: ICommandService,
+		@IKeybindingService keybindingService: IKeybindingService,
+	) {
+		super();
+
+		this.zoomStatusEntry = this._register(new ZoomStatusEntry(statusbarService, commandService, keybindingService));
+
+		this._register(this.windowZoomService.onDidChangeZoom(() => this.updateStatusEntry()));
+		this.updateStatusEntry();
+	}
+
+	/**
+	 * Compare the current effective zoom level against the configured zoom level
+	 * and show or hide the status bar entry accordingly.
+	 */
+	private updateStatusEntry(): void {
+		const currentZoomLevel = this.windowZoomService.getZoomLevel();
+		const configuredZoomLevel = this.windowZoomService.configuredZoomLevel;
+
+		let text: string | undefined = undefined;
+		if (currentZoomLevel < configuredZoomLevel) {
+			text = '$(zoom-out)';
+		} else if (currentZoomLevel > configuredZoomLevel) {
+			text = '$(zoom-in)';
+		}
+
+		this.zoomStatusEntry.updateZoomEntry(text ?? false);
+	}
+}
+
+registerWorkbenchContribution2(ZoomStatusEntryContribution.ID, ZoomStatusEntryContribution, WorkbenchPhase.AfterRestored);

--- a/src/vs/workbench/tauri-browser/desktop.tauri.main.ts
+++ b/src/vs/workbench/tauri-browser/desktop.tauri.main.ts
@@ -13,7 +13,7 @@
 import product from '../../platform/product/common/product.js';
 import { Workbench } from '../browser/workbench.js';
 import { domContentLoaded, addDisposableListener, EventHelper, EventType } from '../../base/browser/dom.js';
-import { setZoomLevel, getZoomLevel } from '../../base/browser/browser.js';
+import { IWindowZoomService } from '../services/zoom/common/zoom.js';
 import { ServiceCollection } from '../../platform/instantiation/common/serviceCollection.js';
 import { ILogService, ILoggerService, getLogLevel, ConsoleLogger } from '../../platform/log/common/log.js';
 import { FileLoggerService } from '../../platform/log/common/fileLog.js';
@@ -67,7 +67,7 @@ import { TauriNativeHostService } from '../../platform/native/tauri-browser/nati
 import { TauriWorkbenchEnvironmentService, ITauriWindowConfiguration } from '../services/environment/tauri-browser/environmentService.js';
 import { IBrowserWorkbenchEnvironmentService } from '../services/environment/browser/environmentService.js';
 import { IWorkbenchConstructionOptions, IWorkspace, IWorkspaceProvider } from '../browser/web.api.js';
-import { isFolderToOpen, isWorkspaceToOpen, zoomLevelToZoomFactor } from '../../platform/window/common/window.js';
+import { isFolderToOpen, isWorkspaceToOpen } from '../../platform/window/common/window.js';
 import { invoke, listen } from '../../platform/tauri/common/tauriApi.js';
 import { ITauriWindowService, TauriWindowService } from '../../platform/window/tauri-browser/windowService.js';
 import { TauriURLCallbackProvider } from './urlCallbackProvider.js';
@@ -139,7 +139,6 @@ export class TauriDesktopMain extends Disposable {
       const layoutService = accessor.get(IWorkbenchLayoutService);
       const nativeHostService = accessor.get(INativeHostService);
       const openerService = accessor.get(IOpenerService);
-      const configurationService = accessor.get(IWorkbenchConfigurationService);
 
       listen('tauri://resize', () => layoutService.layout())
         .then(unlisten => this._register({ dispose: unlisten }));
@@ -169,27 +168,11 @@ export class TauriDesktopMain extends Disposable {
         },
       });
 
-      // Apply window zoom level via Tauri's native WebView zoom.
-      // In Electron, webFrame.setZoomLevel() changes the Chromium page zoom factor,
-      // which correctly updates window.innerWidth/innerHeight and reflows the layout.
-      // Tauri's Webview::set_zoom() provides the same native behavior via WKWebView
-      // on macOS, unlike CSS zoom which doesn't update viewport dimensions.
-      const applyWindowZoom = async (): Promise<void> => {
-        let zoomLevel = configurationService.getValue<number>('window.zoomLevel') ?? 0;
-        zoomLevel = Math.max(-8, Math.min(24, zoomLevel));
-        if (getZoomLevel(mainWindow) === zoomLevel) {
-          return;
-        }
-        setZoomLevel(zoomLevel, mainWindow);
-        await invoke('set_webview_zoom', { scaleFactor: zoomLevelToZoomFactor(zoomLevel) });
-        layoutService.layout();
-      };
-      applyWindowZoom();
-      this._register(configurationService.onDidChangeConfiguration(e => {
-        if (e.affectsConfiguration('window.zoomLevel')) {
-          applyWindowZoom();
-        }
-      }));
+      // Restore zoom level via IWindowZoomService.
+      // The service handles both per-window and global zoom modes,
+      // and manages the status bar indicator.
+      const windowZoomService = accessor.get(IWindowZoomService);
+      windowZoomService.restoreZoom(); // fire and forget — zoom applies asynchronously
     });
   }
 

--- a/src/vs/workbench/workbench.tauri.main.ts
+++ b/src/vs/workbench/workbench.tauri.main.ts
@@ -93,6 +93,7 @@ import './services/auxiliaryWindow/browser/auxiliaryWindowService.js';
 import './services/browserElements/browser/webBrowserElementsService.js';
 import './services/power/tauri-browser/powerService.js';
 import '../platform/sandbox/browser/sandboxHelperService.js';
+import './services/zoom/browser/zoom.contribution.js';
 
 //#endregion
 
@@ -205,5 +206,8 @@ import './contrib/remote/browser/remoteStartEntry.contribution.js';
 
 // Splash
 import './contrib/splash/browser/splash.contribution.js';
+
+// Zoom
+import './tauri-browser/contrib/zoomStatusEntry.js';
 
 //#endregion


### PR DESCRIPTION
## Summary

Implement the zoom status bar indicator that appears when the zoom level differs from the configured default, matching upstream VS Code behavior. Introduce `IWindowZoomService` with `window.zoomPerWindow` setting for per-window zoom that persists across restarts without modifying `settings.json`.

## Related Issue

No related issue.

## Changes

- **Platform layer**: Add `platform/window/tauri-browser/zoom.ts` with `applyZoom()` function wrapping Tauri IPC (`set_webview_zoom`)
- **Service layer**: Add `services/zoom/common/zoom.ts` interface (`IWindowZoomService`) and `services/zoom/browser/zoomService.ts` implementation with per-window zoom state and `IStorageService` persistence
- **Presentation layer**: Add `tauri-browser/contrib/zoomStatusEntry.ts` with `ZoomStatusEntryContribution` rendering status bar entry with ActionBar (zoom-out, level label, zoom-in, reset, settings gear)
- **Configuration**: Register `window.zoomPerWindow` setting (default: `true`) in `IWindowSettings` and `workbench.contribution.ts`
- **Zoom actions**: Modify `nativeActions.ts` to delegate to `IWindowZoomService.applyZoomDelta`/`resetZoom`
- **Startup**: Wire `IWindowZoomService.restoreZoom()` in `desktop.tauri.main.ts` `invokeFunction`

## How to Test

1. `Cmd+=` / `Cmd+-` to zoom in/out -> magnifying glass icon appears on the right side of the status bar
2. Click the icon -> ActionBar with (-), zoom level, (+), Reset, Settings gear
3. "Reset" button resets zoom to configured default
4. Settings gear opens zoom settings page
5. Indicator disappears when zoom matches default level
6. Set `window.zoomPerWindow: false` -> zoom changes modify settings.json directly (global mode)
7. Restart the app -> per-window zoom level is restored from storage

Generated with [Claude Code](https://claude.com/claude-code)