### PR TITLE
chore: release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rename `vscodeee.resizeIncrement` to `vscodeee.workbench.editor.resizeIncrement`
 - Rename pane resize command IDs to `vscodeee.workbench.editor` namespace
 - Fix tab-to-space indentation in tauriDnd.ts
+- Regenerate `monaco.d.ts` to fix REH server build ([#361](https://github.com/j4rviscmd/vscodeee/pull/361))
 
 ## [0.5.1] - 2026-04-28
 


### PR DESCRIPTION
## Summary

Re-release v0.6.0 with updated CHANGELOG and regenerated `monaco.d.ts` to fix REH server build.

### Added
- Add DEV@ prefix to window title in development builds

### Fixed
- Prevent IME composition Enter from triggering unintended actions (#359)
- Restore missing `hasClipboardImage` in `TauriNativeHostService`
- Handle image-only clipboard gracefully and return PNG from `readImage` (#354)
- Enable HTML5 drag-and-drop for editor pane repositioning (#342)
- Prevent empty editor group creation when focusing non-existent group index (#351)
- Improve empty editor watermark contrast for all color themes (#350)
- Regenerate `monaco.d.ts` to fix REH server build (#361)

### Changed
- Rename Tauri-specific settings under `vscodeee` prefix
- Fix tab-to-space indentation in tauriDnd.ts

Closes #360

🤖 Generated with [Claude Code](https://claude.com/claude-code)