### PR TITLE
fix: prevent empty editor group creation when focusing non-existent group index

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorCommands.ts
+++ b/src/vs/workbench/browser/parts/editor/editorCommands.ts
@@ -684,32 +684,13 @@ function registerFocusEditorGroupAtIndexCommands(): void {
 			primary: KeyMod.CtrlCmd | toKeyCode(groupIndex),
 			handler: accessor => {
 				const editorGroupsService = accessor.get(IEditorGroupsService);
-				const configurationService = accessor.get(IConfigurationService);
 
-				// To keep backwards compatibility (pre-grid), allow to focus a group
-				// that does not exist as long as it is the next group after the last
-				// opened group. Otherwise we return.
-				if (groupIndex > editorGroupsService.count) {
-					return;
-				}
-
-				// Group exists: just focus
+				// Only focus groups that already exist. Do not create new
+				// empty editor groups for non-existent indices.
 				const groups = editorGroupsService.getGroups(GroupsOrder.GRID_APPEARANCE);
 				if (groups[groupIndex]) {
 					return groups[groupIndex].focus();
 				}
-
-				// Group does not exist: create new by splitting the active one of the last group
-				const direction = preferredSideBySideGroupDirection(configurationService);
-				const lastGroup = editorGroupsService.findGroup({ location: GroupLocation.LAST });
-				if (!lastGroup) {
-					return;
-				}
-
-				const newGroup = editorGroupsService.addGroup(lastGroup, direction);
-
-				// Focus
-				newGroup.focus();
 			}
 		});
 	}


### PR DESCRIPTION
## Summary

- Remove the pre-grid backwards compatibility logic that created new editor groups when focusing a non-existent group index
- Now `workbench.action.focusThirdEditorGroup` (Cmd+3) in a 2-column layout is a no-op instead of creating an empty third editor group
- Simplifies `registerFocusEditorGroupAtIndexCommands` by removing 19 lines of dead group-creation code

## Changes

| File | Change |
|------|--------|
| `src/vs/workbench/browser/parts/editor/editorCommands.ts` | Remove group creation logic in `registerFocusEditorGroupAtIndexCommands`, keep only existing group focus |

## Root Cause

The original code had backwards-compatibility logic from the pre-grid era that allowed creating a new group if the target index was exactly `count` (the next index after existing groups). This caused unintended empty editor groups to appear when users used keyboard shortcuts targeting groups that don't exist in the current layout.

Closes #329