### PR TITLE
fix: handle image-only clipboard gracefully and return PNG from readImage

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6620,6 +6620,7 @@ dependencies = [
  "futures-util",
  "globset",
  "hostname",
+ "image",
  "keyring",
  "libc",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -27,6 +27,7 @@ tokio = { version = "1", features = ["net", "process", "io-util", "rt", "macros"
 uuid = { version = "1", features = ["v4"] }
 portable-pty = "0.9"
 base64 = "0.22"
+image = { version = "0.25", default-features = false, features = ["png"] }
 libc = "0.2"
 open = "5"
 log = "0.4"

--- a/src-tauri/src/commands/native_host/clipboard.rs
+++ b/src-tauri/src/commands/native_host/clipboard.rs
@@ -10,12 +10,16 @@ use super::error::NativeHostError;
 // ─── Existing commands (moved from native_host.rs) ──────────────────────
 
 /// Read text from the system clipboard.
+///
+/// Returns an empty string if the clipboard contains no text
+/// (e.g. only an image) instead of propagating the error.
 #[tauri::command]
 pub fn read_clipboard_text(app: tauri::AppHandle) -> Result<String, NativeHostError> {
     use tauri_plugin_clipboard_manager::ClipboardExt;
-    app.clipboard()
-        .read_text()
-        .map_err(|e| NativeHostError::Clipboard(e.to_string()))
+    match app.clipboard().read_text() {
+        Ok(text) => Ok(text),
+        Err(_) => Ok(String::new()),
+    }
 }
 
 /// Write text to the system clipboard.
@@ -108,19 +112,46 @@ pub fn write_clipboard_find_text(text: String) {
 
 /// Read an image from the clipboard as PNG bytes (base64-encoded).
 ///
+/// Converts the raw RGBA pixel data from arboard into a proper PNG
+/// file so that consumers receive format-encoded bytes (matching the
+/// contract of BrowserClipboardService.readImage).
 /// Returns an empty string if no image is available.
 #[tauri::command]
 pub fn read_clipboard_image(app: tauri::AppHandle) -> Result<String, NativeHostError> {
     use tauri_plugin_clipboard_manager::ClipboardExt;
     match app.clipboard().read_image() {
-        Ok(image) => {
-            let bytes = image.rgba().to_vec();
+        Ok(image_data) => {
+            let width = image_data.width();
+            let height = image_data.height();
+            let rgba_bytes = image_data.rgba().to_vec();
+
+            let img_buffer = image::RgbaImage::from_raw(width, height, rgba_bytes)
+                .ok_or_else(|| NativeHostError::Other("Invalid image dimensions".to_string()))?;
+
+            let mut png_bytes = Vec::new();
+            img_buffer
+                .write_to(
+                    &mut std::io::Cursor::new(&mut png_bytes),
+                    image::ImageFormat::Png,
+                )
+                .map_err(|e| NativeHostError::Other(format!("PNG encode failed: {e}")))?;
+
             Ok(base64::Engine::encode(
                 &base64::engine::general_purpose::STANDARD,
-                &bytes,
+                &png_bytes,
             ))
         }
         Err(_) => Ok(String::new()),
+    }
+}
+
+/// Check whether the clipboard currently contains an image.
+#[tauri::command]
+pub fn has_clipboard_image(app: tauri::AppHandle) -> Result<bool, NativeHostError> {
+    use tauri_plugin_clipboard_manager::ClipboardExt;
+    match app.clipboard().read_image() {
+        Ok(_) => Ok(true),
+        Err(_) => Ok(false),
     }
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -259,6 +259,7 @@ pub fn run(gui_args: Option<cli::dispatch::ParsedGuiArgs>) {
             commands::native_host::read_clipboard_find_text,
             commands::native_host::write_clipboard_find_text,
             commands::native_host::read_clipboard_image,
+            commands::native_host::has_clipboard_image,
             commands::native_host::trigger_paste,
             // ── OS commands ──
             commands::native_host::get_os_properties,

--- a/src/vs/platform/clipboard/browser/clipboardService.ts
+++ b/src/vs/platform/clipboard/browser/clipboardService.ts
@@ -22,6 +22,11 @@ import { ILogService } from '../../log/common/log.js';
  */
 const vscodeResourcesMime = 'application/vnd.code.resources';
 
+/**
+ * Image MIME types supported by the browser clipboard API.
+ */
+const SUPPORTED_IMAGE_TYPES = ['image/png', 'image/jpeg', 'image/gif', 'image/tiff', 'image/bmp'];
+
 export class BrowserClipboardService extends Disposable implements IClipboardService {
 
 	declare readonly _serviceBrand: undefined;
@@ -55,8 +60,7 @@ export class BrowserClipboardService extends Disposable implements IClipboardSer
 			const clipboardItems = await navigator.clipboard.read();
 			const clipboardItem = clipboardItems[0];
 
-			const supportedImageTypes = ['image/png', 'image/jpeg', 'image/gif', 'image/tiff', 'image/bmp'];
-			const mimeType = supportedImageTypes.find(type => clipboardItem.types.includes(type));
+			const mimeType = SUPPORTED_IMAGE_TYPES.find(type => clipboardItem.types.includes(type));
 
 			if (mimeType) {
 				const blob = await clipboardItem.getType(mimeType);
@@ -71,6 +75,16 @@ export class BrowserClipboardService extends Disposable implements IClipboardSer
 
 		// Return an empty Uint8Array if no image is found or an error occurs
 		return new Uint8Array(0);
+	}
+
+	async hasClipboardImage(): Promise<boolean> {
+		try {
+			const clipboardItems = await navigator.clipboard.read();
+			const clipboardItem = clipboardItems[0];
+			return SUPPORTED_IMAGE_TYPES.some(type => clipboardItem.types.includes(type));
+		} catch {
+			return false;
+		}
 	}
 
 	private webKitPendingClipboardWritePromise: DeferredPromise<string> | undefined;

--- a/src/vs/platform/clipboard/common/clipboardService.ts
+++ b/src/vs/platform/clipboard/common/clipboardService.ts
@@ -64,4 +64,9 @@ export interface IClipboardService {
 	 * image, an empty buffer is returned.
 	 */
 	readImage(): Promise<Uint8Array>;
+
+	/**
+	 * Returns true if the system clipboard currently contains an image.
+	 */
+	hasClipboardImage?(): Promise<boolean>;
 }

--- a/src/vs/platform/native/common/native.ts
+++ b/src/vs/platform/native/common/native.ts
@@ -235,6 +235,7 @@ export interface ICommonNativeHostService {
 	writeClipboardBuffer(format: string, buffer: VSBuffer, type?: 'selection' | 'clipboard'): Promise<void>;
 	readClipboardBuffer(format: string): Promise<VSBuffer>;
 	hasClipboard(format: string, type?: 'selection' | 'clipboard'): Promise<boolean>;
+	hasClipboardImage(): Promise<boolean>;
 	readImage(): Promise<Uint8Array>;
 
 	// macOS Touchbar

--- a/src/vs/platform/native/tauri-browser/nativeHostService.ts
+++ b/src/vs/platform/native/tauri-browser/nativeHostService.ts
@@ -617,7 +617,12 @@ export class TauriNativeHostService extends Disposable implements INativeHostSer
     return invoke<boolean>('has_clipboard', { format });
   }
 
-  /** Reads an image from the clipboard as raw bytes via the Rust backend. */
+  /** Returns whether the clipboard currently contains an image. */
+  async hasClipboardImage(): Promise<boolean> {
+    return invoke<boolean>('has_clipboard_image');
+  }
+
+  /** Reads an image from the clipboard as PNG bytes via the Rust backend. */
   async readImage(): Promise<Uint8Array> {
     const base64 = await invoke<string>('read_clipboard_image');
     if (!base64) {

--- a/src/vs/workbench/services/clipboard/tauri-browser/clipboardService.ts
+++ b/src/vs/workbench/services/clipboard/tauri-browser/clipboardService.ts
@@ -188,6 +188,11 @@ export class TauriClipboardService extends Disposable implements IClipboardServi
     return this.nativeHostService.readImage();
   }
 
+  /** @inheritDoc IClipboardService.hasClipboardImage */
+  async hasClipboardImage(): Promise<boolean> {
+    return this.nativeHostService.hasClipboardImage();
+  }
+
   /**
 	 * Computes a hash of the current system clipboard text content,
 	 * truncated to {@link MAX_RESOURCE_STATE_SOURCE_LENGTH} characters.


### PR DESCRIPTION
## Summary

Fixes an error toast that appeared when pasting a screenshot in the terminal. The root cause was `arboard::read_text()` returning `ContentNotAvailable` when the clipboard contained only image data with no text. Also fixes `read_clipboard_image` to return proper PNG bytes instead of raw RGBA pixels.

Closes #354

## Changes

- `read_clipboard_text` now returns empty string instead of throwing when clipboard has no text (e.g. image-only clipboard)
- `read_clipboard_image` now converts RGBA raw pixels to PNG format using the `image` crate
- Added `has_clipboard_image` command to check if clipboard contains an image
- Added `hasClipboardImage()` to `IClipboardService` and `INativeHostService` interfaces
- Extracted `SUPPORTED_IMAGE_TYPES` constant in `BrowserClipboardService` to eliminate duplication

## How to Test

1. Take a screenshot (Cmd+Shift+4)
2. Paste in the terminal (claude-code) with Cmd+V → no error toast should appear
3. Paste in the Copilot Chat input with Cmd+V → image should paste correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)