### PR TITLE
refactor: rename pane resize command IDs to vscodeee.workbench.editor namespace

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -77,10 +77,10 @@ VSCode の現在の機能を維持しつつ、以下を実現します：
 
 - tmuxライクなPane操作キーバインド
   - Paneサイズ調整コマンドを実装
-    - `vscodeee.resizePaneRight`
-    - `vscodeee.resizePaneLeft`
-    - `vscodeee.resizePaneUp`
-    - `vscodeee.resizePaneDown`
+    - `vscodeee.workbench.editor.resizePaneRight`
+    - `vscodeee.workbench.editor.resizePaneLeft`
+    - `vscodeee.workbench.editor.resizePaneUp`
+    - `vscodeee.workbench.editor.resizePaneDown`
 - エディタグループのプレフィックスにインデックスを表示(tmuxのprefix + `n`向け)
   - `"vscodeee.workbench.editor.editorGroupIndexInTab": true`
 - 最小Paneにフォーカスすると自動的に対象Paneが最大化されることを抑制する

--- a/README.md
+++ b/README.md
@@ -77,10 +77,10 @@ Maintain the current functionality of VSCode while achieving the following:
 
 - tmux-like pane control keybindings
   - Pane resize commands
-    - `vscodeee.resizePaneRight`
-    - `vscodeee.resizePaneLeft`
-    - `vscodeee.resizePaneUp`
-    - `vscodeee.resizePaneDown`
+    - `vscodeee.workbench.editor.resizePaneRight`
+    - `vscodeee.workbench.editor.resizePaneLeft`
+    - `vscodeee.workbench.editor.resizePaneUp`
+    - `vscodeee.workbench.editor.resizePaneDown`
 - Display index prefix on editor groups (for tmux prefix + `n`)
   - `"vscodeee.workbench.editor.editorGroupIndexInTab": true`
 - Suppress auto-maximize when focusing the smallest pane

--- a/src/vs/workbench/tauri-browser/actions/resizePaneActions.ts
+++ b/src/vs/workbench/tauri-browser/actions/resizePaneActions.ts
@@ -32,7 +32,7 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
       scope: ConfigurationScope.APPLICATION,
       description: localize(
         'vscodeee.workbench.editor.resizeIncrement',
-        'The number of pixels to resize a pane by when using directional resize commands (vscodeee.resizePaneUp/Down/Left/Right).',
+        'The number of pixels to resize a pane by when using directional resize commands (vscodeee.workbench.editor.resizePaneUp/Down/Left/Right).',
       ),
     },
   },
@@ -74,33 +74,33 @@ abstract class BaseResizePaneAction extends Action2 {
 
 /** Resizes the focused pane by moving its top border upward. */
 class ResizePaneUpAction extends BaseResizePaneAction {
-  static readonly ID = 'vscodeee.resizePaneUp';
+  static readonly ID = 'vscodeee.workbench.editor.resizePaneUp';
   constructor() {
-    super({ id: ResizePaneUpAction.ID, title: localize2('vscodeee.resizePaneUp', 'Resize Pane Up'), f1: true, category: Categories.View }, Direction.Up);
+    super({ id: ResizePaneUpAction.ID, title: localize2('vscodeee.workbench.editor.resizePaneUp', 'Resize Pane Up'), f1: true, category: Categories.View }, Direction.Up);
   }
 }
 
 /** Resizes the focused pane by moving its bottom border downward. */
 class ResizePaneDownAction extends BaseResizePaneAction {
-  static readonly ID = 'vscodeee.resizePaneDown';
+  static readonly ID = 'vscodeee.workbench.editor.resizePaneDown';
   constructor() {
-    super({ id: ResizePaneDownAction.ID, title: localize2('vscodeee.resizePaneDown', 'Resize Pane Down'), f1: true, category: Categories.View }, Direction.Down);
+    super({ id: ResizePaneDownAction.ID, title: localize2('vscodeee.workbench.editor.resizePaneDown', 'Resize Pane Down'), f1: true, category: Categories.View }, Direction.Down);
   }
 }
 
 /** Resizes the focused pane by moving its left border leftward. */
 class ResizePaneLeftAction extends BaseResizePaneAction {
-  static readonly ID = 'vscodeee.resizePaneLeft';
+  static readonly ID = 'vscodeee.workbench.editor.resizePaneLeft';
   constructor() {
-    super({ id: ResizePaneLeftAction.ID, title: localize2('vscodeee.resizePaneLeft', 'Resize Pane Left'), f1: true, category: Categories.View }, Direction.Left);
+    super({ id: ResizePaneLeftAction.ID, title: localize2('vscodeee.workbench.editor.resizePaneLeft', 'Resize Pane Left'), f1: true, category: Categories.View }, Direction.Left);
   }
 }
 
 /** Resizes the focused pane by moving its right border rightward. */
 class ResizePaneRightAction extends BaseResizePaneAction {
-  static readonly ID = 'vscodeee.resizePaneRight';
+  static readonly ID = 'vscodeee.workbench.editor.resizePaneRight';
   constructor() {
-    super({ id: ResizePaneRightAction.ID, title: localize2('vscodeee.resizePaneRight', 'Resize Pane Right'), f1: true, category: Categories.View }, Direction.Right);
+    super({ id: ResizePaneRightAction.ID, title: localize2('vscodeee.workbench.editor.resizePaneRight', 'Resize Pane Right'), f1: true, category: Categories.View }, Direction.Right);
   }
 }
 


### PR DESCRIPTION
## Summary

Rename pane resize command IDs to match the `vscodeee.workbench.editor.*` hierarchy established in #339, ensuring consistency between settings and commands.

## Changes

- `vscodeee.resizePaneUp`    → `vscodeee.workbench.editor.resizePaneUp`
- `vscodeee.resizePaneDown`  → `vscodeee.workbench.editor.resizePaneDown`
- `vscodeee.resizePaneLeft`  → `vscodeee.workbench.editor.resizePaneLeft`
- `vscodeee.resizePaneRight` → `vscodeee.workbench.editor.resizePaneRight`
- Update localize keys and description text in `resizePaneActions.ts`
- Update command ID references in README.md and README.ja.md

## Related

Follow-up to #339 (settings hierarchy consolidation)

## How to Test

1. Open Command Palette (`Cmd+Shift+P`) → search for "Resize Pane" → verify 4 commands appear with new IDs
2. Bind keys to `vscodeee.workbench.editor.resizePaneUp/Down/Left/Right` → verify pane resize works
3. Verify old command IDs (`vscodeee.resizePane*`) are no longer recognized

🤖 Generated with [Claude Code](https://claude.com/claude-code)