### PR TITLE
fix: add generate-notes dependency to build-reh job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -305,7 +305,7 @@ jobs:
 
   build-reh:
     name: Build REH Server (${{ matrix.os }}-${{ matrix.arch }})
-    needs: [preflight, create-release]
+    needs: [preflight, generate-notes, create-release]
     if: needs.preflight.outputs.skip != 'true'
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

The `build-reh` job in the Release workflow was failing with a 404 error when trying to upload REH server assets to the release. The root cause was a missing dependency — `build-reh` only waited for `preflight` and `create-release`, but not for `generate-notes`. Since `create-release` uses the output from `generate-notes` via `RELEASE_NOTES` env var, the release creation could race with `build-reh` starting.

## Related Issue

Discovered while investigating the failed Release workflow run for v0.5.1 (#332).

## Changes

- Added `generate-notes` to the `needs` array of the `build-reh` job in `.github/workflows/publish.yml`

## How to Test

1. Merge a version bump PR to main
2. Verify the Release workflow completes successfully
3. Confirm all REH server assets are uploaded to the draft release

🤖 Generated with [Claude Code](https://claude.com/claude-code)