### PR TITLE
feat: reduce minimum pane dimensions for tmux-like splits

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editor.ts
+++ b/src/vs/workbench/browser/parts/editor/editor.ts
@@ -29,9 +29,10 @@ export interface IEditorPartCreationOptions {
 }
 
 /**
- * Default minimum dimensions for editor panes (220x70 pixels).
+ * Default minimum dimensions for editor panes.
+ * Reduced from 220x70 to 50x35 to allow tmux-like fine-grained splits.
  */
-export const DEFAULT_EDITOR_MIN_DIMENSIONS = new Dimension(220, 70);
+export const DEFAULT_EDITOR_MIN_DIMENSIONS = new Dimension(50, 35);
 
 /**
  * Default maximum dimensions for editor panes (unbounded).

--- a/src/vs/workbench/browser/parts/panel/panelPart.ts
+++ b/src/vs/workbench/browser/parts/panel/panelPart.ts
@@ -37,9 +37,10 @@ export class PanelPart extends AbstractPaneCompositePart {
 
 	//#region IView
 
-	readonly minimumWidth: number = 300;
+	// Reduced from 300/77 to allow tmux-like fine-grained splits
+	readonly minimumWidth: number = 100;
 	readonly maximumWidth: number = Number.POSITIVE_INFINITY;
-	readonly minimumHeight: number = 77;
+	readonly minimumHeight: number = 35;
 	readonly maximumHeight: number = Number.POSITIVE_INFINITY;
 
 	get preferredHeight(): number | undefined {


### PR DESCRIPTION
## Summary

Reduces minimum pane dimensions to allow finer-grained splits, similar to tmux behavior.

- **Editor**: `DEFAULT_EDITOR_MIN_DIMENSIONS` from `220x70` to `50x35`
- **Panel**: `minimumWidth` from `300` to `100`, `minimumHeight` from `77` to `35`

## Changes

| File | Change |
|------|--------|
| `src/vs/workbench/browser/parts/editor/editor.ts` | `Dimension(220, 70)` → `Dimension(50, 35)` |
| `src/vs/workbench/browser/parts/panel/panelPart.ts` | `minimumWidth: 300` → `100`, `minimumHeight: 77` → `35` |

## Motivation

With the directional pane resize commands (#334) now merged, users can resize panes in any direction. However, the large minimum dimensions (220x70 for editors, 300x77 for panels) prevent creating small panes. Reducing these minimums enables tmux-like fine-grained layout control.

Closes #333