### PR TITLE
fix: show progress notification during remote authority resolution

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadProgress.ts
+++ b/src/vs/workbench/api/browser/mainThreadProgress.ts
@@ -7,14 +7,25 @@ import { IProgress, IProgressService, IProgressStep, ProgressLocation, IProgress
 import { MainThreadProgressShape, MainContext, ExtHostProgressShape, ExtHostContext } from '../common/extHost.protocol.js';
 import { extHostNamedCustomer, IExtHostContext } from '../../services/extensions/common/extHostCustomers.js';
 import { ICommandService } from '../../../platform/commands/common/commands.js';
+import { ILogService } from '../../../platform/log/common/log.js';
 import { localize } from '../../../nls.js';
 import { onUnexpectedExternalError } from '../../../base/common/errors.js';
 import { toAction } from '../../../base/common/actions.js';
 import { NotificationPriority } from '../../../platform/notification/common/notification.js';
 
+/**
+ * Main-thread side of the progress API bridge.
+ *
+ * Receives progress operations from the extension host (via `$startProgress`,
+ * `$progressReport`, `$progressEnd`) and forwards them to the
+ * {@link IProgressService}. For notification-based progress, a "Manage Extension"
+ * secondary action is automatically attached so users can navigate to the
+ * contributing extension.
+ */
 @extHostNamedCustomer(MainContext.MainThreadProgress)
 export class MainThreadProgress implements MainThreadProgressShape {
 
+	/** Extension identifiers whose progress notifications should be promoted to {@link NotificationPriority.URGENT}. */
 	private static readonly URGENT_PROGRESS_SOURCES = [
 		'vscode.github-authentication',
 	];
@@ -26,18 +37,41 @@ export class MainThreadProgress implements MainThreadProgressShape {
 	constructor(
 		extHostContext: IExtHostContext,
 		@IProgressService progressService: IProgressService,
-		@ICommandService private readonly _commandService: ICommandService
+		@ICommandService private readonly _commandService: ICommandService,
+		@ILogService private readonly _logService: ILogService,
 	) {
 		this._proxy = extHostContext.getProxy(ExtHostContext.ExtHostProgress);
 		this._progressService = progressService;
 	}
 
+	/**
+	 * Disposes this main-thread progress instance.
+	 *
+	 * Resolves every in-flight progress promise so that the extension host
+	 * is not left waiting, then clears the internal handle map.
+	 */
 	dispose(): void {
 		this._progress.forEach(handle => handle.resolve());
 		this._progress.clear();
 	}
 
+	/**
+	 * Start a progress operation on behalf of an extension.
+	 *
+	 * When the progress location is {@link ProgressLocation.Notification} and an
+	 * {@link extensionId} is provided, the options are augmented with:
+	 * - An elevated {@link NotificationPriority} if the extension is listed in
+	 *   {@link URGENT_PROGRESS_SOURCES}.
+	 * - A "Manage Extension" secondary action that opens the extension management
+	 *   view for the contributing extension.
+	 *
+	 * @param handle - Opaque identifier that the extension host uses to correlate
+	 *   subsequent `$progressReport` and `$progressEnd` calls.
+	 * @param options - Progress options (location, title, cancellable, etc.).
+	 * @param extensionId - The identifier of the extension that initiated the progress.
+	 */
 	async $startProgress(handle: number, options: IProgressOptions, extensionId?: string): Promise<void> {
+		this._logService.info(`[MainThreadProgress] $startProgress(handle=${handle}, title=${options.title}, extensionId=${extensionId})`);
 		const task = this._createTask(handle);
 
 		if (options.location === ProgressLocation.Notification && extensionId) {
@@ -65,11 +99,31 @@ export class MainThreadProgress implements MainThreadProgressShape {
 		}
 	}
 
+	/**
+	 * Report an incremental progress update for an in-flight progress operation.
+	 *
+	 * If the {@link handle} does not match any active progress, the call is silently ignored.
+	 *
+	 * @param handle - The progress handle originally passed to {@link $startProgress}.
+	 * @param message - The progress step containing an optional message and/or increment value.
+	 */
 	$progressReport(handle: number, message: IProgressStep): void {
+		this._logService.trace(`[MainThreadProgress] $progressReport(handle=${handle}, message=${message.message}, increment=${message.increment})`);
 		const entry = this._progress.get(handle);
-		entry?.progress.report(message);
+		if (entry) {
+			entry.progress.report(message);
+		}
 	}
 
+	/**
+	 * End a progress operation and release its associated resources.
+	 *
+	 * Resolves the progress promise (which signals completion to the
+	 * {@link IProgressService}) and removes the handle from the internal map.
+	 * If the {@link handle} is not found, the call is silently ignored.
+	 *
+	 * @param handle - The progress handle originally passed to {@link $startProgress}.
+	 */
 	$progressEnd(handle: number): void {
 		const entry = this._progress.get(handle);
 		if (entry) {

--- a/src/vs/workbench/services/extensions/tauri-browser/tauriExtensionService.ts
+++ b/src/vs/workbench/services/extensions/tauri-browser/tauriExtensionService.ts
@@ -15,9 +15,12 @@ import { IAutomatedWindow, getLogs } from '../../../../platform/log/browser/log.
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { INotificationService } from '../../../../platform/notification/common/notification.js';
 import { IProductService } from '../../../../platform/product/common/productService.js';
+import { IProgressService, ProgressLocation } from '../../../../platform/progress/common/progress.js';
 import { PersistentConnectionEventType } from '../../../../platform/remote/common/remoteAgentConnection.js';
 import { IRemoteAuthorityResolverService, RemoteAuthorityResolverError, ResolverResult } from '../../../../platform/remote/common/remoteAuthorityResolver.js';
 import { IRemoteExtensionsScannerService } from '../../../../platform/remote/common/remoteExtensionsScanner.js';
+import { getRemoteName } from '../../../../platform/remote/common/remoteHosts.js';
+import { localize } from '../../../../nls.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { IWorkspaceContextService } from '../../../../platform/workspace/common/workspace.js';
 import { IWorkspaceTrustManagementService } from '../../../../platform/workspace/common/workspaceTrust.js';
@@ -47,6 +50,14 @@ import { TauriExtensionHostKindPicker } from './tauriExtensionHostKindPicker.js'
  */
 export class TauriExtensionService extends AbstractExtensionService implements IExtensionService {
 
+  /**
+   * Creates a new {@link TauriExtensionService} instance.
+   *
+   * Configures the extension host factory to route extensions through the Tauri
+   * LocalProcess extension host (Rust WS relay). Registers fetch-based file
+   * system providers for HTTP/HTTPS schemes and schedules initialization on
+   * {@link LifecyclePhase.Ready}.
+   */
   constructor(
     @IInstantiationService instantiationService: IInstantiationService,
     @INotificationService notificationService: INotificationService,
@@ -125,6 +136,13 @@ export class TauriExtensionService extends AbstractExtensionService implements I
     this._register(this._fileService.registerProvider(Schemas.https, provider));
   }
 
+  /**
+   * Initialize the extension service.
+   *
+   * Ensures user-data installed extensions are initialized before delegating
+   * to the base class initialization which starts extension hosts and resolves
+   * extensions.
+   */
   protected override async _initialize(): Promise<void> {
     await this._userDataInitializationService.initializeInstalledExtensions(this._instantiationService);
     await super._initialize();
@@ -181,10 +199,35 @@ export class TauriExtensionService extends AbstractExtensionService implements I
     emitter.emitOne(new LocalExtensions(localExtensions));
   }
 
+  /**
+   * Returns an async iterable that yields {@link ResolvedExtensions} events.
+   *
+   * Delegates to {@link _doResolveExtensions} which handles both the default
+   * resolution path and the resolver-extension path (e.g. Remote-SSH).
+   */
   protected _resolveExtensions(): AsyncIterable<ResolvedExtensions> {
     return new AsyncIterableProducer(emitter => this._doResolveExtensions(emitter));
   }
 
+  /**
+   * Core extension resolution logic.
+   *
+   * Two paths:
+   * 1. **Default** (no resolver extension) -- scans local and remote extensions
+   *    in parallel and emits them directly.
+   * 2. **Resolver extension** -- filters local extensions for resolver candidates,
+   *    resolves the remote authority via the LocalProcess extension host (which
+   *    provides Node.js APIs like `child_process` and `net`), sets up tunnel
+   *    information and connection-loss listeners, then falls through to the
+   *    default path.
+   *
+   * If the authority resolution fails with a handled error, the error is stored
+   * via {@link IRemoteAuthorityResolverService._setResolvedAuthorityError} and
+   * resolution proceeds with the default (local-only) path.
+   *
+   * @param emitter - Emitter used to yield {@link ResolvedExtensions} events to
+   *   the base-class pipeline.
+   */
   private async _doResolveExtensions(emitter: AsyncIterableEmitter<ResolvedExtensions>): Promise<void> {
     if (!this._browserEnvironmentService.expectsResolverExtension) {
       return this._resolveExtensionsDefault(emitter);
@@ -202,7 +245,15 @@ export class TauriExtensionService extends AbstractExtensionService implements I
 
     let resolverResult: ResolverResult;
     try {
-      resolverResult = await this._resolveAuthorityInitial(remoteAuthority);
+      const remoteName = getRemoteName(remoteAuthority) || remoteAuthority;
+      const progressService = this._instantiationService.invokeFunction(accessor => accessor.get(IProgressService));
+      resolverResult = await progressService.withProgress(
+        {
+          location: ProgressLocation.Notification,
+          title: localize('connectingToRemote', "Connecting to {0}...", remoteName),
+        },
+        () => this._resolveAuthorityInitial(remoteAuthority)
+      );
     } catch (err) {
       if (RemoteAuthorityResolverError.isHandled(err)) {
         console.log('Error handled: Not showing a notification for the error');
@@ -253,4 +304,5 @@ export class TauriExtensionService extends AbstractExtensionService implements I
   }
 }
 
+/** Register {@link TauriExtensionService} as the eager singleton for {@link IExtensionService}. */
 registerSingleton(IExtensionService, TauriExtensionService, InstantiationType.Eager);

--- a/src/vs/workbench/services/extensions/tauri-browser/tauriExtensionService.ts
+++ b/src/vs/workbench/services/extensions/tauri-browser/tauriExtensionService.ts
@@ -250,9 +250,9 @@ export class TauriExtensionService extends AbstractExtensionService implements I
       resolverResult = await progressService.withProgress(
         {
           location: ProgressLocation.Notification,
-          title: localize('connectingToRemote', "Connecting to {0}...", remoteName),
+          title: localize('connectingToRemote', 'Connecting to {0}...', remoteName),
         },
-        () => this._resolveAuthorityInitial(remoteAuthority)
+        () => this._resolveAuthorityInitial(remoteAuthority),
       );
     } catch (err) {
       if (RemoteAuthorityResolverError.isHandled(err)) {


### PR DESCRIPTION
## Summary

When connecting to a remote server via resolver extensions (e.g. `jeanp413.open-remote-ssh`), users had no visual feedback that the REH server download was in progress. The connection appeared to hang silently, especially on first connect when the REH server binary needs to be downloaded.

## Related Issue

Fixes #368

## Changes

- Wrap `_resolveAuthorityInitial()` in `TauriExtensionService._doResolveExtensions()` with `IProgressService.withProgress()` to display a "Connecting to {hostname}..." notification during remote authority resolution
- Access `IProgressService` lazily via `invokeFunction()` to avoid a circular DI dependency chain (`extensionService → progressService → keybindingService → ... → extensionService`)
- Add debug logging to `MainThreadProgress.$startProgress()` and `$progressReport()` to trace progress RPC messages from the extension host for future debugging

## How to Test

1. Open VSCodeee with `jeanp413.open-remote-ssh` extension installed
2. Connect to a remote SSH host
3. Verify that a progress notification "Connecting to {hostname}..." appears during the connection process
4. Check browser console for `[MainThreadProgress]` log entries confirming RPC messages arrive

🤖 Generated with [Claude Code](https://claude.com/claude-code)