### PR TITLE
chore: skip BUNDLED extension deps in Phase 2 node_modules bundling

### DIFF
--- a/scripts/bundle-node-modules.mjs
+++ b/scripts/bundle-node-modules.mjs
@@ -62,6 +62,8 @@ const EXCLUDED_PACKAGES = new Set([
 	// or only .d.ts files). The consuming extensions are esbuild-BUNDLED, so all
 	// runtime code is already inlined into dist/. These packages are only used at
 	// TypeScript compile time and are unnecessary in the production bundle.
+	// NOTE: These are also excluded by the BUNDLED extension skip in Phase 2, but
+	// kept here as a safety net in case the detection logic changes.
 	// See: https://github.com/j4rviscmd/vscodeee/issues/274
 	'@octokit/graphql-schema',   // ~7.3MB — GraphQL schema types for github extension
 	'@octokit/openapi-types',    // ~5.1MB — REST API types for github extension
@@ -79,6 +81,38 @@ const EXCLUDED_EXTENSIONS = new Set([
 	'microsoft-authentication',
 	'tunnel-forwarding',
 ]);
+
+// Packages from esbuild-BUNDLED extensions that are still required at runtime
+// in node_modules/ (i.e., NOT inlined by esbuild). All other BUNDLED extension
+// deps are fully inlined into dist/*.js and do not need to be in node_modules/.
+//
+// How to determine if a package needs to be here:
+// 1. Check esbuild.mts for `external: [...]` — packages listed there are NOT
+//    inlined and require() / import() them at runtime from node_modules.
+// 2. Check if the extension loads a file from node_modules at runtime (e.g.,
+//    vscode-markdown-languageserver's workerMain.js is started as a separate
+//    Node.js process via LanguageClient).
+//
+// To verify: inspect the built dist/*.js for external require()/import() calls:
+//   node -e "const c=require('fs').readFileSync('extensions/git/dist/main.js','utf8');
+//     const r=c.match(/(?:require|import)\(['\"][^'\"]+['\"]\)/g)||[];
+//     console.log(r.filter(x=>!x.includes('node:')&&!x.includes('./')&&!x.includes('vscode')))"
+//
+// Entries can be:
+//   - string: package name (transitive deps will be resolved from its package.json)
+//   - { name: string, skipTransitive: true }: package copied but transitive deps skipped
+//     (use when the package's dist is self-contained / pre-bundled)
+/** @type {Array<string | { name: string, skipTransitive: boolean }>} */
+const REQUIRED_BUNDLED_EXT_PACKAGES = [
+	// git extension: native addon marked as external in esbuild.mts.
+	// Used via dynamic import: `const { cp } = await import('@vscode/fs-copyfile')`
+	'@vscode/fs-copyfile',
+	// markdown-language-features: loaded as a separate Node.js process via
+	// LanguageClient (workerMain.js). The dist/node/workerMain.js is fully
+	// self-contained (all deps inlined, only Node.js builtins as external requires),
+	// so transitive deps are NOT needed in node_modules.
+	{ name: 'vscode-markdown-languageserver', skipTransitive: true },
+];
 
 // Directory containing no-op stub packages that replace real implementations.
 // Stubs maintain the same API surface but have zero dependencies and minimal size.
@@ -216,9 +250,25 @@ function findPackageDir(pkgName) {
 }
 
 /**
+ * Detect whether an extension is "BUNDLED" — i.e., it uses esbuild to inline
+ * all dependencies into dist/*.js. BUNDLED extensions do not need their
+ * node_modules dependencies at runtime (except for packages explicitly listed
+ * in REQUIRED_BUNDLED_EXT_PACKAGES).
+ * @param {string} extName — extension directory name (e.g. "git", "emmet")
+ * @returns {boolean}
+ */
+function isBundledExtension(extName) {
+	return fs.existsSync(path.join(EXTENSIONS_DIR, extName, 'esbuild.mts'));
+}
+
+/**
  * Recursively collect all dependency package names from extension manifests,
  * including transitive dependencies. Returns a set of top-level package names
  * (e.g. "@vscode/extension-telemetry", "which") that exist in any node_modules.
+ *
+ * BUNDLED extensions (those with esbuild.mts) are skipped because esbuild
+ * inlines all their dependencies into dist/*.js. Only packages explicitly
+ * listed in REQUIRED_BUNDLED_EXT_PACKAGES are included from BUNDLED extensions.
  * @returns {Set<string>}
  */
 function collectExtensionDependencies() {
@@ -228,11 +278,17 @@ function collectExtensionDependencies() {
 	// Seed with direct dependencies from all extension package.json files.
 	// Skip extensions in EXCLUDED_EXTENSIONS — they are never loaded in production,
 	// so their dependencies (e.g. @azure/* from microsoft-authentication) are unnecessary.
+	// Skip BUNDLED extensions — their deps are inlined by esbuild.
 	for (const extDir of fs.readdirSync(EXTENSIONS_DIR, { withFileTypes: true })) {
 		if (!extDir.isDirectory()) {
 			continue;
 		}
 		if (EXCLUDED_EXTENSIONS.has(extDir.name)) {
+			continue;
+		}
+		// BUNDLED extensions inline all deps via esbuild — skip their dependency trees.
+		// Only REQUIRED_BUNDLED_EXT_PACKAGES are needed at runtime from node_modules.
+		if (isBundledExtension(extDir.name)) {
 			continue;
 		}
 		const pkgPath = path.join(EXTENSIONS_DIR, extDir.name, 'package.json');
@@ -244,6 +300,21 @@ function collectExtensionDependencies() {
 			if (!seen.has(dep)) {
 				seen.add(dep);
 				queue.push(dep);
+			}
+		}
+	}
+
+	// Add packages from BUNDLED extensions that are still required at runtime
+	const skipTransitiveSet = new Set();
+	for (const entry of REQUIRED_BUNDLED_EXT_PACKAGES) {
+		const name = typeof entry === 'string' ? entry : entry.name;
+		const skip = typeof entry === 'object' && entry.skipTransitive;
+		if (!seen.has(name)) {
+			seen.add(name);
+			if (!skip) {
+				queue.push(name);
+			} else {
+				skipTransitiveSet.add(name);
 			}
 		}
 	}
@@ -453,8 +524,16 @@ function main() {
 		}
 	}
 
-	// Phase 2: Auto-discover and copy extension dependencies
+	// Phase 2: Auto-discover and copy extension dependencies.
+	// BUNDLED extensions (with esbuild.mts) are skipped — their deps are inlined.
+	// Only REQUIRED_BUNDLED_EXT_PACKAGES are included from BUNDLED extensions.
 	console.log('[bundle-node-modules] Phase 2: Extension dependencies...');
+	const bundledExtNames = fs.readdirSync(EXTENSIONS_DIR, { withFileTypes: true })
+		.filter(e => e.isDirectory() && isBundledExtension(e.name) && !EXCLUDED_EXTENSIONS.has(e.name))
+		.map(e => e.name);
+	console.log(`[bundle-node-modules]   Skipping ${bundledExtNames.length} BUNDLED extensions (deps inlined by esbuild)`);
+	const requiredNames = REQUIRED_BUNDLED_EXT_PACKAGES.map(e => typeof e === 'string' ? e : e.name);
+	console.log(`[bundle-node-modules]   Required from BUNDLED: ${requiredNames.join(', ')}`);
 	const extDeps = collectExtensionDependencies();
 
 	let extCopied = 0;


### PR DESCRIPTION
## Summary

Skip BUNDLED extension dependencies in Phase 2 of `bundle-node-modules.mjs`, reducing staging `node_modules/` from **66.9MB to 47.5MB (-19.4MB, -29%)**.

## Background

BUNDLED extensions (those with `esbuild.mts`) inline all their dependencies into `dist/*.js` via esbuild. The 101 packages previously copied in Phase 2 were entirely from these BUNDLED extensions and unnecessary at runtime — they were already embedded in the bundled output.

## Changes

- Add `isBundledExtension()` helper to detect extensions with `esbuild.mts`
- Skip BUNDLED extension dependency trees in `collectExtensionDependencies()`
- Add `REQUIRED_BUNDLED_EXT_PACKAGES` whitelist for 2 runtime exceptions:
  - `@vscode/fs-copyfile` — native addon, `external` in git's esbuild config, used via `import('@vscode/fs-copyfile')`
  - `vscode-markdown-languageserver` — loaded as separate Node.js process (`workerMain.js`), with `skipTransitive: true` since `workerMain.js` is self-contained
- Support `{ name, skipTransitive }` entry format for pre-bundled packages

## Verification

- Analyzed all 19 BUNDLED extension `dist/*.js` files — confirmed zero external npm `require()`/`import()` calls (only Node.js builtins and `vscode`)
- Confirmed `vscode-markdown-languageserver/dist/node/workerMain.js` has only Node.js builtin requires (fully self-contained)
- Confirmed `git/dist/main.js` has exactly one external: `import("@vscode/fs-copyfile")`

## Impact

| Metric | Before | After |
|--------|--------|-------|
| Phase 2 packages | 101 | 2 |
| Staging node_modules | 66.9 MB | 47.5 MB |
| **Reduction** | | **-19.4 MB (-29%)** |

Cumulative .app reduction: **464MB → ~355MB (-109MB, -23%)**

Closes #274