### PR TITLE
feat: add tmux-like directional pane resize commands

### DIFF
--- a/src/vs/base/browser/ui/grid/grid.ts
+++ b/src/vs/base/browser/ui/grid/grid.ts
@@ -14,6 +14,9 @@ import type { SplitView, AutoSizing as SplitViewAutoSizing } from '../splitview/
 export type { IViewSize };
 export { LayoutPriority, Orientation, orthogonal } from './gridview.js';
 
+/**
+ * Cardinal directions used for navigating and resizing views within a {@link Grid}.
+ */
 export const enum Direction {
 	Up,
 	Down,
@@ -21,6 +24,7 @@ export const enum Direction {
 	Right
 }
 
+/** Returns the opposite cardinal direction (e.g., `Up` becomes `Down`). */
 function oppositeDirection(direction: Direction): Direction {
 	switch (direction) {
 		case Direction.Up: return Direction.Down;
@@ -51,6 +55,7 @@ export interface IView extends IGridViewView {
 export interface GridLeafNode<T extends IView> {
 	readonly view: T;
 	readonly box: Box;
+	/** The size of the view at the moment it was last hidden, or `undefined` if visible. */
 	readonly cachedVisibleSize: number | undefined;
 	readonly maximized: boolean;
 }
@@ -94,6 +99,10 @@ interface Boundary {
 	readonly range: Range;
 }
 
+/**
+ * Computes the boundary (offset + orthogonal range) of a box edge
+ * in the specified direction.
+ */
 function getBoxBoundary(box: Box, direction: Direction): Boundary {
 	const orientation = getDirectionOrientation(direction);
 	const offset = direction === Direction.Up ? box.top :
@@ -109,6 +118,11 @@ function getBoxBoundary(box: Box, direction: Direction): Boundary {
 	return { offset, range };
 }
 
+/**
+ * Recursively finds all leaf nodes whose edge in the opposite of `direction`
+ * matches the given `boundary`. Used by {@link Grid.getNeighborViews} to
+ * determine which views are adjacent to a reference view.
+ */
 function findAdjacentBoxLeafNodes<T extends IView>(boxNode: GridNode<T>, direction: Direction, boundary: Boundary): GridLeafNode<T>[] {
 	const result: GridLeafNode<T>[] = [];
 
@@ -130,14 +144,28 @@ function findAdjacentBoxLeafNodes<T extends IView>(boxNode: GridNode<T>, directi
 	return result;
 }
 
+/**
+ * Determines the orientation at a given depth in the grid tree.
+ * Even depths use the root orientation; odd depths use its orthogonal.
+ */
 function getLocationOrientation(rootOrientation: Orientation, location: GridLocation): Orientation {
 	return location.length % 2 === 0 ? orthogonal(rootOrientation) : rootOrientation;
 }
 
+/** Maps a cardinal direction to its corresponding orientation (Up/Down -> Vertical, Left/Right -> Horizontal). */
 function getDirectionOrientation(direction: Direction): Orientation {
 	return direction === Direction.Up || direction === Direction.Down ? Orientation.VERTICAL : Orientation.HORIZONTAL;
 }
 
+/**
+ * Computes the grid location where a new view should be inserted when
+ * placing it relative to an existing view in a given direction.
+ *
+ * @param rootOrientation - The orientation of the root split view.
+ * @param location - The location of the reference view.
+ * @param direction - The direction to place the new view.
+ * @returns The grid location for the new view.
+ */
 export function getRelativeLocation(rootOrientation: Orientation, location: GridLocation, direction: Direction): GridLocation {
 	const orientation = getLocationOrientation(rootOrientation, location);
 	const directionOrientation = getDirectionOrientation(direction);
@@ -291,6 +319,7 @@ export class Grid<T extends IView = IView> extends Disposable {
 
 	private didLayout = false;
 
+	/** Fires when a view's maximized state changes. */
 	readonly onDidChangeViewMaximized: Event<boolean>;
 	/**
 	 * Create a new {@link Grid}. A grid must *always* have a view
@@ -418,6 +447,10 @@ export class Grid<T extends IView = IView> extends Disposable {
 		this._addView(newView, viewSize, location);
 	}
 
+	/**
+	 * Internal method to add a view at a specific grid location with
+	 * fixed, distribute, or invisible sizing.
+	 */
 	private addViewAt(newView: T, size: number | DistributeSizing | InvisibleSizing, location: GridLocation): void {
 		if (this.views.has(newView)) {
 			throw new Error('Can\'t add same view twice');
@@ -436,6 +469,10 @@ export class Grid<T extends IView = IView> extends Disposable {
 		this._addView(newView, viewSize, location);
 	}
 
+	/**
+	 * Low-level method to register a view in the internal map and add it
+	 * to the underlying grid view at the specified location.
+	 */
 	protected _addView(newView: T, size: number | GridViewSizing, location: GridLocation): void {
 		this.views.set(newView, newView.element);
 		this.gridview.addView(newView, size, location);
@@ -546,6 +583,25 @@ export class Grid<T extends IView = IView> extends Disposable {
 	}
 
 	/**
+	 * Resize a view's border in a given direction.
+	 * Moves the border between the view and its neighbor by the specified delta,
+	 * growing the view in that direction and shrinking the neighbor.
+	 *
+	 * This is the grid-level equivalent of tmux's `resize-pane -U/-D/-L/-R`.
+	 *
+	 * @param view The reference view.
+	 * @param direction The direction to move the border. All directions grow the view.
+	 * @param delta The pixel amount to move the border. Must be positive.
+	 * @returns true if a border was found and resized, false otherwise.
+	 */
+	resizeViewBorder(view: T, direction: Direction, delta: number): boolean {
+		const location = this.getViewLocation(view);
+		const targetOrientation = getDirectionOrientation(direction);
+		const isForward = direction === Direction.Down || direction === Direction.Right;
+		return this.gridview.resizeViewBorder(location, targetOrientation, isForward, delta);
+	}
+
+	/**
 	 * Returns whether all other {@link IView views} are at their minimum size.
 	 *
 	 * @param view The reference {@link IView view}.
@@ -613,6 +669,7 @@ export class Grid<T extends IView = IView> extends Disposable {
 		this.gridview.maximizeView(location, excludeViews);
 	}
 
+	/** Restores all views that were hidden when a view was maximized. */
 	exitMaximizedView(): void {
 		this.gridview.exitMaximizedView();
 	}
@@ -870,6 +927,13 @@ function isGridBranchNodeDescriptor<T>(nodeDescriptor: GridNodeDescriptor<T>): n
 	return !!(nodeDescriptor as GridBranchNodeDescriptor<T>).groups;
 }
 
+/**
+ * Normalizes a grid node descriptor by removing unnecessary single-child
+ * branch wrappers and ensuring all children have a defined size.
+ *
+ * @param nodeDescriptor - The descriptor to sanitize (mutated in place).
+ * @param rootNode - Whether this descriptor represents the root node.
+ */
 export function sanitizeGridNodeDescriptor<T>(nodeDescriptor: GridNodeDescriptor<T>, rootNode: boolean): void {
 	// eslint-disable-next-line local/code-no-any-casts
 	if (!rootNode && (nodeDescriptor as any).groups && (nodeDescriptor as any).groups.length <= 1) {

--- a/src/vs/base/browser/ui/grid/grid.ts
+++ b/src/vs/base/browser/ui/grid/grid.ts
@@ -13,16 +13,9 @@ import type { SplitView, AutoSizing as SplitViewAutoSizing } from '../splitview/
 
 export type { IViewSize };
 export { LayoutPriority, Orientation, orthogonal } from './gridview.js';
+export { Direction } from '../../../common/direction.js';
 
-/**
- * Cardinal directions used for navigating and resizing views within a {@link Grid}.
- */
-export const enum Direction {
-	Up,
-	Down,
-	Left,
-	Right
-}
+import { Direction } from '../../../common/direction.js';
 
 /** Returns the opposite cardinal direction (e.g., `Up` becomes `Down`). */
 function oppositeDirection(direction: Direction): Direction {

--- a/src/vs/base/browser/ui/grid/grid.ts
+++ b/src/vs/base/browser/ui/grid/grid.ts
@@ -1013,3 +1013,4 @@ export function createSerializedGrid<T>(gridDescriptor: GridDescriptor<T>): ISer
 		height: height || 1
 	};
 }
+

--- a/src/vs/base/browser/ui/grid/gridview.ts
+++ b/src/vs/base/browser/ui/grid/gridview.ts
@@ -167,6 +167,7 @@ export interface ISerializedGridView {
 	height: number;
 }
 
+/** Returns the orthogonal orientation (HORIZONTAL <-> VERTICAL). */
 export function orthogonal(orientation: Orientation): Orientation {
 	return orientation === Orientation.VERTICAL ? Orientation.HORIZONTAL : Orientation.VERTICAL;
 }
@@ -197,6 +198,11 @@ export function isGridBranchNode(node: GridNode): node is GridBranchNode {
 	return !!(node as any).children;
 }
 
+/**
+ * Controls whether layout propagation is enabled. Layout is disabled
+ * until the first explicit call to {@link GridView.layout} to avoid
+ * premature layout of views before the grid is fully constructed.
+ */
 class LayoutController {
 	constructor(public isLayoutEnabled: boolean) { }
 }
@@ -216,6 +222,11 @@ export interface IGridViewOptions {
 	readonly proportionalLayout?: boolean; // default true
 }
 
+/**
+ * Layout context passed down the grid tree during layout propagation.
+ * Contains absolute positioning and sizing information needed by each
+ * node to compute its children's positions.
+ */
 interface ILayoutContext {
 	readonly orthogonalSize: number;
 	readonly absoluteOffset: number;
@@ -224,6 +235,10 @@ interface ILayoutContext {
 	readonly absoluteOrthogonalSize: number;
 }
 
+/**
+ * Converts orientation-relative boundary sashes to absolute boundary sashes.
+ * For horizontal orientation, start/end map to left/right; for vertical, to top/bottom.
+ */
 function toAbsoluteBoundarySashes(sashes: IRelativeBoundarySashes, orientation: Orientation): IBoundarySashes {
 	if (orientation === Orientation.HORIZONTAL) {
 		return { left: sashes.start, right: sashes.end, top: sashes.orthogonalStart, bottom: sashes.orthogonalEnd };
@@ -232,6 +247,10 @@ function toAbsoluteBoundarySashes(sashes: IRelativeBoundarySashes, orientation: 
 	}
 }
 
+/**
+ * Converts absolute boundary sashes to orientation-relative boundary sashes.
+ * Inverse of {@link toAbsoluteBoundarySashes}.
+ */
 function fromAbsoluteBoundarySashes(sashes: IBoundarySashes, orientation: Orientation): IRelativeBoundarySashes {
 	if (orientation === Orientation.HORIZONTAL) {
 		return { start: sashes.left, end: sashes.right, orthogonalStart: sashes.top, orthogonalEnd: sashes.bottom };
@@ -240,6 +259,12 @@ function fromAbsoluteBoundarySashes(sashes: IBoundarySashes, orientation: Orient
 	}
 }
 
+/**
+ * Validates and normalizes a child index using rotation, supporting
+ * negative indices (e.g., -1 maps to the last position).
+ *
+ * @throws Error if the absolute value of `index` exceeds `numChildren + 1`.
+ */
 function validateIndex(index: number, numChildren: number): number {
 	if (Math.abs(index) > numChildren) {
 		throw new Error('Invalid index');
@@ -248,6 +273,11 @@ function validateIndex(index: number, numChildren: number): number {
 	return rot(index, numChildren + 1);
 }
 
+/**
+ * A branch node in the grid tree that contains child nodes arranged
+ * in a {@link SplitView}. Branch nodes flip orientation relative to
+ * their parent, creating the two-dimensional grid layout.
+ */
 class BranchNode implements ISplitView<ILayoutContext>, IDisposable {
 
 	readonly element: HTMLElement;
@@ -753,7 +783,12 @@ class BranchNode implements ISplitView<ILayoutContext>, IDisposable {
 
 /**
  * Creates a latched event that avoids being fired when the view
- * constraints do not change at all.
+ * constraints do not change at all. The event emits a concrete size
+ * when the view explicitly requests a relayout, or `undefined` when
+ * only the constraint properties changed.
+ *
+ * @param view - The view whose `onDidChange` event to latch.
+ * @returns A latched event that only fires when relevant state changes.
  */
 function createLatchedOnDidChangeViewEvent(view: IView): Event<IViewSize | undefined> {
 	const [onDidChangeViewConstraints, onDidSetViewSize] = Event.split<undefined, IViewSize>(view.onDidChange, isUndefined);
@@ -770,6 +805,11 @@ function createLatchedOnDidChangeViewEvent(view: IView): Event<IViewSize | undef
 	);
 }
 
+/**
+ * A leaf node in the grid tree that wraps a single {@link IView}.
+ * Leaf nodes are the terminal nodes of the grid hierarchy and
+ * directly manage view layout and constraint propagation.
+ */
 class LeafNode implements ISplitView<ILayoutContext>, IDisposable {
 
 	private _size: number = 0;
@@ -941,11 +981,24 @@ class LeafNode implements ISplitView<ILayoutContext>, IDisposable {
 
 type Node = BranchNode | LeafNode;
 
-export interface INodeDescriptor {
+export /**
+ * Describes a grid node with its visibility state, used during
+ * grid deserialization to reconstruct the tree structure.
+ */
+interface INodeDescriptor {
 	node: Node;
 	visible?: boolean;
 }
 
+/**
+ * Flips a grid node by swapping its orientation and recursively
+ * flipping all children. The old node is disposed in the process.
+ *
+ * @param node - The node to flip.
+ * @param size - The new size of the flipped node.
+ * @param orthogonalSize - The new orthogonal size of the flipped node.
+ * @returns A new node with the orthogonal orientation.
+ */
 function flipNode(node: BranchNode, size: number, orthogonalSize: number): BranchNode;
 function flipNode(node: LeafNode, size: number, orthogonalSize: number): LeafNode;
 function flipNode(node: Node, size: number, orthogonalSize: number): Node;
@@ -1460,6 +1513,89 @@ export class GridView implements IDisposable {
 	}
 
 	/**
+	 * Resize a view's border in a given direction.
+	 * Moves the border between the view and its neighbor by the specified delta,
+	 * growing the view in that direction and shrinking the neighbor.
+	 *
+	 * This is the grid-primitive equivalent of tmux's `resize-pane -U/-D/-L/-R`.
+	 *
+	 * @param location The {@link GridLocation location} of the view.
+	 * @param targetOrientation The orientation matching the direction (VERTICAL for Up/Down, HORIZONTAL for Left/Right).
+	 * @param isForward Whether the direction is forward (Down/Right) or backward (Up/Left).
+	 * @param delta The pixel amount to move the border. Must be positive.
+	 * @returns true if a border was found and resized, false otherwise.
+	 */
+	resizeViewBorder(location: GridLocation, targetOrientation: Orientation, isForward: boolean, delta: number): boolean {
+		if (this.hasMaximizedView()) {
+			this.exitMaximizedView();
+		}
+
+		// Walk up the location path to find the ancestor BranchNode
+		// whose orientation matches the target direction
+		for (let i = location.length; i > 0; i--) {
+			const parentLocation = location.slice(0, i - 1);
+			const childIndex = location[i - 1];
+			const [, parentNode] = this.getNode(parentLocation);
+
+			if (!(parentNode instanceof BranchNode)) {
+				continue;
+			}
+
+			if (parentNode.orientation !== targetOrientation) {
+				continue;
+			}
+
+			// Find any visible adjacent sibling.
+			// Prefer the sibling in the direction of movement (active grows),
+			// fallback to the opposite side (active shrinks).
+			const candidates = isForward
+				? [childIndex + 1, childIndex - 1]
+				: [childIndex - 1, childIndex + 1];
+			const siblingIndex = candidates.find(idx =>
+				idx >= 0 && idx < parentNode.children.length && parentNode.isChildVisible(idx));
+
+			if (siblingIndex === undefined) {
+				continue;
+			}
+
+			// Compute effective delta for the active child.
+			// isForward=true means border moves right/down; isForward=false means left/up.
+			// With a right/below sibling: isForward -> active grows, !isForward -> active shrinks.
+			// With a left/above sibling: isForward -> active shrinks, !isForward -> active grows.
+			const siblingIsAfter = siblingIndex > childIndex;
+			const activeDeltaSign = (isForward === siblingIsAfter) ? 1 : -1;
+			const rawDelta = activeDeltaSign * delta;
+
+			// Clamp respecting min/max constraints of both children
+			const ourSize = parentNode.getChildSize(childIndex);
+			const siblingSize = parentNode.getChildSize(siblingIndex);
+			const ourMinSize = parentNode.children[childIndex].minimumSize;
+			const ourMaxSize = parentNode.children[childIndex].maximumSize;
+			const siblingMinSize = parentNode.children[siblingIndex].minimumSize;
+			const siblingMaxSize = parentNode.children[siblingIndex].maximumSize;
+
+			const maxGrowDelta = Math.min(ourMaxSize - ourSize, siblingSize - siblingMinSize);
+			const maxShrinkDelta = Math.min(ourSize - ourMinSize, siblingMaxSize - siblingSize);
+
+			const effectiveDelta = rawDelta > 0
+				? Math.min(rawDelta, maxGrowDelta)
+				: Math.max(rawDelta, -maxShrinkDelta);
+
+			if (effectiveDelta === 0) {
+				return false;
+			}
+
+			parentNode.resizeChild(childIndex, ourSize + effectiveDelta);
+			parentNode.resizeChild(siblingIndex, siblingSize - effectiveDelta);
+
+			this.trySet2x2();
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
 	 * Get the size of a {@link IView view}.
 	 *
 	 * @param location The {@link GridLocation location} of the view. Provide `undefined` to get
@@ -1539,6 +1675,13 @@ export class GridView implements IDisposable {
 		return true;
 	}
 
+	/**
+	 * Maximize the size of a {@link IView view} by hiding all other views.
+	 * Optionally excludes specific views from being hidden.
+	 *
+	 * @param location - The {@link GridLocation location} of the view.
+	 * @param excludeViews - Views that should remain visible even when maximizing.
+	 */
 	maximizeView(location: GridLocation, excludeViews: readonly IView[] = []) {
 		const [, nodeToMaximize] = this.getNode(location);
 		if (!(nodeToMaximize instanceof LeafNode)) {
@@ -1574,6 +1717,10 @@ export class GridView implements IDisposable {
 		this._onDidChangeViewMaximized.fire(true);
 	}
 
+	/**
+	 * Restores all views that were hidden during maximization.
+	 * Views are made visible in reverse order to maintain proper sizing.
+	 */
 	exitMaximizedView(): void {
 		if (!this.maximizedNode) {
 			return;
@@ -1598,6 +1745,7 @@ export class GridView implements IDisposable {
 		this._onDidChangeViewMaximized.fire(false);
 	}
 
+	/** Returns whether any view is currently maximized. */
 	hasMaximizedView(): boolean {
 		return this.maximizedNode !== undefined;
 	}

--- a/src/vs/base/browser/ui/grid/gridview.ts
+++ b/src/vs/base/browser/ui/grid/gridview.ts
@@ -985,7 +985,7 @@ export /**
  * Describes a grid node with its visibility state, used during
  * grid deserialization to reconstruct the tree structure.
  */
-interface INodeDescriptor {
+	interface INodeDescriptor {
 	node: Node;
 	visible?: boolean;
 }

--- a/src/vs/base/common/direction.ts
+++ b/src/vs/base/common/direction.ts
@@ -1,0 +1,15 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Cardinal directions used for navigating and resizing views within a grid.
+ * Placed in the common layer so it can be imported by both browser and common code.
+ */
+export const enum Direction {
+	Up,
+	Down,
+	Left,
+	Right
+}

--- a/src/vs/sessions/browser/workbench.ts
+++ b/src/vs/sessions/browser/workbench.ts
@@ -1240,6 +1240,17 @@ export class Workbench extends Disposable implements IWorkbenchLayoutService {
     });
   }
 
+  /**
+   * Pane border resizing is not supported in session windows.
+   * Session windows use a fixed grid layout where the editor is
+   * rendered as a modal overlay rather than being part of the grid.
+   *
+   * @param _direction - Ignored.
+   */
+  resizePaneBorder(_direction: Direction): void {
+    // Not supported in session windows
+  }
+
   private getPartView(part: Parts): ISerializableView | undefined {
     switch (part) {
       case Parts.TITLEBAR_PART:

--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -1835,20 +1835,20 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 		}
 	}
 
-		/**
-		 * Resizes the border of the currently focused pane in the specified direction.
-		 * Implements tmux-like `resize-pane` behavior:
-		 *
-		 * 1. Determines the focused workbench part (defaults to editor part).
-		 * 2. For the editor part with multiple groups, attempts to resize within
-		 *    the editor group's internal grid first. If no matching border exists
-		 *    in that direction (e.g., two horizontal columns but resizing upward),
-		 *    falls back to the workbench grid to match tmux's tree-walking behavior.
-		 * 3. For other parts, resizes directly on the workbench grid.
-		 *
-		 * @param direction - The direction to move the border.
-		 */
-		resizePaneBorder(direction: Direction): void {
+	/**
+	 * Resizes the border of the currently focused pane in the specified direction.
+	 * Implements tmux-like `resize-pane` behavior:
+	 *
+	 * 1. Determines the focused workbench part (defaults to editor part).
+	 * 2. For the editor part with multiple groups, attempts to resize within
+	 *    the editor group's internal grid first. If no matching border exists
+	 *    in that direction (e.g., two horizontal columns but resizing upward),
+	 *    falls back to the workbench grid to match tmux's tree-walking behavior.
+	 * 3. For other parts, resizes directly on the workbench grid.
+	 *
+	 * @param direction - The direction to move the border.
+	 */
+	resizePaneBorder(direction: Direction): void {
 		if (!this.workbenchGrid) {
 			return;
 		}
@@ -1874,15 +1874,15 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 		this.resizePartBorder(part, direction, increment);
 	}
 
-		/**
-		 * Resizes a workbench part's border on the workbench grid.
-		 * No-op if the part is not currently visible.
-		 *
-		 * @param part - The workbench part to resize.
-		 * @param direction - The direction to move the border.
-		 * @param increment - The pixel amount to move the border.
-		 */
-		private resizePartBorder(part: Parts, direction: Direction, increment: number): void {
+	/**
+	 * Resizes a workbench part's border on the workbench grid.
+	 * No-op if the part is not currently visible.
+	 *
+	 * @param part - The workbench part to resize.
+	 * @param direction - The direction to move the border.
+	 * @param increment - The pixel amount to move the border.
+	 */
+	private resizePartBorder(part: Parts, direction: Direction, increment: number): void {
 		if (!this.isVisible(part, mainWindow)) {
 			return;
 		}
@@ -1891,16 +1891,16 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 		this.workbenchGrid.resizeViewBorder(partView, direction, increment);
 	}
 
-		/**
-		 * Attempts to resize the active editor group's border within the
-		 * editor group's internal grid. Uses the editor group's grid-level
-		 * `resizeViewBorder` for tmux-strict directional border movement.
-		 *
-		 * @param direction - The direction to move the border.
-		 * @param increment - The pixel amount to move the border.
-		 * @returns `true` if a border was found and resized, `false` otherwise.
-		 */
-		private resizeEditorGroupBorder(direction: Direction, increment: number): boolean {
+	/**
+	 * Attempts to resize the active editor group's border within the
+	 * editor group's internal grid. Uses the editor group's grid-level
+	 * `resizeViewBorder` for tmux-strict directional border movement.
+	 *
+	 * @param direction - The direction to move the border.
+	 * @param increment - The pixel amount to move the border.
+	 * @returns `true` if a border was found and resized, `false` otherwise.
+	 */
+	private resizeEditorGroupBorder(direction: Direction, increment: number): boolean {
 		const activeGroup = this.editorGroupService.mainPart.activeGroup;
 
 		// Use the editor group's internal grid resizeViewBorder for
@@ -1909,13 +1909,13 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 		return this.editorGroupService.mainPart.resizeGroupBorder(activeGroup, direction, increment);
 	}
 
-		/**
-		 * Reads the `vscodeee.resizeIncrement` configuration value and
-		 * applies screen-aware scaling for high-DPI displays.
-		 *
-		 * @returns The scaled pixel increment, or 0 if invalid.
-		 */
-		private getResizeIncrement(): number {
+	/**
+	 * Reads the `vscodeee.resizeIncrement` configuration value and
+	 * applies screen-aware scaling for high-DPI displays.
+	 *
+	 * @returns The scaled pixel increment, or 0 if invalid.
+	 */
+	private getResizeIncrement(): number {
 		const configValue = this.configurationService.getValue<number>('vscodeee.resizeIncrement');
 		const raw = typeof configValue === 'number' && configValue > 0 ? configValue : 60;
 		return computeScreenAwareSize(getActiveWindow(), raw);

--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -1835,6 +1835,92 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 		}
 	}
 
+		/**
+		 * Resizes the border of the currently focused pane in the specified direction.
+		 * Implements tmux-like `resize-pane` behavior:
+		 *
+		 * 1. Determines the focused workbench part (defaults to editor part).
+		 * 2. For the editor part with multiple groups, attempts to resize within
+		 *    the editor group's internal grid first. If no matching border exists
+		 *    in that direction (e.g., two horizontal columns but resizing upward),
+		 *    falls back to the workbench grid to match tmux's tree-walking behavior.
+		 * 3. For other parts, resizes directly on the workbench grid.
+		 *
+		 * @param direction - The direction to move the border.
+		 */
+		resizePaneBorder(direction: Direction): void {
+		if (!this.workbenchGrid) {
+			return;
+		}
+
+		const focusedPart = this._getFocusedPart();
+		const part = focusedPart ?? Parts.EDITOR_PART;
+
+		const increment = this.getResizeIncrement();
+		if (increment <= 0) {
+			return;
+		}
+
+		// For editor part with multiple groups, try the editor group grid first.
+		// If no matching border exists in that direction (e.g., 2 horizontal
+		// columns but resizePaneUp requested), fall back to the workbench grid
+		// to match tmux's tree-walking behavior.
+		if (part === Parts.EDITOR_PART && this.editorGroupService.mainPart.count > 1) {
+			if (this.resizeEditorGroupBorder(direction, increment)) {
+				return;
+			}
+		}
+
+		this.resizePartBorder(part, direction, increment);
+	}
+
+		/**
+		 * Resizes a workbench part's border on the workbench grid.
+		 * No-op if the part is not currently visible.
+		 *
+		 * @param part - The workbench part to resize.
+		 * @param direction - The direction to move the border.
+		 * @param increment - The pixel amount to move the border.
+		 */
+		private resizePartBorder(part: Parts, direction: Direction, increment: number): void {
+		if (!this.isVisible(part, mainWindow)) {
+			return;
+		}
+
+		const partView = this.getPart(part);
+		this.workbenchGrid.resizeViewBorder(partView, direction, increment);
+	}
+
+		/**
+		 * Attempts to resize the active editor group's border within the
+		 * editor group's internal grid. Uses the editor group's grid-level
+		 * `resizeViewBorder` for tmux-strict directional border movement.
+		 *
+		 * @param direction - The direction to move the border.
+		 * @param increment - The pixel amount to move the border.
+		 * @returns `true` if a border was found and resized, `false` otherwise.
+		 */
+		private resizeEditorGroupBorder(direction: Direction, increment: number): boolean {
+		const activeGroup = this.editorGroupService.mainPart.activeGroup;
+
+		// Use the editor group's internal grid resizeViewBorder for
+		// tmux-strict directional border movement. Returns false if
+		// no border exists in that direction (group is at grid edge).
+		return this.editorGroupService.mainPart.resizeGroupBorder(activeGroup, direction, increment);
+	}
+
+		/**
+		 * Reads the `vscodeee.resizeIncrement` configuration value and
+		 * applies screen-aware scaling for high-DPI displays.
+		 *
+		 * @returns The scaled pixel increment, or 0 if invalid.
+		 */
+		private getResizeIncrement(): number {
+		const configValue = this.configurationService.getValue<number>('vscodeee.resizeIncrement');
+		const raw = typeof configValue === 'number' && configValue > 0 ? configValue : 60;
+		return computeScreenAwareSize(getActiveWindow(), raw);
+	}
+
 	private setActivityBarHidden(hidden: boolean): void {
 		this.stateModel.setRuntimeValue(LayoutStateKeys.ACTIVITYBAR_HIDDEN, hidden);
 		this.workbenchGrid.setViewVisible(this.activityBarPartView, !hidden);

--- a/src/vs/workbench/browser/parts/editor/editorPart.ts
+++ b/src/vs/workbench/browser/parts/editor/editorPart.ts
@@ -479,6 +479,21 @@ export class EditorPart extends Part<IEditorPartMemento> implements IEditorPart,
 	}
 
 	/**
+	 * Resizes the border between the specified editor group and its neighbor
+	 * in the given direction. Delegates to the underlying grid widget's
+	 * directional border resize.
+	 *
+	 * @param group - The editor group or its identifier.
+	 * @param direction - The direction to move the border.
+	 * @param delta - The pixel amount to move the border (must be positive).
+	 * @returns `true` if a border was found and resized, `false` otherwise.
+	 */
+	resizeGroupBorder(group: IEditorGroupView | GroupIdentifier, direction: Direction, delta: number): boolean {
+		const groupView = this.assertGroupView(group);
+		return this.gridWidget.resizeViewBorder(groupView, direction, delta);
+	}
+
+	/**
 	 * Arranges all editor groups according to the specified arrangement strategy.
 	 * Requires at least 2 groups; does nothing otherwise.
 	 *

--- a/src/vs/workbench/browser/parts/editor/editorParts.ts
+++ b/src/vs/workbench/browser/parts/editor/editorParts.ts
@@ -5,6 +5,7 @@
 
 import { localize } from '../../../../nls.js';
 import { EditorGroupLayout, GroupDirection, GroupLocation, GroupOrientation, GroupsArrangement, GroupsOrder, IAuxiliaryEditorPart, IEditorGroupContextKeyProvider, IEditorDropTargetDelegate, IEditorGroupsService, IEditorSideGroup, IEditorWorkingSet, IFindGroupScope, IMergeGroupOptions, IEditorWorkingSetOptions, IEditorPart, IModalEditorPart, IEditorGroupActivationEvent } from '../../../services/editor/common/editorGroupsService.js';
+import { Direction } from '../../../../base/browser/ui/grid/grid.js';
 import { Emitter } from '../../../../base/common/event.js';
 import { DisposableMap, DisposableStore, IDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
 import { GroupIdentifier, IEditorPartOptions } from '../../../common/editor.js';
@@ -982,6 +983,19 @@ export class EditorParts extends MultiWindowParts<EditorPart, IEditorPartsMement
 
 	enforcePartOptions(options: DeepPartial<IEditorPartOptions>): IDisposable {
 		return this.mainPart.enforcePartOptions(options);
+	}
+
+	/**
+	 * Resizes the border of an editor group in the main editor part.
+	 * Delegates to {@link EditorPart.resizeGroupBorder}.
+	 *
+	 * @param group - The editor group or its identifier.
+	 * @param direction - The direction to move the border.
+	 * @param delta - The pixel amount to move the border (must be positive).
+	 * @returns `true` if a border was found and resized, `false` otherwise.
+	 */
+	resizeGroupBorder(group: number | IEditorGroupView, direction: Direction, delta: number): boolean {
+		return this.mainPart.resizeGroupBorder(group, direction, delta);
 	}
 
 	//#endregion

--- a/src/vs/workbench/services/editor/common/editorGroupsService.ts
+++ b/src/vs/workbench/services/editor/common/editorGroupsService.ts
@@ -10,6 +10,8 @@ import { EditorInput } from '../../../common/editor/editorInput.js';
 import { IEditorOptions, IModalEditorNavigation, IModalEditorPartOptions } from '../../../../platform/editor/common/editor.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IDimension } from '../../../../editor/common/core/2d/dimension.js';
+// TODO: Consider moving Direction to base/common to avoid browser import in common layer
+import { Direction } from '../../../../base/browser/ui/grid/grid.js';
 import { DisposableStore, IDisposable } from '../../../../base/common/lifecycle.js';
 import { ContextKeyValue, IContextKeyService, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
 import { URI } from '../../../../base/common/uri.js';
@@ -352,6 +354,21 @@ export interface IEditorGroupsContainer {
 	 * Sets the size of a group.
 	 */
 	setSize(group: IEditorGroup | GroupIdentifier, size: { width: number; height: number }): void;
+
+	/**
+	 * Resizes a group's border in the specified direction.
+	 * Moves the border between the group and its neighbor by delta pixels,
+	 * growing the group in that direction. Returns false if no border
+	 * exists in that direction (group is at the grid edge).
+	 *
+	 * This is the service-level equivalent of tmux's `resize-pane -U/-D/-L/-R`.
+	 *
+	 * @param group - The editor group or its identifier.
+	 * @param direction - The direction to move the border.
+	 * @param delta - The pixel amount to move the border. Must be positive.
+	 * @returns `true` if a border was found and resized, `false` otherwise.
+	 */
+	resizeGroupBorder(group: IEditorGroup | GroupIdentifier, direction: Direction, delta: number): boolean;
 
 	/**
 	 * Arrange all groups in the container according to the provided arrangement.

--- a/src/vs/workbench/services/editor/common/editorGroupsService.ts
+++ b/src/vs/workbench/services/editor/common/editorGroupsService.ts
@@ -10,8 +10,7 @@ import { EditorInput } from '../../../common/editor/editorInput.js';
 import { IEditorOptions, IModalEditorNavigation, IModalEditorPartOptions } from '../../../../platform/editor/common/editor.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IDimension } from '../../../../editor/common/core/2d/dimension.js';
-// TODO: Consider moving Direction to base/common to avoid browser import in common layer
-import { Direction } from '../../../../base/browser/ui/grid/grid.js';
+import { Direction } from '../../../../base/common/direction.js';
 import { DisposableStore, IDisposable } from '../../../../base/common/lifecycle.js';
 import { ContextKeyValue, IContextKeyService, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
 import { URI } from '../../../../base/common/uri.js';

--- a/src/vs/workbench/services/layout/browser/layoutService.ts
+++ b/src/vs/workbench/services/layout/browser/layoutService.ts
@@ -344,6 +344,23 @@ export interface IWorkbenchLayoutService extends ILayoutService {
 	resizePart(part: Parts, sizeChangeWidth: number, sizeChangeHeight: number): void;
 
 	/**
+	 * Resize the focused pane's border in the specified direction.
+	 * Mimics tmux's resize-pane behavior: the border moves in the
+	 * given direction, growing or shrinking the focused pane accordingly.
+	 *
+	 * For the editor part with multiple groups, attempts to resize within
+	 * the editor group grid first. If no matching border exists in that
+	 * direction (e.g., two horizontal columns but resizing upward), falls
+	 * back to the workbench grid to match tmux's tree-walking behavior.
+	 *
+	 * The pixel increment is controlled by the `vscodeee.resizeIncrement`
+	 * configuration setting (default: 60, range: 1-500).
+	 *
+	 * @param direction The direction to move the border.
+	 */
+	resizePaneBorder(direction: Direction): void;
+
+	/**
 	 * Register a part to participate in the layout.
 	 */
 	registerPart(part: Part): IDisposable;

--- a/src/vs/workbench/tauri-browser/actions/resizePaneActions.ts
+++ b/src/vs/workbench/tauri-browser/actions/resizePaneActions.ts
@@ -1,0 +1,119 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) VS Codeee Contributors. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { localize, localize2 } from '../../../nls.js';
+import { Action2, registerAction2 } from '../../../platform/actions/common/actions.js';
+import { Categories } from '../../../platform/action/common/actionCommonCategories.js';
+import { Extensions as ConfigurationExtensions, ConfigurationScope, IConfigurationRegistry } from '../../../platform/configuration/common/configurationRegistry.js';
+import { Registry } from '../../../platform/registry/common/platform.js';
+import { IWorkbenchLayoutService } from '../../services/layout/browser/layoutService.js';
+import { Direction } from '../../../base/browser/ui/grid/grid.js';
+import { ServicesAccessor } from '../../../platform/instantiation/common/instantiation.js';
+
+// #region Configuration
+
+const VSCodeEESettings = {
+	RESIZE_INCREMENT: 'vscodeee.resizeIncrement',
+};
+
+Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).registerConfiguration({
+	id: 'vscodeee',
+	order: 100,
+	title: localize('vscodeeeConfigurationTitle', 'VSCodeEE'),
+	type: 'object',
+	properties: {
+		[VSCodeEESettings.RESIZE_INCREMENT]: {
+			type: 'number',
+			default: 60,
+			minimum: 1,
+			maximum: 500,
+			scope: ConfigurationScope.APPLICATION,
+			description: localize(
+				'vscodeee.resizeIncrement',
+				'The number of pixels to resize a pane by when using directional resize commands (vscodeee.resizePaneUp/Down/Left/Right).'
+			)
+		}
+	}
+});
+
+// #endregion
+
+// #region Actions
+
+/**
+ * Base action class for directional pane resize commands.
+ * Delegates to {@link IWorkbenchLayoutService.resizePaneBorder} to move
+ * the border of the currently focused pane in a specified direction.
+ *
+ * Subclasses provide the concrete direction and action ID.
+ */
+abstract class BaseResizePaneAction extends Action2 {
+	/**
+	 * @param id - The unique action identifier (e.g., `'vscodeee.resizePaneUp'`).
+	 * @param title - The human-readable title shown in the command palette.
+	 * @param direction - The direction to move the focused pane's border.
+	 */
+	constructor(
+		id: string,
+		title: string,
+		private readonly direction: Direction
+	) {
+		super({
+			id,
+			title: localize2(id, title),
+			f1: true,
+			category: Categories.View,
+		});
+	}
+
+	/**
+	 * Executes the pane resize by delegating to the layout service.
+	 *
+	 * @param accessor - The service accessor for dependency injection.
+	 */
+	run(accessor: ServicesAccessor): void {
+		const layoutService = accessor.get(IWorkbenchLayoutService);
+		layoutService.resizePaneBorder(this.direction);
+	}
+}
+
+/** Resizes the focused pane by moving its top border upward. */
+class ResizePaneUpAction extends BaseResizePaneAction {
+	static readonly ID = 'vscodeee.resizePaneUp';
+	constructor() {
+		super(ResizePaneUpAction.ID, 'Resize Pane Up', Direction.Up);
+	}
+}
+
+/** Resizes the focused pane by moving its bottom border downward. */
+class ResizePaneDownAction extends BaseResizePaneAction {
+	static readonly ID = 'vscodeee.resizePaneDown';
+	constructor() {
+		super(ResizePaneDownAction.ID, 'Resize Pane Down', Direction.Down);
+	}
+}
+
+/** Resizes the focused pane by moving its left border leftward. */
+class ResizePaneLeftAction extends BaseResizePaneAction {
+	static readonly ID = 'vscodeee.resizePaneLeft';
+	constructor() {
+		super(ResizePaneLeftAction.ID, 'Resize Pane Left', Direction.Left);
+	}
+}
+
+/** Resizes the focused pane by moving its right border rightward. */
+class ResizePaneRightAction extends BaseResizePaneAction {
+	static readonly ID = 'vscodeee.resizePaneRight';
+	constructor() {
+		super(ResizePaneRightAction.ID, 'Resize Pane Right', Direction.Right);
+	}
+}
+
+registerAction2(ResizePaneUpAction);
+registerAction2(ResizePaneDownAction);
+registerAction2(ResizePaneLeftAction);
+registerAction2(ResizePaneRightAction);
+
+// #endregion

--- a/src/vs/workbench/tauri-browser/actions/resizePaneActions.ts
+++ b/src/vs/workbench/tauri-browser/actions/resizePaneActions.ts
@@ -9,33 +9,33 @@ import { Categories } from '../../../platform/action/common/actionCommonCategori
 import { Extensions as ConfigurationExtensions, ConfigurationScope, IConfigurationRegistry } from '../../../platform/configuration/common/configurationRegistry.js';
 import { Registry } from '../../../platform/registry/common/platform.js';
 import { IWorkbenchLayoutService } from '../../services/layout/browser/layoutService.js';
-import { Direction } from '../../../base/browser/ui/grid/grid.js';
+import { Direction } from '../../../base/common/direction.js';
 import { ServicesAccessor } from '../../../platform/instantiation/common/instantiation.js';
 
 // #region Configuration
 
 const VSCodeEESettings = {
-	RESIZE_INCREMENT: 'vscodeee.resizeIncrement',
+  RESIZE_INCREMENT: 'vscodeee.resizeIncrement',
 };
 
 Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).registerConfiguration({
-	id: 'vscodeee',
-	order: 100,
-	title: localize('vscodeeeConfigurationTitle', 'VSCodeEE'),
-	type: 'object',
-	properties: {
-		[VSCodeEESettings.RESIZE_INCREMENT]: {
-			type: 'number',
-			default: 60,
-			minimum: 1,
-			maximum: 500,
-			scope: ConfigurationScope.APPLICATION,
-			description: localize(
-				'vscodeee.resizeIncrement',
-				'The number of pixels to resize a pane by when using directional resize commands (vscodeee.resizePaneUp/Down/Left/Right).'
-			)
-		}
-	}
+  id: 'vscodeee',
+  order: 100,
+  title: localize('vscodeeeConfigurationTitle', 'VSCodeEE'),
+  type: 'object',
+  properties: {
+    [VSCodeEESettings.RESIZE_INCREMENT]: {
+      type: 'number',
+      default: 60,
+      minimum: 1,
+      maximum: 500,
+      scope: ConfigurationScope.APPLICATION,
+      description: localize(
+        'vscodeee.resizeIncrement',
+        'The number of pixels to resize a pane by when using directional resize commands (vscodeee.resizePaneUp/Down/Left/Right).',
+      ),
+    },
+  },
 });
 
 // #endregion
@@ -50,65 +50,65 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
  * Subclasses provide the concrete direction and action ID.
  */
 abstract class BaseResizePaneAction extends Action2 {
-	/**
-	 * @param id - The unique action identifier (e.g., `'vscodeee.resizePaneUp'`).
-	 * @param title - The human-readable title shown in the command palette.
-	 * @param direction - The direction to move the focused pane's border.
-	 */
-	constructor(
-		id: string,
-		title: string,
-		private readonly direction: Direction
-	) {
-		super({
-			id,
-			title: localize2(id, title),
-			f1: true,
-			category: Categories.View,
-		});
-	}
+  /**
+   * @param id - The unique action identifier (e.g., `'vscodeee.resizePaneUp'`).
+   * @param title - The human-readable title shown in the command palette.
+   * @param direction - The direction to move the focused pane's border.
+   */
+  constructor(
+    id: string,
+    title: string,
+    private readonly direction: Direction,
+  ) {
+    super({
+      id,
+      title: localize2(id, title),
+      f1: true,
+      category: Categories.View,
+    });
+  }
 
-	/**
-	 * Executes the pane resize by delegating to the layout service.
-	 *
-	 * @param accessor - The service accessor for dependency injection.
-	 */
-	run(accessor: ServicesAccessor): void {
-		const layoutService = accessor.get(IWorkbenchLayoutService);
-		layoutService.resizePaneBorder(this.direction);
-	}
+  /**
+   * Executes the pane resize by delegating to the layout service.
+   *
+   * @param accessor - The service accessor for dependency injection.
+   */
+  run(accessor: ServicesAccessor): void {
+    const layoutService = accessor.get(IWorkbenchLayoutService);
+    layoutService.resizePaneBorder(this.direction);
+  }
 }
 
 /** Resizes the focused pane by moving its top border upward. */
 class ResizePaneUpAction extends BaseResizePaneAction {
-	static readonly ID = 'vscodeee.resizePaneUp';
-	constructor() {
-		super(ResizePaneUpAction.ID, 'Resize Pane Up', Direction.Up);
-	}
+  static readonly ID = 'vscodeee.resizePaneUp';
+  constructor() {
+    super(ResizePaneUpAction.ID, 'Resize Pane Up', Direction.Up);
+  }
 }
 
 /** Resizes the focused pane by moving its bottom border downward. */
 class ResizePaneDownAction extends BaseResizePaneAction {
-	static readonly ID = 'vscodeee.resizePaneDown';
-	constructor() {
-		super(ResizePaneDownAction.ID, 'Resize Pane Down', Direction.Down);
-	}
+  static readonly ID = 'vscodeee.resizePaneDown';
+  constructor() {
+    super(ResizePaneDownAction.ID, 'Resize Pane Down', Direction.Down);
+  }
 }
 
 /** Resizes the focused pane by moving its left border leftward. */
 class ResizePaneLeftAction extends BaseResizePaneAction {
-	static readonly ID = 'vscodeee.resizePaneLeft';
-	constructor() {
-		super(ResizePaneLeftAction.ID, 'Resize Pane Left', Direction.Left);
-	}
+  static readonly ID = 'vscodeee.resizePaneLeft';
+  constructor() {
+    super(ResizePaneLeftAction.ID, 'Resize Pane Left', Direction.Left);
+  }
 }
 
 /** Resizes the focused pane by moving its right border rightward. */
 class ResizePaneRightAction extends BaseResizePaneAction {
-	static readonly ID = 'vscodeee.resizePaneRight';
-	constructor() {
-		super(ResizePaneRightAction.ID, 'Resize Pane Right', Direction.Right);
-	}
+  static readonly ID = 'vscodeee.resizePaneRight';
+  constructor() {
+    super(ResizePaneRightAction.ID, 'Resize Pane Right', Direction.Right);
+  }
 }
 
 registerAction2(ResizePaneUpAction);

--- a/src/vs/workbench/tauri-browser/actions/resizePaneActions.ts
+++ b/src/vs/workbench/tauri-browser/actions/resizePaneActions.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { localize, localize2 } from '../../../nls.js';
-import { Action2, registerAction2 } from '../../../platform/actions/common/actions.js';
+import { Action2, IAction2Options, registerAction2 } from '../../../platform/actions/common/actions.js';
 import { Categories } from '../../../platform/action/common/actionCommonCategories.js';
 import { Extensions as ConfigurationExtensions, ConfigurationScope, IConfigurationRegistry } from '../../../platform/configuration/common/configurationRegistry.js';
 import { Registry } from '../../../platform/registry/common/platform.js';
@@ -51,21 +51,14 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
  */
 abstract class BaseResizePaneAction extends Action2 {
   /**
-   * @param id - The unique action identifier (e.g., `'vscodeee.resizePaneUp'`).
-   * @param title - The human-readable title shown in the command palette.
+   * @param desc - The action descriptor including id and localized title.
    * @param direction - The direction to move the focused pane's border.
    */
   constructor(
-    id: string,
-    title: string,
+    desc: Readonly<IAction2Options>,
     private readonly direction: Direction,
   ) {
-    super({
-      id,
-      title: localize2(id, title),
-      f1: true,
-      category: Categories.View,
-    });
+    super(desc);
   }
 
   /**
@@ -83,7 +76,12 @@ abstract class BaseResizePaneAction extends Action2 {
 class ResizePaneUpAction extends BaseResizePaneAction {
   static readonly ID = 'vscodeee.resizePaneUp';
   constructor() {
-    super(ResizePaneUpAction.ID, 'Resize Pane Up', Direction.Up);
+    super({
+      id: ResizePaneUpAction.ID,
+      title: localize2('vscodeee.resizePaneUp', 'Resize Pane Up'),
+      f1: true,
+      category: Categories.View,
+    }, Direction.Up);
   }
 }
 
@@ -91,7 +89,12 @@ class ResizePaneUpAction extends BaseResizePaneAction {
 class ResizePaneDownAction extends BaseResizePaneAction {
   static readonly ID = 'vscodeee.resizePaneDown';
   constructor() {
-    super(ResizePaneDownAction.ID, 'Resize Pane Down', Direction.Down);
+    super({
+      id: ResizePaneDownAction.ID,
+      title: localize2('vscodeee.resizePaneDown', 'Resize Pane Down'),
+      f1: true,
+      category: Categories.View,
+    }, Direction.Down);
   }
 }
 
@@ -99,7 +102,12 @@ class ResizePaneDownAction extends BaseResizePaneAction {
 class ResizePaneLeftAction extends BaseResizePaneAction {
   static readonly ID = 'vscodeee.resizePaneLeft';
   constructor() {
-    super(ResizePaneLeftAction.ID, 'Resize Pane Left', Direction.Left);
+    super({
+      id: ResizePaneLeftAction.ID,
+      title: localize2('vscodeee.resizePaneLeft', 'Resize Pane Left'),
+      f1: true,
+      category: Categories.View,
+    }, Direction.Left);
   }
 }
 
@@ -107,7 +115,12 @@ class ResizePaneLeftAction extends BaseResizePaneAction {
 class ResizePaneRightAction extends BaseResizePaneAction {
   static readonly ID = 'vscodeee.resizePaneRight';
   constructor() {
-    super(ResizePaneRightAction.ID, 'Resize Pane Right', Direction.Right);
+    super({
+      id: ResizePaneRightAction.ID,
+      title: localize2('vscodeee.resizePaneRight', 'Resize Pane Right'),
+      f1: true,
+      category: Categories.View,
+    }, Direction.Right);
   }
 }
 

--- a/src/vs/workbench/test/browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/workbenchTestServices.ts
@@ -695,6 +695,7 @@ export class TestLayoutService implements IWorkbenchLayoutService {
 	isMainEditorLayoutCentered(): boolean { return false; }
 	centerMainEditorLayout(_active: boolean): void { }
 	resizePart(_part: Parts, _sizeChangeWidth: number, _sizeChangeHeight: number): void { }
+	resizePaneBorder(_direction: Direction): void { }
 	getSize(part: Parts): IViewSize { throw new Error('Method not implemented.'); }
 	setSize(part: Parts, size: IViewSize): void { throw new Error('Method not implemented.'); }
 	registerPart(part: Part): IDisposable { return Disposable.None; }
@@ -928,6 +929,7 @@ export class TestEditorGroupsService implements IEditorGroupsService {
 	createEditorDropTarget(container: HTMLElement, delegate: IEditorDropTargetDelegate): IDisposable { return Disposable.None; }
 	registerContextKeyProvider<T extends ContextKeyValue>(_provider: IEditorGroupContextKeyProvider<T>): IDisposable { throw new Error('not implemented'); }
 	getScopedInstantiationService(part: IEditorPart): IInstantiationService { throw new Error('Method not implemented.'); }
+	resizeGroupBorder(_group: number | IEditorGroupView, _direction: Direction, _delta: number): boolean { return false; }
 
 	partOptions!: IEditorPartOptions;
 	enforcePartOptions(options: IEditorPartOptions): IDisposable { return Disposable.None; }

--- a/src/vs/workbench/workbench.tauri.main.ts
+++ b/src/vs/workbench/workbench.tauri.main.ts
@@ -34,6 +34,7 @@ import './tauri-browser/desktop.tauri.main.js';
 
 import './tauri-browser/actions/developerActions.js';
 import './tauri-browser/actions/nativeActions.js';
+import './tauri-browser/actions/resizePaneActions.js';
 import './tauri-browser/actions/shellCommandActions.js';
 
 //#endregion


### PR DESCRIPTION
## Summary

- Add `vscodeee.resizePaneUp/Down/Left/Right` commands that move the focused pane's border in the specified direction, matching tmux's `resize-pane` behavior
- Add `resizeViewBorder()` to `Grid`/`GridView` as a new primitive for directional border movement within the VS Code grid tree
- Add `resizePaneBorder()` to `IWorkbenchLayoutService` with automatic fallback from editor group grid to workbench grid
- Add `vscodeee.resizeIncrement` setting (APPLICATION scope, default: 60px) to control resize amount

## Implementation details

The core algorithm in `GridView.resizeViewBorder()` walks up the grid tree to find the nearest `BranchNode` matching the target orientation (HORIZONTAL for Left/Right, VERTICAL for Up/Down). It finds any visible adjacent sibling — preferring the sibling in the movement direction (active pane grows) with fallback to the opposite side (active pane shrinks) — then moves the border while respecting min/max size constraints.

For multi-editor-group layouts, the editor group's internal grid is tried first. If no matching border exists in that direction (e.g., 2 horizontal columns + resizePaneUp), the workbench grid is tried as fallback, matching tmux's tree-walking propagation behavior.

## Test plan

- [ ] Verify all 4 directions work correctly with 2-column editor layout
- [ ] Verify all 4 directions work correctly with 2-row editor layout
- [ ] Verify behavior with sidebar, panel, and auxiliary bar visible
- [ ] Verify `vscodeee.resizeIncrement` setting changes take effect
- [ ] Verify edge case: single editor group + no sidebar/panel = no-op
- [ ] Verify editor group grid fallback to workbench grid (e.g., 2-column editors + resizePaneUp moves panel border)

Closes #321

🤖 Generated with [Claude Code](https://claude.com/claude-code)