### PR TITLE
feat: add DEV@ prefix to window title in development builds

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -63,6 +63,10 @@ pub struct WindowConfiguration {
     /// Used as a fallback when the URL query string doesn't contain `?workspace=`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub restored_workspace_uri: Option<String>,
+    /// Whether the binary was compiled in debug mode (`cargo build` without `--release`).
+    /// Determined by `cfg!(debug_assertions)` — a compile-time constant.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub is_dev_build: Option<bool>,
 }
 
 /// Retrieve native host environment information.
@@ -166,6 +170,7 @@ pub async fn get_window_configuration(
     // and None on subsequent calls (e.g. after "Close Folder" page reload).
     let restored_folder_uri = window_manager.consume_restored_uri(&label).await;
     let restored_workspace_uri: Option<String> = None; // workspace files handled separately
+    let is_dev_build = cfg!(debug_assertions).then_some(true);
 
     Ok(WindowConfiguration {
         window_id,
@@ -175,6 +180,7 @@ pub async fn get_window_configuration(
         app_data_dir,
         restored_folder_uri,
         restored_workspace_uri,
+        is_dev_build,
     })
 }
 

--- a/src/vs/code/tauri-browser/workbench/workbench-tauri.ts
+++ b/src/vs/code/tauri-browser/workbench/workbench-tauri.ts
@@ -117,6 +117,7 @@
     appDataDir: string;
     restoredFolderUri?: string;
     restoredWorkspaceUri?: string;
+    isDevBuild?: boolean;
   }
 
   /**
@@ -152,6 +153,7 @@
     homeDir: hostInfo.homeDir,
     tmpDir: hostInfo.tmpDir,
     windowLabel: new URL(document.location.href).searchParams.get('windowLabel') ?? 'main',
+    isDevBuild: windowConfig.isDevBuild,
   };
 
   //#endregion

--- a/src/vs/workbench/browser/parts/titlebar/windowTitle.ts
+++ b/src/vs/workbench/browser/parts/titlebar/windowTitle.ts
@@ -33,11 +33,24 @@ import { CodeWindow } from '../../../../base/browser/window.js';
 import { IDecorationsService } from '../../../services/decorations/common/decorations.js';
 import { IAccessibilityService } from '../../../../platform/accessibility/common/accessibility.js';
 
+/** Configuration setting names used by the window title. */
 const enum WindowSettingNames {
 	titleSeparator = 'window.titleSeparator',
 	title = 'window.title',
 }
 
+/**
+ * Default window title template string, computed at module load time.
+ *
+ * The template varies by platform to match native conventions:
+ * - **macOS**: Omits `${dirty}` (the native title bar shows the dot indicator)
+ *   and `${appName}` (the app name is shown by the menu bar).
+ * - **Windows/Linux**: Includes `${dirty}` and `${appName}` in the title.
+ * - **Web**: Appends `${remoteName}` to always indicate remote connections.
+ *
+ * In Tauri, the same per-OS defaults as Electron are used since Tauri
+ * behaves as a native application.
+ */
 export const defaultWindowTitle = (() => {
 	// Tauri behaves as native app — match upstream Electron defaults per OS
 	if (isTauri) {
@@ -58,12 +71,34 @@ export const defaultWindowTitle = (() => {
 
 	return base;
 })();
+/**
+ * Default title separator character(s).
+ *
+ * Uses an em dash on macOS and a hyphen on all other platforms,
+ * matching each OS's native window title conventions.
+ */
 export const defaultWindowTitleSeparator = isMacintosh ? ' \u2014 ' : ' - ';
 
+/**
+ * Manages the window title for a VS Code window.
+ *
+ * Computes and applies the window title by resolving a configurable
+ * template string against the current editor, workspace, and environment
+ * state. Supports template variables such as `${activeEditorShort}`,
+ * `${rootName}`, `${appName}`, `${dirty}`, `${focusedView}`, and
+ * custom context-key-based variables registered by extensions.
+ *
+ * The resolved title is set on `document.title` and, on Tauri, also
+ * forwarded to the native window via `plugin:window|set_title` so that
+ * Cmd+Tab / Mission Control / Alt+Tab displays the correct title.
+ *
+ * @see `window.title` and `window.titleSeparator` settings for customization.
+ */
 export class WindowTitle extends Disposable {
 
 	private static readonly NLS_USER_IS_ADMIN = isWindows ? localize('userIsAdmin', "[Administrator]") : localize('userIsSudo', "[Superuser]");
 	private static readonly NLS_EXTENSION_HOST = localize('devExtensionWindowTitlePrefix', "[Extension Development Host]");
+	private static readonly DEV_BUILD_PREFIX = 'DEV@'; // Intentionally not localized: compact technical prefix for dev/prod differentiation
 	private static readonly TITLE_DIRTY = '\u25cf ';
 
 	private readonly properties: ITitleProperties = { isPure: true, isAdmin: false, prefix: undefined };
@@ -73,10 +108,18 @@ export class WindowTitle extends Disposable {
 	private readonly titleUpdater = this._register(new RunOnceScheduler(() => this.doUpdateTitle(), 0));
 
 	private readonly onDidChangeEmitter = this._register(new Emitter<void>());
+	/** Event that fires when the resolved window title changes. */
 	readonly onDidChange = this.onDidChangeEmitter.event;
 
+	/** The current resolved window title string, or empty string if not yet computed. */
 	get value() { return this.title ?? ''; }
+	/** The human-readable workspace name from the label service. */
 	get workspaceName() { return this.labelService.getWorkspaceLabel(this.contextService.getWorkspace()); }
+	/**
+	 * The file name of the currently active editor with a dirty indicator
+	 * prefix (a bullet character) if the editor has unsaved changes.
+	 * Returns `undefined` when no editor is active.
+	 */
 	get fileName() {
 		const activeEditor = this.editorService.activeEditor;
 		if (!activeEditor) {
@@ -117,6 +160,10 @@ export class WindowTitle extends Disposable {
 		this.registerListeners();
 	}
 
+	/**
+	 * Register event listeners for configuration, editor, workspace, and
+	 * context-key changes that may affect the window title.
+	 */
 	private registerListeners(): void {
 		this._register(this.configurationService.onDidChangeConfiguration(e => this.onConfigurationChanged(e)));
 		this._register(this.editorService.onDidActiveEditorChange(() => this.onActiveEditorChange()));
@@ -138,6 +185,13 @@ export class WindowTitle extends Disposable {
 		this._register(this.accessibilityService.onDidChangeScreenReaderOptimized(() => this.titleUpdater.schedule()));
 	}
 
+	/**
+	 * Handle configuration change events.
+	 *
+	 * Re-checks the title template for `${focusedView}` / `${activeEditorState}`
+	 * variables and schedules a title update if the title or separator settings
+	 * have changed.
+	 */
 	private onConfigurationChanged(event: IConfigurationChangeEvent): void {
 		const affectsTitleConfiguration = event.affectsConfiguration(WindowSettingNames.title);
 		if (affectsTitleConfiguration) {
@@ -149,6 +203,11 @@ export class WindowTitle extends Disposable {
 		}
 	}
 
+	/**
+	 * Scan the current title template for `${focusedView}` and
+	 * `${activeEditorState}` variables to determine which additional
+	 * listeners are needed for change detection.
+	 */
 	private checkTitleVariables(): void {
 		const titleTemplate = this.configurationService.getValue<unknown>(WindowSettingNames.title);
 		if (typeof titleTemplate === 'string') {
@@ -157,6 +216,14 @@ export class WindowTitle extends Disposable {
 		}
 	}
 
+	/**
+	 * Handle active editor changes.
+	 *
+	 * Clears previous editor-specific listeners, schedules a title update,
+	 * and attaches new listeners for dirty state, label changes, focus/blur
+	 * (when `${focusedView}` is in the template), and decoration changes
+	 * (when `${activeEditorState}` is in the template).
+	 */
 	private onActiveEditorChange(): void {
 
 		// Dispose old listeners
@@ -194,6 +261,14 @@ export class WindowTitle extends Disposable {
 		}
 	}
 
+	/**
+	 * Resolve and apply the new window title.
+	 *
+	 * Sets `document.title` on the target window. On Tauri, also invokes
+	 * `plugin:window|set_title` to update the native window title for
+	 * OS-level window switching (Cmd+Tab, Mission Control, Alt+Tab).
+	 * Fires the `onDidChange` event when the title actually changes.
+	 */
 	private doUpdateTitle(): void {
 		const title = this.getFullWindowTitle();
 		if (title !== this.title) {
@@ -232,6 +307,14 @@ export class WindowTitle extends Disposable {
 		}
 	}
 
+	/**
+	 * Build the full window title including prefix/suffix decorations.
+	 *
+	 * Falls back to the product name when the computed title is empty,
+	 * and normalizes any non-space whitespace characters to spaces.
+	 *
+	 * @returns The fully decorated window title string.
+	 */
 	private getFullWindowTitle(): string {
 		const { prefix, suffix } = this.getTitleDecorations();
 
@@ -248,6 +331,15 @@ export class WindowTitle extends Disposable {
 		return title.replace(/[^\S ]/g, ' ');
 	}
 
+	/**
+	 * Compute the prefix and suffix decorations for the window title.
+	 *
+	 * Prefix is composed from (in order of innermost to outermost):
+	 * extension development host label, dev build prefix, and custom prefix.
+	 * Suffix is added when running with elevated privileges (admin/sudo).
+	 *
+	 * @returns An object with optional `prefix` and `suffix` strings.
+	 */
 	getTitleDecorations() {
 		let prefix: string | undefined;
 		let suffix: string | undefined;
@@ -262,6 +354,12 @@ export class WindowTitle extends Disposable {
 				: `${WindowTitle.NLS_EXTENSION_HOST} - ${prefix}`;
 		}
 
+		if (this.environmentService.isDevBuild) {
+			prefix = !prefix
+				? WindowTitle.DEV_BUILD_PREFIX
+				: `${WindowTitle.DEV_BUILD_PREFIX} ${prefix}`;
+		}
+
 		if (this.properties.isAdmin) {
 			suffix = WindowTitle.NLS_USER_IS_ADMIN;
 		}
@@ -269,6 +367,14 @@ export class WindowTitle extends Disposable {
 		return { prefix, suffix };
 	}
 
+	/**
+	 * Update the title properties (admin state, purity, custom prefix).
+	 *
+	 * Only triggers a title update if at least one property has actually changed.
+	 *
+	 * @param properties - The new title properties to apply. Missing fields
+	 *   retain their current values.
+	 */
 	updateProperties(properties: ITitleProperties): void {
 		const isAdmin = typeof properties.isAdmin === 'boolean' ? properties.isAdmin : this.properties.isAdmin;
 		const isPure = typeof properties.isPure === 'boolean' ? properties.isPure : this.properties.isPure;
@@ -283,6 +389,15 @@ export class WindowTitle extends Disposable {
 		}
 	}
 
+	/**
+	 * Register custom title template variables provided by extensions.
+	 *
+	 * Each variable maps a context key (for change detection) to a template
+	 * placeholder name (e.g., `{name: "gitBranch", contextKey: "git.branch"}`).
+	 * Triggers a title update if any new variable is registered.
+	 *
+	 * @param variables - Array of title variable definitions to register.
+	 */
 	registerVariables(variables: ITitleVariable[]): void {
 		let changed = false;
 
@@ -300,6 +415,9 @@ export class WindowTitle extends Disposable {
 	}
 
 	/**
+	 * Compute the full window title by resolving the configured template
+	 * against the current editor, workspace, and environment state.
+	 *
 	 * Possible template values:
 	 *
 	 * {activeEditorLong}: e.g. /Users/Development/myFolder/myFileFolder/myFile.txt
@@ -319,6 +437,8 @@ export class WindowTitle extends Disposable {
 	 * {focusedView}: e.g. Terminal
 	 * {separator}: conditional separator
 	 * {activeEditorState}: e.g. Modified
+	 *
+	 * @returns The resolved window title string.
 	 */
 	getWindowTitle(): string {
 		const editor = this.editorService.activeEditor;
@@ -435,6 +555,16 @@ export class WindowTitle extends Disposable {
 		});
 	}
 
+	/**
+	 * Determine whether the current window title uses a custom format.
+	 *
+	 * Returns `true` if:
+	 * - A screen reader is active (which appends `${activeEditorState}`), or
+	 * - The `window.title` or `window.titleSeparator` settings are explicitly configured, or
+	 * - The default title value has been overridden in the configuration registry.
+	 *
+	 * @returns `true` if the title format deviates from the upstream default.
+	 */
 	isCustomTitleFormat(): boolean {
 		if (this.accessibilityService.isScreenReaderOptimized() || this.titleIncludesEditorState) {
 			return true;

--- a/src/vs/workbench/services/environment/browser/environmentService.ts
+++ b/src/vs/workbench/services/environment/browser/environmentService.ts
@@ -37,15 +37,42 @@ export interface IBrowserWorkbenchEnvironmentService extends IWorkbenchEnvironme
 	 * Gets whether a resolver extension is expected for the environment.
 	 */
 	readonly expectsResolverExtension: boolean;
+
+	/**
+	 * Whether the application was compiled in debug mode.
+	 * Always `false` in the base browser implementation;
+	 * overridden to `true` by `TauriWorkbenchEnvironmentService`
+	 * when `cfg!(debug_assertions)` is set in the Rust backend.
+	 */
+	readonly isDevBuild: boolean;
 }
 
+/**
+ * Base browser implementation of the workbench environment service.
+ *
+ * Provides environment information for the workbench when running in a
+ * browser context. Filesystem URIs default to virtual in-memory paths
+ * (`vscode-userdata://`). Subclasses (e.g., `TauriWorkbenchEnvironmentService`)
+ * override these to point at real local filesystem paths.
+ *
+ * Reads initial configuration from `IWorkbenchConstructionOptions` and an
+ * optional payload map provided by the workspace provider (used to pass
+ * CLI arguments and debug flags into the web workbench).
+ */
 export class BrowserWorkbenchEnvironmentService implements IBrowserWorkbenchEnvironmentService {
 
 	declare readonly _serviceBrand: undefined;
 
+	/** The remote authority string, or `undefined` for local sessions. */
 	@memoize
 	get remoteAuthority(): string | undefined { return this.options.remoteAuthority; }
 
+	/**
+	 * Whether a resolver extension is expected to handle the remote connection.
+	 *
+	 * Returns `true` when the remote authority contains a `+` separator
+	 * (e.g., `ssh-remote+host`) and no custom WebSocket factory is provided.
+	 */
 	@memoize
 	get expectsResolverExtension(): boolean {
 		return !!this.options.remoteAuthority?.includes('+') && !this.options.webSocketFactory;
@@ -53,6 +80,8 @@ export class BrowserWorkbenchEnvironmentService implements IBrowserWorkbenchEnvi
 
 	@memoize
 	get isBuilt(): boolean { return !!this.productService.commit; }
+
+	get isDevBuild(): boolean { return false; }
 
 	@memoize
 	get logLevel(): string | undefined {
@@ -283,6 +312,17 @@ export class BrowserWorkbenchEnvironmentService implements IBrowserWorkbenchEnvi
 		}
 	}
 
+	/**
+	 * Resolve extension host debug settings from the workspace payload and
+	 * development options.
+	 *
+	 * Parses payload keys such as `extensionDevelopmentPath`,
+	 * `inspect-brk-extensions`, and `enableProposedApi` into a structured
+	 * environment object. Falls back to `developmentOptions` from the
+	 * workbench construction options when no payload entries exist.
+	 *
+	 * @returns The resolved extension host debug environment.
+	 */
 	private resolveExtensionHostDebugEnvironment(): IExtensionHostDebugEnvironment {
 		const extensionHostDebugEnvironment: IExtensionHostDebugEnvironment = {
 			params: {
@@ -417,6 +457,7 @@ export class BrowserWorkbenchEnvironmentService implements IBrowserWorkbenchEnvi
 	}
 }
 
+/** Internal structure holding resolved extension host debug settings. */
 interface IExtensionHostDebugEnvironment {
 	params: IExtensionHostDebugParams;
 	debugRenderer: boolean;

--- a/src/vs/workbench/services/environment/tauri-browser/environmentService.ts
+++ b/src/vs/workbench/services/environment/tauri-browser/environmentService.ts
@@ -31,6 +31,7 @@ export interface ITauriWindowConfiguration {
   readonly homeDir?: string;
   readonly tmpDir?: string;
   readonly windowLabel?: string;
+  readonly isDevBuild?: boolean;
 }
 
 /**
@@ -157,5 +158,16 @@ export class TauriWorkbenchEnvironmentService extends BrowserWorkbenchEnvironmen
   get extensionsPath(): string {
     const dataFolderName = this.tauriProductService.dataFolderName ?? 'vscodeee';
     return URI.joinPath(this.userHome, dataFolderName, 'extensions').fsPath;
+  }
+
+  /**
+   * Whether the application was compiled in debug mode.
+   *
+   * Determined by `cfg!(debug_assertions)` in the Rust backend and
+   * passed via `WindowConfiguration.isDevBuild` at startup.
+   */
+  @memoize
+  override get isDevBuild(): boolean {
+    return this.tauriConfig.isDevBuild === true;
   }
 }


### PR DESCRIPTION
## Summary

Add a visual indicator to distinguish dev builds from production by prefixing the window title with `DEV@` when the app is compiled in debug mode (`cfg!(debug_assertions)`).

## Changes

- Add `is_dev_build` field to Rust `WindowConfiguration` struct (`cfg!(debug_assertions).then_some(true)`)
- Expose `isDevBuild` via `IBrowserWorkbenchEnvironmentService` interface and `TauriWorkbenchEnvironmentService`
- Add `DEV@` prefix in `WindowTitle.getTitleDecorations()` for dev builds
- Wire `isDevBuild` through bootstrap mapping in `workbench-tauri.ts`

## How to Test

1. Run `npm run tauri:dev` (debug build)
2. Verify window title shows `DEV@` prefix (e.g., `DEV@filename — workspace`)
3. Run production build and verify no `DEV@` prefix appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)