### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-04-28
+
+### Added
+
+- Add zoom status bar indicator with per-window zoom support ([#315](https://github.com/j4rviscmd/vscodeee/pull/315))
+- Add system font enumeration for `editor.fontFamily` suggestions ([#310](https://github.com/j4rviscmd/vscodeee/pull/310))
+
+### Fixed
+
+- Detect and remove symlink at `src-tauri/node_modules` before bundling ([#314](https://github.com/j4rviscmd/vscodeee/pull/314))
+- Disable single-instance plugin in dev builds
+
+### Changed
+
+- Exclude test files from production build (-51MB) ([#317](https://github.com/j4rviscmd/vscodeee/pull/317))
+- Add Cargo release profile for binary size optimization ([#313](https://github.com/j4rviscmd/vscodeee/pull/313))
+- Exclude unused built-in extensions to reduce bundle size ([#311](https://github.com/j4rviscmd/vscodeee/pull/311))
+- Fix ESLint `@stylistic/ts` violations in zoom files ([#316](https://github.com/j4rviscmd/vscodeee/pull/316), [#318](https://github.com/j4rviscmd/vscodeee/pull/318))
+
 ## [0.3.1] - 2026-04-27
 
 ### Fixed

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-utils/schema.json",
   "productName": "VS Codeee",
   "mainBinaryName": "codeee",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "identifier": "com.vscodeee.app",
   "build": {
     "frontendDist": "../out",


### PR DESCRIPTION
## Summary

Release v0.4.0 — minor version bump with new features, bug fixes, and bundle size optimizations.

## Changes

### Added
- Zoom status bar indicator with per-window zoom support (#315)
- System font enumeration for `editor.fontFamily` suggestions (#310)

### Fixed
- Detect and remove symlink at `src-tauri/node_modules` before bundling (#314)
- Disable single-instance plugin in dev builds

### Changed
- Exclude test files from production build (-51MB) (#317)
- Add Cargo release profile for binary size optimization (#313)
- Exclude unused built-in extensions to reduce bundle size (#311)
- Fix ESLint `@stylistic/ts` violations in zoom files (#316, #318)

## How to Test

1. Checkout this branch and verify `src-tauri/tauri.conf.json` version is `0.4.0`
2. Verify CHANGELOG.md contains the v0.4.0 entry with all changes listed above
3. Confirm no other files were unexpectedly modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)