### PR TITLE
feat: add editor group index indicator in tab bar

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editor.ts
+++ b/src/vs/workbench/browser/parts/editor/editor.ts
@@ -50,6 +50,7 @@ export const DEFAULT_EDITOR_PART_OPTIONS: IEditorPartOptions = {
 	tabActionCloseVisibility: true,
 	tabActionUnpinVisibility: true,
 	showTabIndex: false,
+	editorGroupIndexInTab: false,
 	alwaysShowEditorActions: false,
 	tabSizing: 'fit',
 	tabSizingFixedMinWidth: 50,
@@ -95,19 +96,24 @@ export const DEFAULT_EDITOR_PART_OPTIONS: IEditorPartOptions = {
 
 /**
  * Checks whether a configuration change event affects editor part options.
- * Covers `workbench.editor`, `workbench.iconTheme`, and `window.density` settings.
+ * Covers `workbench.editor`, `workbench.iconTheme`, `window.density`,
+ * and `vscodeee.editorGroupIndexInTab` settings.
  *
  * @param event - The configuration change event to evaluate.
  * @returns `true` if the event may change editor part options.
  */
 export function impactsEditorPartOptions(event: IConfigurationChangeEvent): boolean {
-	return event.affectsConfiguration('workbench.editor') || event.affectsConfiguration('workbench.iconTheme') || event.affectsConfiguration('window.density');
+	return event.affectsConfiguration('workbench.editor') ||
+		event.affectsConfiguration('workbench.iconTheme') ||
+		event.affectsConfiguration('window.density') ||
+		event.affectsConfiguration('vscodeee.editorGroupIndexInTab');
 }
 
 /**
  * Resolves the effective editor part options by merging user configuration
  * with the default options. Handles special cases like `autoLockGroups` object
- * conversion and `window.density.editorTabHeight` override.
+ * conversion, `window.density.editorTabHeight` override, and the
+ * `vscodeee.editorGroupIndexInTab` setting.
  *
  * @param configurationService - The configuration service to read settings from.
  * @param themeService - The theme service to determine icon availability.
@@ -144,6 +150,12 @@ export function getEditorPartOptions(configurationService: IConfigurationService
 		options.tabHeight = windowConfig.window.density.editorTabHeight;
 	}
 
+	// Handle vscodeee-specific setting
+	const vscodeeeConfig = configurationService.getValue<{ vscodeee?: { editorGroupIndexInTab?: boolean } }>();
+	if (vscodeeeConfig?.vscodeee?.editorGroupIndexInTab !== undefined) {
+		options.editorGroupIndexInTab = vscodeeeConfig.vscodeee.editorGroupIndexInTab;
+	}
+
 	return validateEditorPartOptions(options);
 }
 
@@ -161,6 +173,7 @@ function validateEditorPartOptions(options: IEditorPartOptions): IEditorPartOpti
 		'tabActionCloseVisibility': new BooleanVerifier(DEFAULT_EDITOR_PART_OPTIONS['tabActionCloseVisibility']),
 		'tabActionUnpinVisibility': new BooleanVerifier(DEFAULT_EDITOR_PART_OPTIONS['tabActionUnpinVisibility']),
 		'showTabIndex': new BooleanVerifier(DEFAULT_EDITOR_PART_OPTIONS['showTabIndex']),
+		'editorGroupIndexInTab': new BooleanVerifier(DEFAULT_EDITOR_PART_OPTIONS['editorGroupIndexInTab']),
 		'alwaysShowEditorActions': new BooleanVerifier(DEFAULT_EDITOR_PART_OPTIONS['alwaysShowEditorActions']),
 		'pinnedTabsOnSeparateRow': new BooleanVerifier(DEFAULT_EDITOR_PART_OPTIONS['pinnedTabsOnSeparateRow']),
 		'focusRecentEditorAfterClose': new BooleanVerifier(DEFAULT_EDITOR_PART_OPTIONS['focusRecentEditorAfterClose']),
@@ -328,6 +341,12 @@ export interface IEditorGroupView extends IDisposable, ISerializableView, IEdito
 
 	notifyIndexChanged(newIndex: number): void;
 	notifyLabelChanged(newLabel: string): void;
+
+	/**
+	 * Updates the editor group index indicator in the tab bar.
+	 * Only has an effect when the `editorGroupIndexInTab` option is enabled.
+	 */
+	updateEditorGroupIndex(): void;
 
 	openEditor(editor: EditorInput, options?: IEditorOptions, internalOptions?: IInternalEditorOpenOptions): Promise<IEditorPane | undefined>;
 

--- a/src/vs/workbench/browser/parts/editor/editorGroupView.ts
+++ b/src/vs/workbench/browser/parts/editor/editorGroupView.ts
@@ -610,6 +610,11 @@ export class EditorGroupView extends Themable implements IEditorGroupView {
 			case GroupModelChangeKind.EDITORS_SELECTION:
 				this.onDidChangeEditorSelection();
 				break;
+			case GroupModelChangeKind.GROUP_INDEX:
+				if (this.groupsView.partOptions.editorGroupIndexInTab) {
+					this.updateEditorGroupIndex();
+				}
+				break;
 		}
 
 		if (!e.editor) {
@@ -831,6 +836,15 @@ export class EditorGroupView extends Themable implements IEditorGroupView {
 				this.pinEditor(this.model.previewEditor);
 			}
 		}
+	}
+
+	/**
+	 * Updates the editor group index indicator in the title control.
+	 * Delegates to the title control to refresh the displayed group
+	 * index when the `editorGroupIndexInTab` option is enabled.
+	 */
+	updateEditorGroupIndex(): void {
+		this.titleControl.updateEditorGroupIndex();
 	}
 
 	private onDidChangeEditorDirty(editor: EditorInput): void {

--- a/src/vs/workbench/browser/parts/editor/editorPart.ts
+++ b/src/vs/workbench/browser/parts/editor/editorPart.ts
@@ -212,6 +212,10 @@ export class EditorPart extends Part<IEditorPartMemento> implements IEditorPart,
 		this._register(this.configurationService.onDidChangeConfiguration(e => this.onConfigurationUpdated(e)));
 		this._register(this.themeService.onDidFileIconThemeChange(() => this.handleChangedPartOptions()));
 		this._register(this.onDidChangeMementoValue(StorageScope.WORKSPACE, this._store)(e => this.onDidChangeMementoState(e)));
+
+		// Update editor group index indicator when groups are added/removed
+		this._register(this.onDidAddGroup(() => this.updateAllGroupIndexIndicators()));
+		this._register(this.onDidRemoveGroup(() => this.updateAllGroupIndexIndicators()));
 	}
 
 	private onConfigurationUpdated(event: IConfigurationChangeEvent): void {
@@ -236,6 +240,17 @@ export class EditorPart extends Part<IEditorPartMemento> implements IEditorPart,
 		this._partOptions = newPartOptions;
 
 		this._onDidChangeEditorPartOptions.fire({ oldPartOptions, newPartOptions });
+	}
+
+	/**
+	 * Updates the editor group index indicator for all groups in the
+	 * editor part. Called when groups are added or removed so that
+	 * each group displays its current position index in the tab bar.
+	 */
+	private updateAllGroupIndexIndicators(): void {
+		for (const groupView of this.groupViews.values()) {
+			groupView.updateEditorGroupIndex();
+		}
 	}
 
 	private enforcedPartOptions: DeepPartial<IEditorPartOptions>[] = [];
@@ -1515,6 +1530,11 @@ export class EditorPart extends Part<IEditorPartMemento> implements IEditorPart,
 		this.container.classList.toggle('empty', this.isEmpty);
 	}
 
+	/**
+	 * Notifies all editor groups of their current grid appearance index.
+	 * Called after group add, remove, move, or grid layout changes to keep
+	 * the group index indicators in tab bars up to date.
+	 */
 	private notifyGroupIndexChange(): void {
 		this.getGroups(GroupsOrder.GRID_APPEARANCE).forEach((group, index) => group.notifyIndexChanged(index));
 	}

--- a/src/vs/workbench/browser/parts/editor/editorTabsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/editorTabsControl.ts
@@ -91,6 +91,14 @@ export interface IEditorTabsControl extends IDisposable {
 	updateEditorDirty(editor: EditorInput): void;
 	layout(dimensions: IEditorTitleControlDimensions): Dimension;
 	getHeight(): number;
+
+	/**
+	 * Updates the editor group index indicator displayed in the tab bar.
+	 * Called when a group is added, removed, moved, or when the group's
+	 * active state changes. Only has an effect when the
+	 * `editorGroupIndexInTab` option is enabled and multiple groups exist.
+	 */
+	updateEditorGroupIndex?(): void;
 }
 
 export abstract class EditorTabsControl extends Themable implements IEditorTabsControl {

--- a/src/vs/workbench/browser/parts/editor/editorTitleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/editorTitleControl.ts
@@ -175,6 +175,15 @@ export class EditorTitleControl extends Themable {
 		return this.editorTabsControl.updateEditorDirty(editor);
 	}
 
+	/**
+	 * Updates the editor group index indicator by delegating to the
+	 * underlying tabs control. Only has a visible effect when the
+	 * `editorGroupIndexInTab` option is enabled and multiple groups exist.
+	 */
+	updateEditorGroupIndex(): void {
+		this.editorTabsControl.updateEditorGroupIndex?.();
+	}
+
 	updateOptions(oldOptions: IEditorPartOptions, newOptions: IEditorPartOptions): void {
 
 		// Update editor tabs control if options changed

--- a/src/vs/workbench/browser/parts/editor/media/multieditortabscontrol.css
+++ b/src/vs/workbench/browser/parts/editor/media/multieditortabscontrol.css
@@ -566,3 +566,27 @@
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab:first-child.drop-target-right::before {
 	width: 2px;
 }
+
+/* Editor group index indicator */
+.monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-and-actions-container > .editor-group-index {
+	display: none;
+	align-items: center;
+	justify-content: center;
+	align-self: center;
+	min-width: 18px;
+	height: 18px;
+	margin: 0 4px 0 10px;
+	padding: 0 4px;
+	font-size: 13px;
+	font-weight: 600;
+	white-space: nowrap;
+	flex-shrink: 0;
+	border-radius: 5px;
+	background-color: var(--vscode-tab-unfocusedActiveBackground);
+	color: var(--vscode-tab-unfocusedActiveForeground);
+}
+
+.monaco-workbench .part.editor > .content .editor-group-container.active > .title .tabs-and-actions-container > .editor-group-index {
+	background-color: var(--vscode-tab-activeBackground);
+	color: var(--vscode-tab-activeForeground);
+}

--- a/src/vs/workbench/browser/parts/editor/multiEditorTabsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/multiEditorTabsControl.ts
@@ -111,6 +111,9 @@ export class MultiEditorTabsControl extends EditorTabsControl {
 	private tabsScrollbar: ScrollableElement | undefined;
 	private tabSizingFixedDisposables: DisposableStore | undefined;
 
+	/** DOM element that displays the editor group index (e.g. `[1]`) in the tab bar. */
+	private editorGroupIndexElement: HTMLElement | undefined;
+
 	private readonly closeEditorAction = this._register(this.instantiationService.createInstance(CloseEditorTabAction, CloseEditorTabAction.ID, CloseEditorTabAction.LABEL));
 	private readonly unpinEditorAction = this._register(this.instantiationService.createInstance(UnpinEditorAction, UnpinEditorAction.ID, UnpinEditorAction.LABEL));
 
@@ -186,6 +189,11 @@ export class MultiEditorTabsControl extends EditorTabsControl {
 		// Tabs Scrollbar
 		this.tabsScrollbar = this.createTabsScrollbar(this.tabsContainer);
 		this.tabsAndActionsContainer.appendChild(this.tabsScrollbar.getDomNode());
+
+		// Editor group index indicator
+		this.editorGroupIndexElement = $('.editor-group-index');
+		this.tabsAndActionsContainer.insertBefore(this.editorGroupIndexElement, this.tabsScrollbar.getDomNode());
+		this._register(scheduleAtNextAnimationFrame(getWindow(this.parent), () => this.updateEditorGroupIndex()));
 
 		// Tabs Container listeners
 		this.registerTabsContainerListeners(this.tabsContainer, this.tabsScrollbar);
@@ -510,6 +518,7 @@ export class MultiEditorTabsControl extends EditorTabsControl {
 	}
 
 	openEditors(editors: EditorInput[]): boolean {
+		this.updateEditorGroupIndex();
 		return this.handleOpenedEditors();
 	}
 
@@ -688,6 +697,9 @@ export class MultiEditorTabsControl extends EditorTabsControl {
 
 	setActive(isGroupActive: boolean): void {
 
+		// Update editor group index indicator
+		this.updateEditorGroupIndex();
+
 		// Activity has an impact on each tab's active indication
 		this.forEachTab((editor, tabIndex, tabContainer, tabLabelWidget, tabLabel, tabActionBar) => {
 			this.redrawTabSelectedActiveAndDirty(isGroupActive, editor, tabContainer, tabActionBar);
@@ -734,6 +746,27 @@ export class MultiEditorTabsControl extends EditorTabsControl {
 		this.withTab(editor, (editor, tabIndex, tabContainer, tabLabelWidget, tabLabel, tabActionBar) => this.redrawTabSelectedActiveAndDirty(this.groupsView.activeGroup === this.groupView, editor, tabContainer, tabActionBar));
 	}
 
+	/**
+	 * Updates the editor group index indicator element in the tabs bar.
+	 * Shows a bracketed index (e.g. `[1]`) when the `editorGroupIndexInTab`
+	 * option is enabled and there are at least 2 editor groups. Hides the
+	 * indicator otherwise.
+	 */
+	updateEditorGroupIndex(): void {
+		if (!this.editorGroupIndexElement) {
+			return;
+		}
+		const options = this.groupsView.partOptions;
+		if (options.editorGroupIndexInTab && this.editorPartsView.count >= 2) {
+			const index = this.groupView.index + 1;
+			this.editorGroupIndexElement.textContent = `[${index}]`;
+			this.editorGroupIndexElement.style.display = 'flex';
+		} else {
+			this.editorGroupIndexElement.textContent = '';
+			this.editorGroupIndexElement.style.display = 'none';
+		}
+	}
+
 	override updateOptions(oldOptions: IEditorPartOptions, newOptions: IEditorPartOptions): void {
 		super.updateOptions(oldOptions, newOptions);
 
@@ -766,6 +799,11 @@ export class MultiEditorTabsControl extends EditorTabsControl {
 			this.updateTabSizing(true);
 		}
 
+		// Update editor group index indicator
+		if (oldOptions.editorGroupIndexInTab !== newOptions.editorGroupIndexInTab) {
+			this.updateEditorGroupIndex();
+		}
+
 		// Redraw tabs when other options change
 		if (
 			oldOptions.labelFormat !== newOptions.labelFormat ||
@@ -779,6 +817,7 @@ export class MultiEditorTabsControl extends EditorTabsControl {
 			oldOptions.highlightModifiedTabs !== newOptions.highlightModifiedTabs ||
 			oldOptions.wrapTabs !== newOptions.wrapTabs ||
 			oldOptions.showTabIndex !== newOptions.showTabIndex ||
+			oldOptions.editorGroupIndexInTab !== newOptions.editorGroupIndexInTab ||
 			!equals(oldOptions.decorations, newOptions.decorations)
 		) {
 			this.redraw();

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -1105,17 +1105,17 @@ Registry.as<IConfigurationMigrationRegistry>(Extensions.ConfigurationMigration)
 		}
 	}]);
 
-	// VSCodeEE: Editor group index in tab
-	registry.registerConfiguration({
-		'id': 'vscodeee',
-		'order': 20,
-		'title': localize('vscodeeeConfigurationTitle', "VSCodeEE"),
-		'type': 'object',
-		'properties': {
-			'vscodeee.editorGroupIndexInTab': {
-				'type': 'boolean',
-				'default': false,
-				'description': localize('editorGroupIndexInTab', "When enabled, shows the editor group index prefix (e.g., [1]) on the active tab of each editor group. Only appears when 2 or more editor groups are open.")
-			}
+// VSCodeEE: Editor group index in tab
+registry.registerConfiguration({
+	'id': 'vscodeee',
+	'order': 20,
+	'title': localize('vscodeeeConfigurationTitle', "VSCodeEE"),
+	'type': 'object',
+	'properties': {
+		'vscodeee.editorGroupIndexInTab': {
+			'type': 'boolean',
+			'default': false,
+			'description': localize('editorGroupIndexInTab', "When enabled, shows the editor group index prefix (e.g., [1]) on the active tab of each editor group. Only appears when 2 or more editor groups are open.")
 		}
-	});
+	}
+});

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -1104,3 +1104,18 @@ Registry.as<IConfigurationMigrationRegistry>(Extensions.ConfigurationMigration)
 			return result;
 		}
 	}]);
+
+	// VSCodeEE: Editor group index in tab
+	registry.registerConfiguration({
+		'id': 'vscodeee',
+		'order': 20,
+		'title': localize('vscodeeeConfigurationTitle', "VSCodeEE"),
+		'type': 'object',
+		'properties': {
+			'vscodeee.editorGroupIndexInTab': {
+				'type': 'boolean',
+				'default': false,
+				'description': localize('editorGroupIndexInTab', "When enabled, shows the editor group index prefix (e.g., [1]) on the active tab of each editor group. Only appears when 2 or more editor groups are open.")
+			}
+		}
+	});

--- a/src/vs/workbench/common/editor.ts
+++ b/src/vs/workbench/common/editor.ts
@@ -1440,6 +1440,14 @@ interface IEditorPartConfiguration {
 	tabActionCloseVisibility?: boolean;
 	tabActionUnpinVisibility?: boolean;
 	showTabIndex?: boolean;
+	/**
+	 * Controls whether the editor group index is displayed in the tab bar.
+	 * When enabled, a bracketed number (e.g. `[1]`, `[2]`) is shown
+	 * before the tabs when multiple editor groups exist. Only visible when
+	 * the `vscodeee.editorGroupIndexInTab` setting is enabled and there are
+	 * at least 2 editor groups in the grid.
+	 */
+	editorGroupIndexInTab?: boolean;
 	alwaysShowEditorActions?: boolean;
 	tabSizing?: 'fit' | 'shrink' | 'fixed';
 	tabSizingFixedMinWidth?: number;

--- a/src/vs/workbench/test/browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/workbenchTestServices.ts
@@ -1016,6 +1016,7 @@ export class TestEditorGroupView implements IEditorGroupView {
 	layout(_width: number, _height: number): void { }
 	relayout() { }
 	createEditorActions(_menuDisposable: IDisposable): { actions: IToolbarActions; onDidChange: Event<IMenuChangeEvent> } { throw new Error('not implemented'); }
+	updateEditorGroupIndex(): void { }
 }
 
 export class TestEditorGroupAccessor implements IEditorGroupsView {


### PR DESCRIPTION
## Summary
- Add `vscodeee.editorGroupIndexInTab` setting that displays a bracketed group index (e.g. `[1]`, `[2]`) as a badge at the left edge of each editor group's tab bar when 2 or more groups are open
- The indicator follows the active theme colors (active/unfocused active foreground and background) and updates dynamically on group add/remove, index change, and active state change
- Added `updateEditorGroupIndex` to `IEditorTabsControl` and `IEditorGroupView` interfaces for type-safe propagation

Closes #206

## Test plan
- [ ] Enable `vscodeee.editorGroupIndexInTab` in settings and verify no indicator with single group
- [ ] Split editor to create 2+ groups and verify `[1]` `[2]` badges appear
- [ ] Switch active group and verify color changes (active vs unfocused theme colors)
- [ ] Close a group to return to single group and verify indicators disappear
- [ ] Restart app with multiple groups open and verify indicators restore correctly
- [ ] Test with various themes (dark, light, high contrast) to verify color adaptation

🤖 Generated with [Claude Code](https://claude.com/claude-code)