### PR TITLE
fix: add event coalescing and NFC normalization to Tauri file watcher

### DIFF
--- a/src/vs/platform/files/tauri-browser/tauriWatcher.ts
+++ b/src/vs/platform/files/tauri-browser/tauriWatcher.ts
@@ -7,8 +7,10 @@ import { Emitter } from '../../../base/common/event.js';
 import { Disposable } from '../../../base/common/lifecycle.js';
 import { URI } from '../../../base/common/uri.js';
 import { IFileChange, FileChangeType } from '../common/files.js';
-import { ILogMessage, IUniversalWatcher, IUniversalWatchRequest, IWatcherErrorEvent } from '../common/watcher.js';
+import { coalesceEvents, ILogMessage, IUniversalWatcher, IUniversalWatchRequest, IWatcherErrorEvent } from '../common/watcher.js';
 import { invoke, listen } from '../../tauri/common/tauriApi.js';
+import { isMacintosh } from '../../../base/common/platform.js';
+import { normalizeNFC } from '../../../base/common/normalization.js';
 
 /**
  * Raw file change event from the Rust `notify` crate, received via Tauri events.
@@ -46,18 +48,37 @@ export class TauriWatcher extends Disposable implements IUniversalWatcher {
   private nextWatchId = 1;
   private verboseLogging = false;
 
+  /**
+   * Generates a unique string key for a watch request based on its path and recursiveness.
+   * Used to deduplicate and diff watch requests during incremental updates.
+   *
+   * @param request - The watch request to generate a key for
+   * @returns A composite key in the format `"path|recursive"`
+   */
+  private static toWatchKey(request: IUniversalWatchRequest): string {
+    return `${request.path}|${request.recursive}`;
+  }
+
   constructor() {
     super();
 
     this.setupEventListener();
   }
 
+  /**
+   * Subscribes to the Tauri event channel that the Rust backend emits file
+   * changes on (`vscode:fs_change`). The unlisten handle is registered as
+   * a disposable so it is cleaned up when this watcher is disposed.
+   *
+   * If the subscription fails (e.g. the Tauri event system is unavailable),
+   * an error event is fired via {@link onDidError}.
+   */
   private async setupEventListener(): Promise<void> {
     try {
       const unlisten = await listen<RawFileChange[]>('vscode:fs_change', (event) => {
         this.onRawFileChanges(event.payload);
       });
-      this._register({ dispose: () => unlisten() });
+      this._register({ dispose: unlisten });
     } catch (err) {
       this._onDidError.fire({
         error: `Failed to setup Tauri file watcher event listener: ${err}`,
@@ -65,19 +86,37 @@ export class TauriWatcher extends Disposable implements IUniversalWatcher {
     }
   }
 
+  /**
+   * Processes a batch of raw file change events received from the Rust `notify`
+   * backend. Each raw change is converted to an {@link IFileChange}, coalesced
+   * to eliminate redundant events, and then emitted via {@link onDidChangeFile}.
+   *
+   * On macOS, file paths are normalized to NFC form to handle HFS+ decomposition
+   * differences between the Rust side and the VS Code side.
+   *
+   * When verbose logging is enabled, each individual change is traced through
+   * {@link onDidLogMessage} before the batch is emitted.
+   *
+   * @param rawChanges - Array of raw change events from the Rust backend
+   */
   private onRawFileChanges(rawChanges: RawFileChange[]): void {
     if (rawChanges.length === 0) {
       return;
     }
 
     const changes: IFileChange[] = rawChanges.map(raw => ({
-      resource: URI.file(raw.resource),
+      resource: URI.file(isMacintosh ? normalizeNFC(raw.resource) : raw.resource),
       type: this.toFileChangeType(raw.type),
       cId: raw.cId,
     }));
 
+    const coalesced = coalesceEvents(changes);
+    if (coalesced.length === 0) {
+      return;
+    }
+
     if (this.verboseLogging) {
-      for (const change of changes) {
+      for (const change of coalesced) {
         this._onDidLogMessage.fire({
           type: 'trace',
           message: `[TauriWatcher] ${this.changeTypeToString(change.type)} ${change.resource.fsPath}`,
@@ -85,9 +124,23 @@ export class TauriWatcher extends Disposable implements IUniversalWatcher {
       }
     }
 
-    this._onDidChangeFile.fire(changes);
+    this._onDidChangeFile.fire(coalesced);
   }
 
+  /**
+   * Maps the numeric change kind from the Rust `notify` crate to VS Code's
+   * {@link FileChangeType} enum.
+   *
+   * Mapping:
+   * - `0` -> {@link FileChangeType.UPDATED}
+   * - `1` -> {@link FileChangeType.ADDED}
+   * - `2` -> {@link FileChangeType.DELETED}
+   *
+   * Unknown values default to {@link FileChangeType.UPDATED}.
+   *
+   * @param type - The numeric change kind from the Rust backend
+   * @returns The corresponding VS Code file change type
+   */
   private toFileChangeType(type: number): FileChangeType {
     switch (type) {
       case 0: return FileChangeType.UPDATED;
@@ -97,6 +150,13 @@ export class TauriWatcher extends Disposable implements IUniversalWatcher {
     }
   }
 
+  /**
+   * Converts a {@link FileChangeType} enum value to a human-readable string
+   * for use in verbose log messages.
+   *
+   * @param type - The file change type to stringify
+   * @returns A capitalized string representation (e.g. `"ADDED"`, `"DELETED"`, `"UPDATED"`)
+   */
   private changeTypeToString(type: FileChangeType): string {
     switch (type) {
       case FileChangeType.ADDED: return 'ADDED';
@@ -105,20 +165,29 @@ export class TauriWatcher extends Disposable implements IUniversalWatcher {
     }
   }
 
+  /**
+   * Applies the given set of watch requests by computing an incremental diff
+   * against the currently active watches. Watches that are no longer present
+   * in `requests` are stopped, and new watches are started.
+   *
+   * This method is called by the watcher client whenever the set of watched
+   * paths changes (e.g. when a workspace folder is opened or closed).
+   *
+   * @param requests - The complete set of watch requests that should be active
+   *   after this call
+   */
   async watch(requests: IUniversalWatchRequest[]): Promise<void> {
     // Compute the diff: what to stop, what to start
     const requestPaths = new Map<string, IUniversalWatchRequest>();
 
     for (const req of requests) {
-      const key = `${req.path}|${req.recursive}`;
-      requestPaths.set(key, req);
+      requestPaths.set(TauriWatcher.toWatchKey(req), req);
     }
 
     // Stop watches that are no longer needed
     const existingKeys = new Map<string, number>();
     for (const [id, watch] of this.activeWatches) {
-      const key = `${watch.path}|${watch.recursive}`;
-      existingKeys.set(key, id);
+      existingKeys.set(TauriWatcher.toWatchKey(watch), id);
     }
 
     for (const [key, id] of existingKeys) {
@@ -135,6 +204,18 @@ export class TauriWatcher extends Disposable implements IUniversalWatcher {
     }
   }
 
+  /**
+   * Starts a single file watch by invoking the `fs_watch_start` Tauri command
+   * in the Rust backend. On success, the watch is registered in
+   * {@link activeWatches} for later tracking and cleanup.
+   *
+   * If the Rust backend fails to start the watch, an error log is emitted
+   * via {@link onDidLogMessage} and an error event is fired via
+   * {@link onDidError} so the watcher client can attempt recovery.
+   *
+   * @param request - The watch request describing the path, recursiveness,
+   *   exclude patterns, and optional correlation ID
+   */
   private async startWatch(request: IUniversalWatchRequest): Promise<void> {
     const id = this.nextWatchId++;
 
@@ -170,6 +251,17 @@ export class TauriWatcher extends Disposable implements IUniversalWatcher {
     }
   }
 
+  /**
+   * Stops a single active watch by invoking the `fs_watch_stop` Tauri command
+   * with the watch's numeric ID, then removes it from {@link activeWatches}.
+   *
+   * If the Rust backend fails to stop the watch, a warning is logged via
+   * {@link onDidLogMessage} but no error event is fired, since a leaked
+   * watcher on the Rust side is non-critical.
+   *
+   * @param id - The numeric ID of the watch to stop (as assigned by
+   *   {@link startWatch})
+   */
   private async stopWatch(id: number): Promise<void> {
     const request = this.activeWatches.get(id);
     this.activeWatches.delete(id);
@@ -191,10 +283,24 @@ export class TauriWatcher extends Disposable implements IUniversalWatcher {
     }
   }
 
+  /**
+   * Enables or disables verbose trace-level logging for watch lifecycle events
+   * (start, stop) and individual file change notifications.
+   *
+   * @param enabled - `true` to enable verbose logging, `false` to disable
+   */
   async setVerboseLogging(enabled: boolean): Promise<void> {
     this.verboseLogging = enabled;
   }
 
+  /**
+   * Stops all active file watches by invoking the `fs_watch_stop_all` Tauri
+   * command, then clears the local {@link activeWatches} map.
+   *
+   * Failure to stop all watches on the Rust side is silently ignored (best
+   * effort), since the Rust backend will clean up watches when the Tauri
+   * window is closed.
+   */
   async stop(): Promise<void> {
     try {
       await invoke<void>('fs_watch_stop_all');
@@ -205,6 +311,11 @@ export class TauriWatcher extends Disposable implements IUniversalWatcher {
     this.activeWatches.clear();
   }
 
+  /**
+   * Disposes this watcher by stopping all active watches and releasing the
+   * Tauri event listener. Called automatically when this instance is
+   * registered with a {@link DisposableStore}.
+   */
   override dispose(): void {
     this.stop();
     super.dispose();


### PR DESCRIPTION
## Summary

- Add `coalesceEvents()` call to `TauriWatcher.onRawFileChanges()` to merge DELETE+CREATE event pairs into a single UPDATED event, fixing editor reload detection after git operations (`git checkout -- file`, `git stash`, etc.)
- Add `normalizeNFC()` path normalization on macOS to ensure correct URI matching for non-ASCII file paths
- Extract `toWatchKey()` helper and simplify dispose wrapper (code review improvements)

## Root Cause

The TauriWatcher was firing raw file change events without coalescing, unlike the Node/Electron ParcelWatcher which calls `coalesceEvents()`. When `git checkout -- file` atomically replaces a file, the `notify` crate generates DELETE followed by CREATE events. Without coalescing, these arrive as separate events and the editor fails to reload the file content.

## Test plan

- [ ] Open a git-tracked file in the editor, make a change and save it
- [ ] Run `Git: Discard Changes` from the command palette
- [ ] Verify the editor tab immediately shows the reverted content
- [ ] Repeat with `git checkout -- file` from a terminal
- [ ] On macOS, verify files with non-ASCII characters (e.g., Japanese names) are correctly detected

Closes #366

🤖 Generated with [Claude Code](https://claude.com/claude-code)