### PR TITLE
fix: add missing preflight dependency to upload-stable-assets job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -485,7 +485,8 @@ jobs:
 
   upload-stable-assets:
     name: Upload fixed-name assets for README links
-    needs: [publish-tauri, build-reh, create-release]
+    needs: [preflight, publish-tauri, build-reh, create-release]
+    if: needs.preflight.outputs.skip != 'true'
     permissions:
       contents: write
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Add `preflight` to the `needs` array of the `upload-stable-assets` job so that `needs.preflight.outputs.version` and `needs.preflight.outputs.tag` are correctly resolved
- Add `if: needs.preflight.outputs.skip != 'true'` guard for consistency with all other downstream jobs
- This fixes the Release workflow failure where Tauri asset name matching failed because VERSION was empty (e.g., `_0.5.1_aarch64.dmg` became `__aarch64.dmg`)

## Root Cause

The `upload-stable-assets` job referenced `needs.preflight.outputs.version` and `needs.preflight.outputs.tag` but did not include `preflight` in its `needs` array. GitHub Actions only allows access to outputs of jobs listed in the direct `needs` key — indirect dependencies (through `publish-tauri` or `build-reh`) are not accessible.

Fixes the failure in the v0.5.1 re-release workflow run ([#346](https://github.com/j4rviscmd/vscodeee/pull/346)).

## Test plan

- [ ] Merge this PR and verify the Release workflow completes successfully
- [ ] Confirm all 9 assets (4 Tauri + 5 REH) are present in the release
- [ ] Confirm the draft release is published (no longer stuck as draft)

🤖 Generated with [Claude Code](https://claude.com/claude-code)