### PR TITLE
chore: release v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rename `workbench.editor.autoMaximizeOnFocus` to `vscodeee.workbench.editor.autoMaximizeOnFocus` (Tauri-specific setting now under `vscodeee` prefix)
 - Rename `vscodeee.editorGroupIndexInTab` to `vscodeee.workbench.editor.editorGroupIndexInTab`
 - Rename `vscodeee.resizeIncrement` to `vscodeee.workbench.editor.resizeIncrement`
+- Rename pane resize command IDs to `vscodeee.workbench.editor` namespace
 
 ## [0.5.1] - 2026-04-28
 
+### Added
+
+- Add tmux-like directional pane resize commands ([#334](https://github.com/j4rviscmd/vscodeee/pull/334))
+- Reduce minimum pane dimensions for tmux-like splits
+
+### Fixed
+
+- Add `generate-notes` dependency to `build-reh` job to prevent 404 errors when uploading REH assets ([#337](https://github.com/j4rviscmd/vscodeee/pull/337))
+
 ### Changed
 
+- Add Japanese README (README.ja.md) and restructure documentation ([#335](https://github.com/j4rviscmd/vscodeee/pull/335))
 - Skip BUNDLED extension dependencies in Phase 2 node_modules bundling — reduces staging node_modules from 66.9MB to 47.5MB (-19.4MB, -29%) ([#330](https://github.com/j4rviscmd/vscodeee/pull/330))
 - Exclude unused `@azure` and `@octokit` type packages from bundle ([#328](https://github.com/j4rviscmd/vscodeee/pull/328))
 - Parallelize `publish-tauri` and `build-reh` CI jobs for faster releases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.5.1] - 2026-04-28
 
+### Fixed
+
+- Add `generate-notes` dependency to `build-reh` job to prevent 404 errors when uploading REH assets ([#337](https://github.com/j4rviscmd/vscodeee/pull/337))
+
 ### Changed
 
 - Skip BUNDLED extension dependencies in Phase 2 node_modules bundling — reduces staging node_modules from 66.9MB to 47.5MB (-19.4MB, -29%) ([#330](https://github.com/j4rviscmd/vscodeee/pull/330))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- Add `generate-notes` dependency to `build-reh` job to prevent 404 errors when uploading REH assets ([#337](https://github.com/j4rviscmd/vscodeee/pull/337))
-
 ### Changed
 
 - Rename `workbench.editor.autoMaximizeOnFocus` to `vscodeee.workbench.editor.autoMaximizeOnFocus` (Tauri-specific setting now under `vscodeee` prefix)


### PR DESCRIPTION
## Summary

Re-release v0.5.1 with the CI fix for the `build-reh` job dependency. The original v0.5.1 release workflow failed because `build-reh` was missing a `generate-notes` dependency, causing 404 errors when uploading REH server assets.

## Changes

- CHANGELOG: add CI fix entry for `build-reh` job dependency

## How to Test

1. Merge this PR to trigger the Release workflow
2. Verify all jobs (publish-tauri, build-reh, upload-stable-assets) complete successfully
3. Confirm the release is published with all expected assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)