### PR TITLE
refactor: consolidate vscodeee editor settings under vscodeee.workbench.editor namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Rename `workbench.editor.autoMaximizeOnFocus` to `vscodeee.workbench.editor.autoMaximizeOnFocus` (Tauri-specific setting now under `vscodeee` prefix)
+- Rename `vscodeee.editorGroupIndexInTab` to `vscodeee.workbench.editor.editorGroupIndexInTab`
+- Rename `vscodeee.resizeIncrement` to `vscodeee.workbench.editor.resizeIncrement`
+
 ## [0.5.1] - 2026-04-28
 
 ### Changed

--- a/README.ja.md
+++ b/README.ja.md
@@ -82,9 +82,9 @@ VSCode の現在の機能を維持しつつ、以下を実現します：
     - `vscodeee.resizePaneUp`
     - `vscodeee.resizePaneDown`
 - エディタグループのプレフィックスにインデックスを表示(tmuxのprefix + `n`向け)
-  - `"vscodeee.editorGroupIndexInTab": true`
+  - `"vscodeee.workbench.editor.editorGroupIndexInTab": true`
 - 最小Paneにフォーカスすると自動的に対象Paneが最大化されることを抑制する
-  - `"workbench.editor.autoMaximizeOnFocus": false`
+  - `"vscodeee.workbench.editor.autoMaximizeOnFocus": false`
   - 本家VSCodeの[issue#85309](https://github.com/microsoft/vscode/issues/85309)
 
 ---

--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ Maintain the current functionality of VSCode while achieving the following:
     - `vscodeee.resizePaneUp`
     - `vscodeee.resizePaneDown`
 - Display index prefix on editor groups (for tmux prefix + `n`)
-  - `"vscodeee.editorGroupIndexInTab": true`
+  - `"vscodeee.workbench.editor.editorGroupIndexInTab": true`
 - Suppress auto-maximize when focusing the smallest pane
-  - `"workbench.editor.autoMaximizeOnFocus": false`
+  - `"vscodeee.workbench.editor.autoMaximizeOnFocus": false`
   - Upstream VSCode [issue#85309](https://github.com/microsoft/vscode/issues/85309)
 
 ---

--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -123,6 +123,10 @@ const COMMAND_CENTER_SETTINGS = [
 	'workbench.experimental.share.enabled',
 ];
 
+/**
+ * Configuration setting keys that affect the title bar appearance.
+ * Used to trigger layout recalculations when any of these settings change.
+ */
 export const TITLE_BAR_SETTINGS = [
 	LayoutSettings.ACTIVITY_BAR_LOCATION,
 	LayoutSettings.COMMAND_CENTER,
@@ -137,6 +141,17 @@ export const TITLE_BAR_SETTINGS = [
 const DEFAULT_EMPTY_WINDOW_DIMENSIONS = new Dimension(DEFAULT_EMPTY_WINDOW_SIZE.width, DEFAULT_EMPTY_WINDOW_SIZE.height);
 const DEFAULT_WORKSPACE_WINDOW_DIMENSIONS = new Dimension(DEFAULT_WORKSPACE_WINDOW_SIZE.width, DEFAULT_WORKSPACE_WINDOW_SIZE.height);
 
+/**
+ * Abstract base class for the workbench layout manager.
+ *
+ * Manages the sizing, visibility, and positioning of all workbench parts
+ * (title bar, activity bar, sidebar, editor, panel, auxiliary bar, status bar)
+ * within a grid-based layout system. Handles initialization, restoration,
+ * zen mode transitions, panel maximization, and pane resizing.
+ *
+ * Implementations must provide `createWorkbenchLayout()` to build the
+ * concrete grid of parts.
+ */
 export abstract class Layout extends Disposable implements IWorkbenchLayoutService {
 
 	declare readonly _serviceBrand: undefined;
@@ -1406,6 +1421,16 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 		this.stateModel.setRuntimeValue(LayoutStateKeys.ZEN_MODE_ACTIVE, active);
 	}
 
+	/**
+		 * Toggles the workbench in and out of zen mode. When entering zen mode,
+		 * parts are hidden, the window may go fullscreen, line numbers may be
+		 * hidden, and notifications may be silenced depending on configuration.
+		 * When exiting, the previous state of all parts is restored.
+		 *
+		 * @param skipLayout - If `true`, skips the layout recalculation after toggling.
+		 * @param restoring - If `true`, this is a session restore and transition
+		 *                    metadata (fullscreen, centered layout) is not re-recorded.
+		 */
 	toggleZenMode(skipLayout?: boolean, restoring = false): void {
 		const focusedPartPreTransition = this._getFocusedPart();
 
@@ -1595,6 +1620,12 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 		this.workbenchGrid.setViewVisible(this.statusBarPartView, !hidden);
 	}
 
+	/**
+		 * Creates the workbench grid layout from all registered parts.
+		 * Builds the grid descriptor, deserializes the grid widget, and sets up
+		 * event listeners for part visibility changes, state persistence, and
+		 * pane composite open/close events.
+		 */
 	protected createWorkbenchLayout(): void {
 		const titleBar = this.getPart(Parts.TITLEBAR_PART);
 		const bannerPart = this.getPart(Parts.BANNER_PART);
@@ -1720,6 +1751,15 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 		return this.stateModel.getRuntimeValue(LayoutStateKeys.MAIN_EDITOR_CENTERED);
 	}
 
+	/**
+		 * Enables or disables the centered editor layout on the main editor part.
+		 * Automatically disables centering when complex editors (diff, multi-editor)
+		 * are active or when there is more than one editor column, unless
+		 * `workbench.editor.centeredLayoutAutoResize` is disabled.
+		 *
+		 * @param active - Whether to enable centered layout.
+		 * @param skipLayout - If `true`, skips the layout recalculation.
+		 */
 	centerMainEditorLayout(active: boolean, skipLayout?: boolean): void {
 		this.stateModel.setRuntimeValue(LayoutStateKeys.MAIN_EDITOR_CENTERED, active);
 
@@ -1771,6 +1811,17 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 		this.workbenchGrid.resizeView(this.getPart(part), size);
 	}
 
+	/**
+		 * Resizes the specified workbench part by the given pixel amounts.
+		 * Applies screen-aware scaling for high-DPI displays.
+		 * For the editor part with multiple groups, resizes the active group
+		 * within the editor grid; falls back to resizing the full editor part
+		 * if the active group cannot be resized in the requested direction.
+		 *
+		 * @param part - The workbench part to resize.
+		 * @param sizeChangeWidth - The horizontal size change in logical pixels.
+		 * @param sizeChangeHeight - The vertical size change in logical pixels.
+		 */
 	resizePart(part: Parts, sizeChangeWidth: number, sizeChangeHeight: number): void {
 		const sizeChangePxWidth = Math.sign(sizeChangeWidth) * computeScreenAwareSize(getActiveWindow(), Math.abs(sizeChangeWidth));
 		const sizeChangePxHeight = Math.sign(sizeChangeHeight) * computeScreenAwareSize(getActiveWindow(), Math.abs(sizeChangeHeight));
@@ -1910,13 +1961,13 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 	}
 
 	/**
-	 * Reads the `vscodeee.resizeIncrement` configuration value and
+	 * Reads the `vscodeee.workbench.editor.resizeIncrement` configuration value and
 	 * applies screen-aware scaling for high-DPI displays.
 	 *
 	 * @returns The scaled pixel increment, or 0 if invalid.
 	 */
 	private getResizeIncrement(): number {
-		const configValue = this.configurationService.getValue<number>('vscodeee.resizeIncrement');
+		const configValue = this.configurationService.getValue<number>('vscodeee.workbench.editor.resizeIncrement');
 		const raw = typeof configValue === 'number' && configValue > 0 ? configValue : 60;
 		return computeScreenAwareSize(getActiveWindow(), raw);
 	}
@@ -2193,6 +2244,15 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 		this.setAuxiliaryBarMaximized(!this.isAuxiliaryBarMaximized());
 	}
 
+	/**
+		 * Maximizes or restores the auxiliary sidebar. When maximizing, hides the
+		 * sidebar, editor, and panel. When restoring, shows the previously visible
+		 * parts and restores the auxiliary bar to its last non-maximized size.
+		 * Re-entrant calls during a transition are no-ops.
+		 *
+		 * @param maximized - `true` to maximize, `false` to restore.
+		 * @returns `true` if the maximization state changed, `false` otherwise.
+		 */
 	setAuxiliaryBarMaximized(maximized: boolean): boolean {
 		if (
 			this.inMaximizedAuxiliaryBarTransition ||		// prevent re-entrance
@@ -2413,6 +2473,14 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 		return this.stateModel.getRuntimeValue(LayoutStateKeys.PANEL_POSITION);
 	}
 
+	/**
+		 * Sets the panel position. If the panel is currently hidden, it is shown.
+		 * Preserves the panel's non-maximized size when moving between horizontal
+		 * and vertical positions. Adjusts sidebar and auxiliary bar positions
+		 * to maintain the correct grid layout.
+		 *
+		 * @param position - The new panel position.
+		 */
 	setPanelPosition(position: Position): void {
 		if (!this.isVisible(Parts.PANEL_PART)) {
 			this.setPanelHidden(false);
@@ -2516,6 +2584,15 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 		this._onDidChangeWindowMaximized.fire({ windowId: targetWindowId, maximized });
 	}
 
+	/**
+		 * Returns the next visible workbench part adjacent to the given part
+		 * in the specified direction. Returns `undefined` if no visible neighbor
+		 * exists in that direction.
+		 *
+		 * @param part - The source part to search from.
+		 * @param direction - The direction to search for a neighbor.
+		 * @returns The adjacent visible part, or `undefined`.
+		 */
 	getVisibleNeighborPart(part: Parts, direction: Direction): Parts | undefined {
 		if (!this.workbenchGrid) {
 			return undefined;

--- a/src/vs/workbench/browser/parts/editor/editor.ts
+++ b/src/vs/workbench/browser/parts/editor/editor.ts
@@ -22,6 +22,21 @@ import { ContextKeyValue, IContextKey, RawContextKey } from '../../../../platfor
 import { coalesce } from '../../../../base/common/arrays.js';
 
 /**
+ * Configuration shape for VSCodeEE-specific editor settings.
+ * Nested under `vscodeee.workbench.editor` in settings.json.
+ */
+interface IVSCodeEEEditorConfiguration {
+	vscodeee?: {
+		workbench?: {
+			editor?: {
+				autoMaximizeOnFocus?: boolean;
+				editorGroupIndexInTab?: boolean;
+			};
+		};
+	};
+}
+
+/**
  * Options for creating an editor part instance.
  */
 export interface IEditorPartCreationOptions {
@@ -97,7 +112,7 @@ export const DEFAULT_EDITOR_PART_OPTIONS: IEditorPartOptions = {
 /**
  * Checks whether a configuration change event affects editor part options.
  * Covers `workbench.editor`, `workbench.iconTheme`, `window.density`,
- * and `vscodeee.editorGroupIndexInTab` settings.
+ * and `vscodeee.workbench.editor` settings.
  *
  * @param event - The configuration change event to evaluate.
  * @returns `true` if the event may change editor part options.
@@ -106,14 +121,14 @@ export function impactsEditorPartOptions(event: IConfigurationChangeEvent): bool
 	return event.affectsConfiguration('workbench.editor') ||
 		event.affectsConfiguration('workbench.iconTheme') ||
 		event.affectsConfiguration('window.density') ||
-		event.affectsConfiguration('vscodeee.editorGroupIndexInTab');
+		event.affectsConfiguration('vscodeee.workbench.editor');
 }
 
 /**
  * Resolves the effective editor part options by merging user configuration
  * with the default options. Handles special cases like `autoLockGroups` object
  * conversion, `window.density.editorTabHeight` override, and the
- * `vscodeee.editorGroupIndexInTab` setting.
+ * `vscodeee.workbench.editor` settings.
  *
  * @param configurationService - The configuration service to read settings from.
  * @param themeService - The theme service to determine icon availability.
@@ -150,10 +165,13 @@ export function getEditorPartOptions(configurationService: IConfigurationService
 		options.tabHeight = windowConfig.window.density.editorTabHeight;
 	}
 
-	// Handle vscodeee-specific setting
-	const vscodeeeConfig = configurationService.getValue<{ vscodeee?: { editorGroupIndexInTab?: boolean } }>();
-	if (vscodeeeConfig?.vscodeee?.editorGroupIndexInTab !== undefined) {
-		options.editorGroupIndexInTab = vscodeeeConfig.vscodeee.editorGroupIndexInTab;
+	// Handle vscodeee.workbench.editor settings
+	const vscodeeeEditorConfig = configurationService.getValue<IVSCodeEEEditorConfiguration>()?.vscodeee?.workbench?.editor;
+	if (vscodeeeEditorConfig?.autoMaximizeOnFocus !== undefined) {
+		options.autoMaximizeOnFocus = vscodeeeEditorConfig.autoMaximizeOnFocus;
+	}
+	if (vscodeeeEditorConfig?.editorGroupIndexInTab !== undefined) {
+		options.editorGroupIndexInTab = vscodeeeEditorConfig.editorGroupIndexInTab;
 	}
 
 	return validateEditorPartOptions(options);

--- a/src/vs/workbench/browser/parts/editor/editorPart.ts
+++ b/src/vs/workbench/browser/parts/editor/editorPart.ts
@@ -876,7 +876,7 @@ export class EditorPart extends Part<IEditorPartMemento> implements IEditorPart,
 	/**
 	 * Restores a minimized group by unmaximizing any currently maximized group
 	 * and expanding the target group if it is at its minimum size.
-	 * This behavior is controlled by the `autoMaximizeOnFocus` editor part option.
+	 * This behavior is controlled by the `vscodeee.workbench.editor.autoMaximizeOnFocus` setting.
 	 *
 	 * @param group - The group to restore.
 	 */

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -431,11 +431,6 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 				'default': false,
 				'description': localize('centeredLayoutDynamicWidth', "Controls whether the centered layout tries to maintain constant width when the window is resized.")
 			},
-			'workbench.editor.autoMaximizeOnFocus': {
-				'type': 'boolean',
-				'default': true,
-				'description': localize('autoMaximizeOnFocus', "Controls whether editor groups are automatically expanded or unmaximized when receiving focus. When disabled, minimized editor groups stay minimized and other groups stay maximized when focus moves between them.")
-			},
 			'workbench.editor.doubleClickTabToToggleEditorGroupSizes': {
 				'type': 'string',
 				'enum': ['maximize', 'expand', 'off'],
@@ -1105,14 +1100,19 @@ Registry.as<IConfigurationMigrationRegistry>(Extensions.ConfigurationMigration)
 		}
 	}]);
 
-// VSCodeEE: Editor group index in tab
+// VSCodeEE: Workbench editor settings
 registry.registerConfiguration({
 	'id': 'vscodeee',
 	'order': 20,
 	'title': localize('vscodeeeConfigurationTitle', "VSCodeEE"),
 	'type': 'object',
 	'properties': {
-		'vscodeee.editorGroupIndexInTab': {
+		'vscodeee.workbench.editor.autoMaximizeOnFocus': {
+			'type': 'boolean',
+			'default': true,
+			'description': localize('autoMaximizeOnFocus', "Controls whether editor groups are automatically expanded or unmaximized when receiving focus. When disabled, minimized editor groups stay minimized and other groups stay maximized when focus moves between them.")
+		},
+		'vscodeee.workbench.editor.editorGroupIndexInTab': {
 			'type': 'boolean',
 			'default': false,
 			'description': localize('editorGroupIndexInTab', "When enabled, shows the editor group index prefix (e.g., [1]) on the active tab of each editor group. Only appears when 2 or more editor groups are open.")

--- a/src/vs/workbench/common/editor.ts
+++ b/src/vs/workbench/common/editor.ts
@@ -1444,7 +1444,7 @@ interface IEditorPartConfiguration {
 	 * Controls whether the editor group index is displayed in the tab bar.
 	 * When enabled, a bracketed number (e.g. `[1]`, `[2]`) is shown
 	 * before the tabs when multiple editor groups exist. Only visible when
-	 * the `vscodeee.editorGroupIndexInTab` setting is enabled and there are
+	 * the `vscodeee.workbench.editor.editorGroupIndexInTab` setting is enabled and there are
 	 * at least 2 editor groups in the grid.
 	 */
 	editorGroupIndexInTab?: boolean;

--- a/src/vs/workbench/services/layout/browser/layoutService.ts
+++ b/src/vs/workbench/services/layout/browser/layoutService.ts
@@ -16,8 +16,15 @@ import { isFullscreen, isWCOEnabled } from '../../../../base/browser/browser.js'
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IDisposable } from '../../../../base/common/lifecycle.js';
 
+/**
+ * Service decorator that refines {@link ILayoutService} into the full
+ * {@link IWorkbenchLayoutService} interface used by the workbench.
+ */
 export const IWorkbenchLayoutService = refineServiceDecorator<ILayoutService, IWorkbenchLayoutService>(ILayoutService);
 
+/**
+ * Identifiers for all workbench parts that participate in the layout grid.
+ */
 export const enum Parts {
 	TITLEBAR_PART = 'workbench.parts.titlebar',
 	BANNER_PART = 'workbench.parts.banner',
@@ -30,6 +37,9 @@ export const enum Parts {
 	STATUSBAR_PART = 'workbench.parts.statusbar'
 }
 
+/**
+ * Configuration setting keys that control zen mode behavior.
+ */
 export const enum ZenModeSettings {
 	SHOW_TABS = 'zenMode.showTabs',
 	HIDE_LINENUMBERS = 'zenMode.hideLineNumbers',
@@ -41,6 +51,9 @@ export const enum ZenModeSettings {
 	SILENT_NOTIFICATIONS = 'zenMode.silentNotifications',
 }
 
+/**
+ * Configuration setting keys for workbench layout options.
+ */
 export const enum LayoutSettings {
 	ACTIVITY_BAR_LOCATION = 'workbench.activityBar.location',
 	ACTIVITY_BAR_AUTO_HIDE = 'workbench.activityBar.autoHide',
@@ -52,6 +65,9 @@ export const enum LayoutSettings {
 	SHADOWS = 'workbench.shadows'
 }
 
+/**
+ * Possible positions for the activity bar.
+ */
 export const enum ActivityBarPosition {
 	DEFAULT = 'default',
 	TOP = 'top',
@@ -59,18 +75,27 @@ export const enum ActivityBarPosition {
 	HIDDEN = 'hidden'
 }
 
+/**
+ * Display modes for editor tabs in the editor title area.
+ */
 export const enum EditorTabsMode {
 	MULTIPLE = 'multiple',
 	SINGLE = 'single',
 	NONE = 'none'
 }
 
+/**
+ * Locations where editor actions can be displayed.
+ */
 export const enum EditorActionsLocation {
 	DEFAULT = 'default',
 	TITLEBAR = 'titleBar',
 	HIDDEN = 'hidden'
 }
 
+/**
+ * Cardinal positions for side bar and panel placement.
+ */
 export const enum Position {
 	LEFT,
 	RIGHT,
@@ -78,18 +103,36 @@ export const enum Position {
 	TOP
 }
 
+/**
+ * Returns `true` if the given position is horizontal (top or bottom).
+ *
+ * @param position - The position to check.
+ * @returns Whether the position is horizontal.
+ */
 export function isHorizontal(position: Position): boolean {
 	return position === Position.BOTTOM || position === Position.TOP;
 }
 
+/**
+ * Options controlling when a part (panel, auxiliary bar) opens maximized.
+ */
 export const enum PartOpensMaximizedOptions {
 	ALWAYS,
 	NEVER,
 	REMEMBER_LAST
 }
 
+/**
+ * Horizontal alignment options for the panel when positioned at the top or bottom.
+ */
 export type PanelAlignment = 'left' | 'center' | 'right' | 'justify';
 
+/**
+ * Converts a {@link Position} enum value to its lowercase string representation.
+ *
+ * @param position - The position to convert.
+ * @returns The lowercase string representation, or `'bottom'` as a fallback.
+ */
 export function positionToString(position: Position): string {
 	switch (position) {
 		case Position.LEFT: return 'left';
@@ -107,6 +150,12 @@ const positionsByString: { [key: string]: Position } = {
 	[positionToString(Position.TOP)]: Position.TOP
 };
 
+/**
+ * Converts a lowercase string to a {@link Position} enum value.
+ *
+ * @param str - The string to convert (e.g., `'left'`, `'right'`, `'top'`, `'bottom'`).
+ * @returns The corresponding `Position`, or `undefined` if not recognized.
+ */
 export function positionFromString(str: string): Position {
 	return positionsByString[str];
 }
@@ -126,24 +175,53 @@ const partOpensMaximizedByString: { [key: string]: PartOpensMaximizedOptions } =
 	[partOpensMaximizedSettingToString(PartOpensMaximizedOptions.REMEMBER_LAST)]: PartOpensMaximizedOptions.REMEMBER_LAST
 };
 
+/**
+ * Converts a string to a {@link PartOpensMaximizedOptions} enum value.
+ *
+ * @param str - The string to convert (e.g., `'always'`, `'never'`, `'preserve'`).
+ * @returns The corresponding `PartOpensMaximizedOptions`, or `undefined` if not recognized.
+ */
 export function partOpensMaximizedFromString(str: string): PartOpensMaximizedOptions {
 	return partOpensMaximizedByString[str];
 }
 
+/**
+ * Parts that can exist in multiple windows (main and auxiliary).
+ */
 export type MULTI_WINDOW_PARTS = Parts.EDITOR_PART | Parts.STATUSBAR_PART | Parts.TITLEBAR_PART;
+
+/**
+ * Parts that only exist in the main window.
+ */
 export type SINGLE_WINDOW_PARTS = Exclude<Parts, MULTI_WINDOW_PARTS>;
 
+/**
+ * Type guard that returns `true` if the given part is a multi-window part.
+ *
+ * @param part - The part to check.
+ * @returns Whether the part is a multi-window part.
+ */
 export function isMultiWindowPart(part: Parts): part is MULTI_WINDOW_PARTS {
 	return part === Parts.EDITOR_PART ||
 		part === Parts.STATUSBAR_PART ||
 		part === Parts.TITLEBAR_PART;
 }
 
+/**
+ * Event payload fired when a workbench part's visibility changes.
+ */
 export interface IPartVisibilityChangeEvent {
+	/** The identifier of the part whose visibility changed. */
 	readonly partId: string;
+	/** Whether the part is now visible. */
 	readonly visible: boolean;
 }
 
+/**
+ * The workbench layout service manages the layout of all workbench parts
+ * (title bar, sidebar, panel, editor, status bar, activity bar, etc.),
+ * including visibility, position, maximized states, zen mode, and pane resizing.
+ */
 export interface IWorkbenchLayoutService extends ILayoutService {
 
 	readonly _serviceBrand: undefined;
@@ -353,7 +431,7 @@ export interface IWorkbenchLayoutService extends ILayoutService {
 	 * direction (e.g., two horizontal columns but resizing upward), falls
 	 * back to the workbench grid to match tmux's tree-walking behavior.
 	 *
-	 * The pixel increment is controlled by the `vscodeee.resizeIncrement`
+	 * The pixel increment is controlled by the `vscodeee.workbench.editor.resizeIncrement`
 	 * configuration setting (default: 60, range: 1-500).
 	 *
 	 * @param direction The direction to move the border.
@@ -381,6 +459,22 @@ export interface IWorkbenchLayoutService extends ILayoutService {
 	getVisibleNeighborPart(part: Parts, direction: Direction): Parts | undefined;
 }
 
+/**
+ * Determines whether the custom title bar should be shown based on the
+ * current configuration, platform, and fullscreen state.
+ *
+ * Takes into account:
+ * - Custom title bar configuration setting
+ * - Native title bar and native menu availability
+ * - Fullscreen state on macOS (Electron and Tauri)
+ * - Window Controls Overlay (WCO) visibility on the web
+ * - Menu bar visibility mode
+ *
+ * @param configurationService - The configuration service to read settings from.
+ * @param window - The target window to evaluate.
+ * @param menuBarToggled - Whether the menu bar has been manually toggled.
+ * @returns `true` if the custom title bar should be displayed.
+ */
 export function shouldShowCustomTitleBar(configurationService: IConfigurationService, window: Window, menuBarToggled?: boolean): boolean {
 	if (!hasCustomTitlebar(configurationService)) {
 		return false;

--- a/src/vs/workbench/tauri-browser/actions/resizePaneActions.ts
+++ b/src/vs/workbench/tauri-browser/actions/resizePaneActions.ts
@@ -15,7 +15,7 @@ import { ServicesAccessor } from '../../../platform/instantiation/common/instant
 // #region Configuration
 
 const VSCodeEESettings = {
-  RESIZE_INCREMENT: 'vscodeee.resizeIncrement',
+  RESIZE_INCREMENT: 'vscodeee.workbench.editor.resizeIncrement',
 };
 
 Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).registerConfiguration({
@@ -31,7 +31,7 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
       maximum: 500,
       scope: ConfigurationScope.APPLICATION,
       description: localize(
-        'vscodeee.resizeIncrement',
+        'vscodeee.workbench.editor.resizeIncrement',
         'The number of pixels to resize a pane by when using directional resize commands (vscodeee.resizePaneUp/Down/Left/Right).',
       ),
     },
@@ -76,12 +76,7 @@ abstract class BaseResizePaneAction extends Action2 {
 class ResizePaneUpAction extends BaseResizePaneAction {
   static readonly ID = 'vscodeee.resizePaneUp';
   constructor() {
-    super({
-      id: ResizePaneUpAction.ID,
-      title: localize2('vscodeee.resizePaneUp', 'Resize Pane Up'),
-      f1: true,
-      category: Categories.View,
-    }, Direction.Up);
+    super({ id: ResizePaneUpAction.ID, title: localize2('vscodeee.resizePaneUp', 'Resize Pane Up'), f1: true, category: Categories.View }, Direction.Up);
   }
 }
 
@@ -89,12 +84,7 @@ class ResizePaneUpAction extends BaseResizePaneAction {
 class ResizePaneDownAction extends BaseResizePaneAction {
   static readonly ID = 'vscodeee.resizePaneDown';
   constructor() {
-    super({
-      id: ResizePaneDownAction.ID,
-      title: localize2('vscodeee.resizePaneDown', 'Resize Pane Down'),
-      f1: true,
-      category: Categories.View,
-    }, Direction.Down);
+    super({ id: ResizePaneDownAction.ID, title: localize2('vscodeee.resizePaneDown', 'Resize Pane Down'), f1: true, category: Categories.View }, Direction.Down);
   }
 }
 
@@ -102,12 +92,7 @@ class ResizePaneDownAction extends BaseResizePaneAction {
 class ResizePaneLeftAction extends BaseResizePaneAction {
   static readonly ID = 'vscodeee.resizePaneLeft';
   constructor() {
-    super({
-      id: ResizePaneLeftAction.ID,
-      title: localize2('vscodeee.resizePaneLeft', 'Resize Pane Left'),
-      f1: true,
-      category: Categories.View,
-    }, Direction.Left);
+    super({ id: ResizePaneLeftAction.ID, title: localize2('vscodeee.resizePaneLeft', 'Resize Pane Left'), f1: true, category: Categories.View }, Direction.Left);
   }
 }
 
@@ -115,12 +100,7 @@ class ResizePaneLeftAction extends BaseResizePaneAction {
 class ResizePaneRightAction extends BaseResizePaneAction {
   static readonly ID = 'vscodeee.resizePaneRight';
   constructor() {
-    super({
-      id: ResizePaneRightAction.ID,
-      title: localize2('vscodeee.resizePaneRight', 'Resize Pane Right'),
-      f1: true,
-      category: Categories.View,
-    }, Direction.Right);
+    super({ id: ResizePaneRightAction.ID, title: localize2('vscodeee.resizePaneRight', 'Resize Pane Right'), f1: true, category: Categories.View }, Direction.Right);
   }
 }
 


### PR DESCRIPTION
## Summary

Consolidate all VSCodeEE-specific editor settings under a consistent `vscodeee.workbench.editor.*` hierarchy to follow the CLAUDE.md convention that Tauri-specific settings must use the `vscodeee` prefix at the first level.

## Changes

- Rename `workbench.editor.autoMaximizeOnFocus` → `vscodeee.workbench.editor.autoMaximizeOnFocus` (was missing `vscodeee` prefix entirely)
- Rename `vscodeee.editorGroupIndexInTab` → `vscodeee.workbench.editor.editorGroupIndexInTab` (add semantic hierarchy)
- Rename `vscodeee.resizeIncrement` → `vscodeee.workbench.editor.resizeIncrement` (add semantic hierarchy)
- Extract `IVSCodeEEEditorConfiguration` interface for cleaner type-safe config reading in `getEditorPartOptions()`
- Update `impactsEditorPartOptions()` to check `vscodeee.workbench.editor` section (future-proof)
- Update all documentation (README.md, README.ja.md, CHANGELOG.md)

## How to Test

1. Open Settings UI → search for "vscodeee.workbench.editor" → verify 3 settings appear
2. Set `"vscodeee.workbench.editor.autoMaximizeOnFocus": false` → open multiple editor groups → verify maximized groups stay maximized on focus change
3. Set `"vscodeee.workbench.editor.editorGroupIndexInTab": true` → verify index prefix appears on tabs
4. Use `vscodeee.resizePaneUp/Down/Left/Right` commands → verify resize works with new setting key
5. Verify old setting keys (`workbench.editor.autoMaximizeOnFocus`, `vscodeee.editorGroupIndexInTab`, `vscodeee.resizeIncrement`) are no longer recognized

🤖 Generated with [Claude Code](https://claude.com/claude-code)