### PR TITLE
fix: restore terminal editor tabs on app restart

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminal.ts
@@ -628,6 +628,10 @@ export interface ITerminalEditorService extends ITerminalInstanceHost {
 	revealActiveEditor(preserveFocus?: boolean): Promise<void>;
 	resolveResource(instance: ITerminalInstance): URI;
 	reviveInput(deserializedInput: IDeserializedTerminalEditorInput): EditorInput;
+	/** Creates a new terminal editor input from a fresh-restore snapshot, launching a brand new shell process
+	 *  instead of reattaching to a persistent process. Used when the original process cannot be reconnected
+	 *  (e.g. non-persistent terminals on cold start). */
+	reviveFreshInput(input: IFreshTerminalEditorInput): EditorInput;
 	getInputFromResource(resource: URI): TerminalEditorInput;
 }
 
@@ -653,6 +657,37 @@ export interface ISerializedTerminalEditorInput extends ITerminalEditorInputObje
 }
 
 export interface IDeserializedTerminalEditorInput extends ITerminalEditorInputObject {
+}
+
+/** Serialized state for a terminal editor that will be restored with a fresh shell process. */
+export interface IFreshTerminalEditorInput {
+	readonly title: string;
+	readonly titleSource: TitleEventSource;
+	readonly cwd: string;
+	readonly icon: TerminalIcon | undefined;
+	readonly color: string | undefined;
+	readonly hasChildProcesses?: boolean;
+	readonly isFeatureTerminal?: boolean;
+	readonly hideFromUser?: boolean;
+	readonly reconnectionProperties?: IReconnectionProperties;
+	readonly shellIntegrationNonce: string;
+}
+
+/** Cached serializable snapshot captured before terminal instance disposal on shutdown. */
+export interface ITerminalEditorSnapshot {
+	readonly persistentProcessId: number | undefined;
+	readonly processId: number | undefined;
+	readonly shouldPersist: boolean;
+	readonly title: string;
+	readonly titleSource: TitleEventSource;
+	readonly cwd: string;
+	readonly icon: TerminalIcon | undefined;
+	readonly color: string | undefined;
+	readonly hasChildProcesses: boolean;
+	readonly isFeatureTerminal: boolean | undefined;
+	readonly hideFromUser: boolean | undefined;
+	readonly reconnectionProperties: IReconnectionProperties | undefined;
+	readonly shellIntegrationNonce: string;
 }
 
 export type ITerminalLocationOptions = TerminalLocation | TerminalEditorLocation | { parentTerminal: MaybePromise<ITerminalInstance> } | { splitActiveTerminal: boolean };

--- a/src/vs/workbench/contrib/terminal/browser/terminalEditorInput.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalEditorInput.ts
@@ -11,7 +11,7 @@ import { EditorInputCapabilities, IEditorIdentifier, IUntypedEditorInput } from 
 import { IThemeService } from '../../../../platform/theme/common/themeService.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { EditorInput, IEditorCloseHandler } from '../../../common/editor/editorInput.js';
-import { ITerminalInstance, ITerminalInstanceService, terminalEditorId } from './terminal.js';
+import { ITerminalInstance, ITerminalInstanceService, ITerminalEditorSnapshot, terminalEditorId } from './terminal.js';
 import { getColorClass, getUriClasses } from './terminalIcon.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { IShellLaunchConfig, TerminalExitReason, TerminalLocation, TerminalSettingId } from '../../../../platform/terminal/common/terminal.js';
@@ -36,6 +36,8 @@ export class TerminalEditorInput extends EditorInput implements IEditorCloseHand
 	private _copyLaunchConfig?: IShellLaunchConfig;
 	private _terminalEditorFocusContextKey: IContextKey<boolean>;
 	private _group: IEditorGroup | undefined;
+	/** Cached serializable snapshot captured before terminal instance disposal on shutdown. */
+	private _serializedSnapshot: ITerminalEditorSnapshot | undefined;
 
 	protected readonly _onDidRequestAttach = this._register(new Emitter<ITerminalInstance>());
 	readonly onDidRequestAttach = this._onDidRequestAttach.event;
@@ -91,6 +93,11 @@ export class TerminalEditorInput extends EditorInput implements IEditorCloseHand
 	 */
 	get terminalInstance(): ITerminalInstance | undefined {
 		return this._isDetached ? undefined : this._terminalInstance;
+	}
+
+	/** Cached serializable snapshot captured before terminal instance disposal on shutdown. */
+	get serializedSnapshot(): ITerminalEditorSnapshot | undefined {
+		return this._serializedSnapshot;
 	}
 
 	showConfirm(): boolean {
@@ -179,6 +186,25 @@ export class TerminalEditorInput extends EditorInput implements IEditorCloseHand
 		// the editor/tabs don't disappear
 		this._register(this._lifecycleService.onWillShutdown((e: WillShutdownEvent) => {
 			this._isShuttingDown = true;
+
+			// Cache serializable state before disposing the instance so the
+			// editor serializer can still produce output during storage flush.
+			this._serializedSnapshot = {
+				persistentProcessId: instance.persistentProcessId,
+				processId: instance.processId,
+				shouldPersist: instance.shouldPersist,
+				title: instance.title,
+				titleSource: instance.titleSource,
+				cwd: instance.initialCwd || '',
+				icon: instance.icon,
+				color: instance.color,
+				hasChildProcesses: instance.hasChildProcesses,
+				isFeatureTerminal: instance.shellLaunchConfig.isFeatureTerminal,
+				hideFromUser: instance.shellLaunchConfig.hideFromUser,
+				reconnectionProperties: instance.shellLaunchConfig.reconnectionProperties,
+				shellIntegrationNonce: instance.shellIntegrationNonce,
+			};
+
 			dispose(disposeListeners);
 
 			// Don't touch processes if the shutdown was a result of reload as they will be reattached

--- a/src/vs/workbench/contrib/terminal/browser/terminalEditorSerializer.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalEditorSerializer.ts
@@ -76,7 +76,7 @@ export class TerminalInputSerializer implements IEditorSerializer {
 		}
 
 		// Fresh-restore format: tab is restored with a new shell process
-		if ('freshRestore' in parsed && (parsed as IFreshSerializedTerminalEditorInput).freshRestore === true) {
+		if (Object.prototype.hasOwnProperty.call(parsed, 'freshRestore') && (parsed as IFreshSerializedTerminalEditorInput).freshRestore === true) {
 			const fresh = parsed as IFreshSerializedTerminalEditorInput;
 			return this._terminalEditorService.reviveFreshInput({
 				title: fresh.title,
@@ -155,5 +155,5 @@ export class TerminalInputSerializer implements IEditorSerializer {
 }
 
 function isDeserializedTerminalEditorInput(obj: unknown): obj is IDeserializedTerminalEditorInput {
-	return isObject(obj) && 'id' in obj && 'pid' in obj;
+	return isObject(obj) && Object.prototype.hasOwnProperty.call(obj, 'id') && Object.prototype.hasOwnProperty.call(obj, 'pid');
 }

--- a/src/vs/workbench/contrib/terminal/browser/terminalEditorSerializer.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalEditorSerializer.ts
@@ -7,8 +7,13 @@ import { isNumber, isObject } from '../../../../base/common/types.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { IEditorSerializer } from '../../../common/editor.js';
 import { EditorInput } from '../../../common/editor/editorInput.js';
-import { ISerializedTerminalEditorInput, ITerminalEditorService, ITerminalInstance, type IDeserializedTerminalEditorInput } from './terminal.js';
+import { ISerializedTerminalEditorInput, ITerminalEditorService, ITerminalEditorSnapshot, ITerminalInstance, type IDeserializedTerminalEditorInput } from './terminal.js';
 import { TerminalEditorInput } from './terminalEditorInput.js';
+
+/** Serialized format for fresh-restore mode (no process reattachment). */
+interface IFreshSerializedTerminalEditorInput extends ISerializedTerminalEditorInput {
+	freshRestore: true;
+}
 
 export class TerminalInputSerializer implements IEditorSerializer {
 	constructor(
@@ -16,25 +21,86 @@ export class TerminalInputSerializer implements IEditorSerializer {
 	) { }
 
 	public canSerialize(editorInput: TerminalEditorInput): editorInput is TerminalEditorInput & { readonly terminalInstance: ITerminalInstance } {
-		return isNumber(editorInput.terminalInstance?.persistentProcessId) && editorInput.terminalInstance.shouldPersist;
+		// Prefer cached snapshot (available after onWillShutdown begins)
+		const snapshot = editorInput.serializedSnapshot;
+		if (snapshot) {
+			// Reattach path: process persistence is supported
+			if (isNumber(snapshot.persistentProcessId) && snapshot.shouldPersist) {
+				return true;
+			}
+			// Fresh-restore path: tab restoration without process reattachment.
+			// Exclude transient, hidden, and feature terminals.
+			if (!snapshot.isFeatureTerminal && !snapshot.hideFromUser) {
+				return true;
+			}
+			return false;
+		}
+
+		// Live instance path (e.g. window reload without full shutdown)
+		const instance = editorInput.terminalInstance;
+		if (!instance) {
+			return false;
+		}
+		if (isNumber(instance.persistentProcessId) && instance.shouldPersist) {
+			return true;
+		}
+		return !instance.shellLaunchConfig.isTransient &&
+			!instance.shellLaunchConfig.hideFromUser &&
+			!instance.shellLaunchConfig.isFeatureTerminal;
 	}
 
 	public serialize(editorInput: TerminalEditorInput): string | undefined {
 		if (!this.canSerialize(editorInput)) {
 			return;
 		}
-		return JSON.stringify(this._toJson(editorInput.terminalInstance));
+
+		// Use cached snapshot when available (post-shutdown)
+		const snapshot = editorInput.serializedSnapshot;
+		if (snapshot) {
+			return JSON.stringify(this._snapshotToJson(snapshot));
+		}
+
+		// Serialize from live instance
+		const instance = editorInput.terminalInstance;
+		if (instance) {
+			return JSON.stringify(this._instanceToJson(instance));
+		}
+
+		return undefined;
 	}
 
 	public deserialize(instantiationService: IInstantiationService, serializedEditorInput: string): EditorInput | undefined {
-		const editorInput = JSON.parse(serializedEditorInput) as unknown;
-		if (!isDeserializedTerminalEditorInput(editorInput)) {
-			throw new Error(`Could not revive terminal editor input, ${editorInput}`);
+		const parsed = JSON.parse(serializedEditorInput) as unknown;
+		if (!isObject(parsed)) {
+			throw new Error(`Could not revive terminal editor input, ${parsed}`);
 		}
-		return this._terminalEditorService.reviveInput(editorInput);
+
+		// Fresh-restore format: tab is restored with a new shell process
+		if ('freshRestore' in parsed && (parsed as IFreshSerializedTerminalEditorInput).freshRestore === true) {
+			const fresh = parsed as IFreshSerializedTerminalEditorInput;
+			return this._terminalEditorService.reviveFreshInput({
+				title: fresh.title,
+				titleSource: fresh.titleSource,
+				cwd: fresh.cwd,
+				icon: fresh.icon,
+				color: fresh.color,
+				hasChildProcesses: fresh.hasChildProcesses,
+				isFeatureTerminal: fresh.isFeatureTerminal,
+				hideFromUser: fresh.hideFromUser,
+				reconnectionProperties: fresh.reconnectionProperties,
+				shellIntegrationNonce: fresh.shellIntegrationNonce,
+			});
+		}
+
+		// Legacy reattach format
+		if (!isDeserializedTerminalEditorInput(parsed)) {
+			throw new Error(`Could not revive terminal editor input, ${serializedEditorInput}`);
+		}
+		return this._terminalEditorService.reviveInput(parsed);
 	}
 
-	private _toJson(instance: ITerminalInstance): ISerializedTerminalEditorInput {
+	private _instanceToJson(instance: ITerminalInstance): IFreshSerializedTerminalEditorInput | ISerializedTerminalEditorInput {
+		const canReattach = isNumber(instance.persistentProcessId) && instance.shouldPersist;
 		return {
 			id: instance.persistentProcessId!,
 			pid: instance.processId || 0,
@@ -47,7 +113,43 @@ export class TerminalInputSerializer implements IEditorSerializer {
 			isFeatureTerminal: instance.shellLaunchConfig.isFeatureTerminal,
 			hideFromUser: instance.shellLaunchConfig.hideFromUser,
 			reconnectionProperties: instance.shellLaunchConfig.reconnectionProperties,
-			shellIntegrationNonce: instance.shellIntegrationNonce
+			shellIntegrationNonce: instance.shellIntegrationNonce,
+			...(!canReattach ? { freshRestore: true as const } : {}),
+		};
+	}
+
+	private _snapshotToJson(snapshot: ITerminalEditorSnapshot): IFreshSerializedTerminalEditorInput | ISerializedTerminalEditorInput {
+		const canReattach = isNumber(snapshot.persistentProcessId) && snapshot.shouldPersist;
+		if (canReattach) {
+			return {
+				id: snapshot.persistentProcessId!,
+				pid: snapshot.processId || 0,
+				title: snapshot.title,
+				titleSource: snapshot.titleSource,
+				cwd: '',
+				icon: snapshot.icon,
+				color: snapshot.color,
+				hasChildProcesses: snapshot.hasChildProcesses,
+				isFeatureTerminal: snapshot.isFeatureTerminal,
+				hideFromUser: snapshot.hideFromUser,
+				reconnectionProperties: snapshot.reconnectionProperties,
+				shellIntegrationNonce: snapshot.shellIntegrationNonce,
+			};
+		}
+		return {
+			id: 0,
+			pid: 0,
+			title: snapshot.title,
+			titleSource: snapshot.titleSource,
+			cwd: snapshot.cwd,
+			icon: snapshot.icon,
+			color: snapshot.color,
+			hasChildProcesses: snapshot.hasChildProcesses,
+			isFeatureTerminal: snapshot.isFeatureTerminal,
+			hideFromUser: snapshot.hideFromUser,
+			reconnectionProperties: snapshot.reconnectionProperties,
+			shellIntegrationNonce: snapshot.shellIntegrationNonce,
+			freshRestore: true,
 		};
 	}
 }

--- a/src/vs/workbench/contrib/terminal/browser/terminalEditorService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalEditorService.ts
@@ -12,7 +12,7 @@ import { IInstantiationService } from '../../../../platform/instantiation/common
 import { IShellLaunchConfig, TerminalLocation } from '../../../../platform/terminal/common/terminal.js';
 import { IEditorPane } from '../../../common/editor.js';
 import { EditorInput } from '../../../common/editor/editorInput.js';
-import { IDeserializedTerminalEditorInput, ITerminalEditorService, ITerminalInstance, ITerminalInstanceService, TerminalEditorLocation } from './terminal.js';
+import { IDeserializedTerminalEditorInput, IFreshTerminalEditorInput, ITerminalEditorService, ITerminalInstance, ITerminalInstanceService, TerminalEditorLocation } from './terminal.js';
 import { TerminalEditorInput } from './terminalEditorInput.js';
 import { getInstanceFromResource } from './terminalUri.js';
 import { TerminalContextKeys } from '../common/terminalContextKey.js';
@@ -238,6 +238,22 @@ export class TerminalEditorService extends Disposable implements ITerminalEditor
 	reviveInput(deserializedInput: IDeserializedTerminalEditorInput): EditorInput {
 		const newDeserializedInput = { ...deserializedInput, findRevivedId: true };
 		const instance = this._terminalInstanceService.createInstance({ attachPersistentProcess: newDeserializedInput }, TerminalLocation.Editor);
+		const input = this._instantiationService.createInstance(TerminalEditorInput, instance.resource, instance);
+		this._registerInstance(instance.resource.path, input, instance);
+		return input;
+	}
+
+	reviveFreshInput(freshInput: IFreshTerminalEditorInput): EditorInput {
+		const shellLaunchConfig: IShellLaunchConfig = {
+			cwd: freshInput.cwd || undefined,
+			icon: freshInput.icon,
+			color: freshInput.color,
+			name: freshInput.title,
+			isFeatureTerminal: freshInput.isFeatureTerminal,
+			hideFromUser: freshInput.hideFromUser,
+			reconnectionProperties: freshInput.reconnectionProperties,
+		};
+		const instance = this._terminalInstanceService.createInstance(shellLaunchConfig, TerminalLocation.Editor);
 		const input = this._instantiationService.createInstance(TerminalEditorInput, instance.resource, instance);
 		this._registerInstance(instance.resource.path, input, instance);
 		return input;

--- a/src/vs/workbench/test/browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/workbenchTestServices.ts
@@ -1826,6 +1826,7 @@ export class TestTerminalEditorService implements ITerminalEditorService {
 	resolveResource(instance: ITerminalInstance): URI { throw new Error('Method not implemented.'); }
 	reviveInput(deserializedInput: IDeserializedTerminalEditorInput): TerminalEditorInput { throw new Error('Method not implemented.'); }
 	getInputFromResource(resource: URI): TerminalEditorInput { throw new Error('Method not implemented.'); }
+	reviveFreshInput(input: import('../../contrib/terminal/browser/terminal.js').IFreshTerminalEditorInput): TerminalEditorInput { throw new Error('Method not implemented.'); }
 	setActiveInstance(instance: ITerminalInstance): void { throw new Error('Method not implemented.'); }
 	focusActiveInstance(): Promise<void> { throw new Error('Method not implemented.'); }
 	async focusInstance(instance: ITerminalInstance): Promise<void> { throw new Error('Method not implemented.'); }


### PR DESCRIPTION
## Summary
- Terminal editors were not restored on app restart because `canSerialize()` always returned `false` when `shouldPersist` was `false` (TauriPty hardcodes this), causing terminal editor tabs to appear as empty editors
- Introduces a "fresh-restore" mode that serializes terminal tab metadata (title, cwd, icon, color) without requiring process reattachment, creating a new shell process on restore
- Maintains backward compatibility: legacy reattach format (`freshRestore` flag absent) falls through to existing `reviveInput()` path

## Changes
- **terminal.ts**: Add `IFreshTerminalEditorInput` and `ITerminalEditorSnapshot` interfaces, `reviveFreshInput()` method to `ITerminalEditorService`
- **terminalEditorInput.ts**: Cache terminal snapshot before instance disposal during `onWillShutdown` via `serializedSnapshot` getter
- **terminalEditorSerializer.ts**: Rewrite serialization to support fresh-restore mode with `freshRestore: true` flag, check cached snapshot first in `canSerialize()`/`serialize()`, route `deserialize()` to `reviveFreshInput()` or `reviveInput()` based on flag
- **terminalEditorService.ts**: Implement `reviveFreshInput()` — creates new terminal instance with saved cwd/icon/color/title
- **workbenchTestServices.ts**: Add `reviveFreshInput` stub to `TestTerminalEditorService`

## Test plan
- [ ] Open a terminal as editor tab, restart app, verify terminal tab restores with new shell process
- [ ] Open multiple terminal editor tabs, restart, verify all restore correctly
- [ ] Verify panel terminals still work (unaffected by this change)
- [ ] Verify terminal editor with custom icon/color/title persists on restore
- [ ] Verify feature terminals and hidden terminals are correctly excluded from restoration

Closes #323

🤖 Generated with [Claude Code](https://claude.com/claude-code)