### PR TITLE
ci: add monaco.d.ts staleness check to prevent REH build failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
     outputs:
       frontend: ${{ steps.filter.outputs.frontend }}
       backend: ${{ steps.filter.outputs.backend }}
+      monaco: ${{ steps.filter.outputs.monaco }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -57,6 +58,11 @@ jobs:
             backend:
               - 'src-tauri/**'
               - '.github/workflows/ci.yml'
+            monaco:
+              - 'src/vs/editor/**'
+              - 'build/monaco/**'
+              - 'build/lib/monaco-api.ts'
+              - 'src/vs/monaco.d.ts'
 
   frontend-lint:
     name: Frontend Lint
@@ -102,6 +108,15 @@ jobs:
 
       - name: Valid layers check
         run: npm run valid-layers-check
+
+      - name: Monaco.d.ts staleness check
+        if: ${{ needs.changes.outputs.monaco == 'true' }}
+        run: |
+          npm run gulp monacodts
+          if ! git diff --exit-code src/vs/monaco.d.ts; then
+            echo "::error::monaco.d.ts is out of date. Run 'npm run gulp monacodts' and commit the result."
+            exit 1
+          fi
 
   csp-hash-check:
     name: CSP Hash Check


### PR DESCRIPTION
## Summary
- Add a path-filtered monaco.d.ts staleness check to the CI pipeline
- When files in `src/vs/editor/`, `build/monaco/`, `build/lib/monaco-api.ts`, or `src/vs/monaco.d.ts` change, the `frontend-compile` job runs `gulp monacodts` and verifies the output matches the committed file
- This catches monaco.d.ts sync issues at PR time instead of during release REH builds

## Context
During the v0.6.0 release, `monaco.d.ts` was out of sync, causing all 5 REH server build jobs to fail (#361, #363). The root cause was that no CI check validated monaco.d.ts staleness before merge — the issue only surfaced during the release workflow's REH build step.

## Changes
- Add `monaco` path filter to the `changes` job (targets editor API, recipe, generator, and generated file paths)
- Add conditional "Monaco.d.ts staleness check" step in `frontend-compile` job (runs only when monaco paths change)
- No changes to `ci-gate` — existing aggregation logic covers the new step

## Test plan
- [ ] Verify CI passes on this PR
- [ ] Verify the staleness check is skipped when no monaco paths are changed
- [ ] Verify the staleness check runs when `src/vs/editor/` files are changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)