### PR TITLE
chore: exclude unused @azure and @octokit type packages from bundle

### DIFF
--- a/scripts/bundle-node-modules.mjs
+++ b/scripts/bundle-node-modules.mjs
@@ -57,6 +57,27 @@ const EXCLUDED_PACKAGES = new Set([
 	'@microsoft/dynamicproto-js',
 	'@nevware21/ts-async',
 	'@nevware21/ts-utils',
+
+	// Type-definition-only packages — these have no runtime code (empty "main" field
+	// or only .d.ts files). The consuming extensions are esbuild-BUNDLED, so all
+	// runtime code is already inlined into dist/. These packages are only used at
+	// TypeScript compile time and are unnecessary in the production bundle.
+	// See: https://github.com/j4rviscmd/vscodeee/issues/274
+	'@octokit/graphql-schema',   // ~7.3MB — GraphQL schema types for github extension
+	'@octokit/openapi-types',    // ~5.1MB — REST API types for github extension
+]);
+
+// Extensions excluded from the production build. Their dependencies should NOT
+// be collected in Phase 2 since the extensions themselves are never loaded.
+// This list must be kept in sync with EXCLUDED_EXTENSIONS in build/next/index.ts.
+const EXCLUDED_EXTENSIONS = new Set([
+	'vscode-api-tests',
+	'vscode-colorize-tests',
+	'vscode-colorize-perf-tests',
+	'vscode-test-resolver',
+	// TODO(Phase 1): Excluded for Tauri fork - SettingsSync/RemoteTunnel not supported
+	'microsoft-authentication',
+	'tunnel-forwarding',
 ]);
 
 // Directory containing no-op stub packages that replace real implementations.
@@ -204,9 +225,14 @@ function collectExtensionDependencies() {
 	const seen = new Set();
 	const queue = [];
 
-	// Seed with direct dependencies from all extension package.json files
+	// Seed with direct dependencies from all extension package.json files.
+	// Skip extensions in EXCLUDED_EXTENSIONS — they are never loaded in production,
+	// so their dependencies (e.g. @azure/* from microsoft-authentication) are unnecessary.
 	for (const extDir of fs.readdirSync(EXTENSIONS_DIR, { withFileTypes: true })) {
 		if (!extDir.isDirectory()) {
+			continue;
+		}
+		if (EXCLUDED_EXTENSIONS.has(extDir.name)) {
 			continue;
 		}
 		const pkgPath = path.join(EXTENSIONS_DIR, extDir.name, 'package.json');


### PR DESCRIPTION
## Summary

`bundle-node-modules.mjs` の `collectExtensionDependencies()` が `EXCLUDED_EXTENSIONS` を参照していなかったため、除外済み拡張（`microsoft-authentication`）の依存パッケージ（`@azure/*` ~44MB）が不要にバンドルされていた問題を修正。併せて、型定義のみでランタイム不要な `@octokit/graphql-schema` (~7.3MB) と `@octokit/openapi-types` (~5.1MB) を `EXCLUDED_PACKAGES` に追加。

## Related Issue

Closes #274

## Changes

- `EXCLUDED_EXTENSIONS` を `bundle-node-modules.mjs` に追加（`build/next/index.ts` と同期）
- `collectExtensionDependencies()` で除外拡張のディレクトリをスキップ
- `@octokit/graphql-schema` と `@octokit/openapi-types` を `EXCLUDED_PACKAGES` に追加

## Size Impact

| Metric | Before | After | Reduction |
|--------|--------|-------|-----------|
| Staging node_modules | 145MB | 85MB | **-60MB** |
| .app node_modules | 91MB | 77MB | **-14MB** |
| .app total | 387MB | 374MB | **-13MB** |

## How to Test

1. `node scripts/bundle-node-modules.mjs --clean` を実行
2. ログに `@azure/*` パッケージが出現しないことを確認
3. `@octokit/graphql-schema` が `SKIP (excluded)` と表示されることを確認
4. `npm run tauri:build` でビルドが正常に完了することを確認
5. ビルドされた .app でエディタ基本機能・GitHub拡張が正常動作することを確認