### PR TITLE
fix: pass GITHUB_TOKEN to cross-compile Docker container

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -420,6 +420,7 @@ jobs:
           # Reinstall for target arch via Docker + QEMU
           docker run --rm \
             --platform "$DOCKER_PLATFORM" \
+            -e GITHUB_TOKEN \
             -v "$PWD/remote:/workspace" \
             -w /workspace \
             node:22 \


### PR DESCRIPTION
## Summary
- Add `-e GITHUB_TOKEN` to the `docker run` command in the cross-compile step of `publish.yml`
- Prevents 403 rate-limit errors when downloading native dependencies (ripgrep, etc.) during Linux ARM cross-compilation
- `@vscode/ripgrep` postinstall already has 5-retry logic, but unauthenticated downloads hit GitHub API rate limits (60/hour); passing `GITHUB_TOKEN` raises this to 1000/hour

## Test plan
- [ ] Verify the next release workflow completes the linux-armhf cross-compile step without 403 errors
- [ ] Confirm no other Docker steps in the workflow are affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)