### PR TITLE
chore: release v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `generate-notes` dependency to `build-reh` job to prevent 404 errors when uploading REH assets ([#337](https://github.com/j4rviscmd/vscodeee/pull/337))
 - Restore terminal editor tabs on app restart ([#344](https://github.com/j4rviscmd/vscodeee/pull/344))
 - Resolve draft release lookup failure in CI publish workflow — replace `getReleaseByTag` with `getRelease` by ID across build-reh and upload-stable-assets jobs, add input validation guards, and consolidate `tauri.conf.json` reads ([#345](https://github.com/j4rviscmd/vscodeee/pull/345))
+- Add missing `preflight` dependency to `upload-stable-assets` job to fix empty VERSION/TAG env vars ([#348](https://github.com/j4rviscmd/vscodeee/pull/348))
 
 ### Changed
 


### PR DESCRIPTION
## Summary

Re-release v0.5.1 after fixing the CI publish workflow failure where `upload-stable-assets` job failed due to missing `preflight` dependency in its `needs` array, causing `VERSION` and `TAG` env vars to be empty.

## Changes

- Update CHANGELOG.md with [#348](https://github.com/j4rviscmd/vscodeee/pull/348) fix entry (missing `preflight` dependency)

## How to Test

1. Merge this PR
2. Verify the publish workflow triggers and completes successfully
3. Verify the release v0.5.1 is published with all assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)