### PR TITLE
fix: add IME composition guards to prevent Enter from triggering actions during Japanese input

### DIFF
--- a/src/vs/base/browser/ui/tree/abstractTree.ts
+++ b/src/vs/base/browser/ui/tree/abstractTree.ts
@@ -886,6 +886,34 @@ class FindWidget<T, TFilterData> extends Disposable {
 
 		this.actionbar = this._register(new ActionBar(this.elements.actionbar));
 
+		// Local IME composition tracking for this input element.
+		// WKWebView/Tauri has unreliable composition event bubbling to window,
+		// so we track directly on the element for maximum reliability.
+		let localComposing = false;
+		const inputElement = this.findInput.inputBox.inputElement;
+		this._register(addDisposableListener(inputElement, 'compositionstart', () => {
+			localComposing = true;
+		}));
+		this._register(addDisposableListener(inputElement, 'compositionend', () => {
+			// Keep localComposing true for a grace period to catch the Enter keydown
+			// that may fire after compositionend in WKWebView
+			setTimeout(() => { localComposing = false; }, 100);
+		}));
+
+		// Direct native keydown listener to intercept Enter during IME composition
+		// BEFORE any Event.chain/DomEmitter processing. This is the most reliable
+		// guard because it checks the raw native event directly.
+		this._register(addDisposableListener(inputElement, 'keydown', (e: KeyboardEvent) => {
+			if (e.key === 'Enter' || e.keyCode === 13) {
+				if (localComposing || e.isComposing || this.findInput.isImeSessionInProgress || StandardKeyboardEvent.isComposingActive || StandardKeyboardEvent.recentlyComposed) {
+					e.preventDefault();
+					e.stopPropagation();
+					e.stopImmediatePropagation();
+					return;
+				}
+			}
+		}));
+
 		const emitter = this._register(new DomEmitter(this.findInput.inputBox.inputElement, 'keydown'));
 		const onKeyDown = Event.chain(emitter.event, $ => $.map(e => new StandardKeyboardEvent(e)));
 

--- a/src/vs/workbench/browser/parts/views/viewFilter.ts
+++ b/src/vs/workbench/browser/parts/views/viewFilter.ts
@@ -220,6 +220,25 @@ export class FilterWidget extends Widget {
 			inputBox.value = this.options.text;
 		}
 		this._register(inputBox.onDidChange(filter => this.delayedFilterUpdate.trigger(() => this.onDidInputChange(inputBox))));
+		// Native keydown IME guard - intercepts Enter during composition before
+		// addStandardDisposableListener handler can process it. Required because
+		// global composition tracking via window-level events is unreliable in WKWebView/Tauri.
+		let localComposing = false;
+		this._register(DOM.addDisposableListener(inputBox.inputElement, 'compositionstart', () => {
+			localComposing = true;
+		}));
+		this._register(DOM.addDisposableListener(inputBox.inputElement, 'compositionend', () => {
+			setTimeout(() => { localComposing = false; }, 100);
+		}));
+		this._register(DOM.addDisposableListener(inputBox.inputElement, DOM.EventType.KEY_DOWN, (e: KeyboardEvent) => {
+			if (e.key === 'Enter' || e.keyCode === 13) {
+				if (localComposing || e.isComposing || StandardKeyboardEvent.isComposingActive || StandardKeyboardEvent.recentlyComposed) {
+					e.preventDefault();
+					e.stopPropagation();
+					e.stopImmediatePropagation();
+				}
+			}
+		}));
 		this._register(DOM.addStandardDisposableListener(inputBox.inputElement, DOM.EventType.KEY_DOWN, (e: StandardKeyboardEvent) => this.onInputKeyDown(e)));
 		this._register(DOM.addStandardDisposableListener(container, DOM.EventType.KEY_DOWN, (e: StandardKeyboardEvent) => this.handleKeyboardEvent(e)));
 		this._register(DOM.addStandardDisposableListener(container, DOM.EventType.KEY_UP, (e: StandardKeyboardEvent) => this.handleKeyboardEvent(e)));
@@ -282,6 +301,10 @@ export class FilterWidget extends Widget {
 	}
 
 	private onInputKeyDown(event: StandardKeyboardEvent) {
+		// Skip during IME composition (e.g. Japanese input confirming with Enter)
+		if (event.isComposing || StandardKeyboardEvent.isComposingActive || StandardKeyboardEvent.recentlyComposed) {
+			return;
+		}
 		let handled = false;
 		if (event.equals(KeyCode.Tab) && !this.toolbar.isEmpty()) {
 			this.toolbar.focus();

--- a/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { StandardKeyboardEvent } from '../../../../../base/browser/keyboardEvent.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
 import { KeyCode, KeyMod } from '../../../../../base/common/keyCodes.js';
 import { basename } from '../../../../../base/common/resources.js';
@@ -52,6 +53,11 @@ export interface IChatExecuteActionContext {
 
 abstract class SubmitAction extends Action2 {
 	async run(accessor: ServicesAccessor, ...args: unknown[]) {
+		// IME guard: prevent submit during/immediately after IME composition
+		if (StandardKeyboardEvent.isComposingActive || StandardKeyboardEvent.recentlyComposed) {
+			return;
+		}
+
 		const context = args[0] as IChatExecuteActionContext | undefined;
 		const telemetryService = accessor.get(ITelemetryService);
 		const widgetService = accessor.get(IChatWidgetService);
@@ -211,6 +217,7 @@ export class ChatSubmitAction extends SubmitAction {
 				when: ContextKeyExpr.and(
 					ChatContextKeys.inChatInput,
 					ChatContextKeys.withinEditSessionDiff.negate(),
+					EditorContextKeys.isComposing.negate(),
 				),
 				primary: KeyCode.Enter,
 				weight: KeybindingWeight.EditorContrib

--- a/src/vs/workbench/contrib/chat/browser/actions/chatQueueActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatQueueActions.ts
@@ -3,10 +3,12 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { StandardKeyboardEvent } from '../../../../../base/browser/keyboardEvent.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
 import { KeyCode, KeyMod } from '../../../../../base/common/keyCodes.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ServicesAccessor } from '../../../../../editor/browser/editorExtensions.js';
+import { EditorContextKeys } from '../../../../../editor/common/editorContextKeys.js';
 import { localize, localize2 } from '../../../../../nls.js';
 import { Action2, MenuId, MenuRegistry, registerAction2 } from '../../../../../platform/actions/common/actions.js';
 import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
@@ -84,6 +86,7 @@ export class ChatQueueMessageAction extends Action2 {
 					ChatContextKeys.inChatInput,
 					queuingActionsPresent,
 					effectiveDefaultIsQueue,
+					EditorContextKeys.isComposing.negate(),
 				),
 				primary: KeyCode.Enter,
 				weight: KeybindingWeight.EditorContrib + 1
@@ -92,6 +95,11 @@ export class ChatQueueMessageAction extends Action2 {
 	}
 
 	override run(accessor: ServicesAccessor, ...args: unknown[]): void {
+		// IME guard: prevent submit during/immediately after IME composition
+		if (StandardKeyboardEvent.isComposingActive || StandardKeyboardEvent.recentlyComposed) {
+			return;
+		}
+
 		const widgetService = accessor.get(IChatWidgetService);
 		const widget = widgetService.lastFocusedWidget;
 		if (!widget?.viewModel) {
@@ -127,6 +135,7 @@ export class ChatSteerWithMessageAction extends Action2 {
 					ChatContextKeys.inChatInput,
 					queuingActionsPresent,
 					effectiveDefaultIsSteer,
+					EditorContextKeys.isComposing.negate(),
 				),
 				primary: KeyCode.Enter,
 				weight: KeybindingWeight.EditorContrib + 1
@@ -143,6 +152,11 @@ export class ChatSteerWithMessageAction extends Action2 {
 	}
 
 	override run(accessor: ServicesAccessor, ...args: unknown[]): void {
+		// IME guard: prevent submit during/immediately after IME composition
+		if (StandardKeyboardEvent.isComposingActive || StandardKeyboardEvent.recentlyComposed) {
+			return;
+		}
+
 		const widgetService = accessor.get(IChatWidgetService);
 		const widget = widgetService.lastFocusedWidget;
 		if (!widget?.viewModel) {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatQuestionCarouselPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatQuestionCarouselPart.ts
@@ -185,6 +185,10 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 		// Register keyboard navigation
 		interactiveStore.add(dom.addDisposableListener(this.domNode, dom.EventType.KEY_DOWN, (e: KeyboardEvent) => {
 			const event = new StandardKeyboardEvent(e);
+			// Skip during IME composition (e.g. Japanese input confirming with Enter)
+			if (event.isComposing || StandardKeyboardEvent.isComposingActive || StandardKeyboardEvent.recentlyComposed) {
+				return;
+			}
 			if (event.keyCode === KeyCode.Escape && this.carousel.allowSkip) {
 				e.preventDefault();
 				e.stopPropagation();

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -2139,6 +2139,10 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		// Only prevent default behavior if ChatSubmitAction is bound to Enter AND its precondition is met
 		this._register(this._inputEditor.onKeyDown((e) => {
 			if (e.keyCode === KeyCode.Enter && !hasModifierKeys(e)) {
+				// Skip during IME composition (e.g. Japanese input confirming with Enter)
+				if (e.isComposing || StandardKeyboardEvent.isComposingActive || StandardKeyboardEvent.recentlyComposed) {
+					return;
+				}
 				// Check if ChatSubmitAction has a keybinding for plain Enter in the current context
 				// This respects user's custom keybindings that disable the submit action
 				for (const keybinding of this.keybindingService.lookupKeybindings(ChatSubmitAction.ID)) {

--- a/src/vs/workbench/contrib/debug/browser/repl.ts
+++ b/src/vs/workbench/contrib/debug/browser/repl.ts
@@ -6,6 +6,7 @@
 import * as dom from '../../../../base/browser/dom.js';
 import * as domStylesheetsJs from '../../../../base/browser/domStylesheets.js';
 import { IHistoryNavigationWidget } from '../../../../base/browser/history.js';
+import { StandardKeyboardEvent } from '../../../../base/browser/keyboardEvent.js';
 import { IActionViewItem } from '../../../../base/browser/ui/actionbar/actionbar.js';
 import * as aria from '../../../../base/browser/ui/aria/aria.js';
 import { MOUSE_CURSOR_TEXT_CSS_CLASS_NAME } from '../../../../base/browser/ui/mouseCursor/mouseCursor.js';
@@ -924,6 +925,10 @@ class AcceptReplInputAction extends EditorAction {
 	}
 
 	run(accessor: ServicesAccessor, editor: ICodeEditor): void | Promise<void> {
+		// IME guard: prevent submit during/immediately after IME composition
+		if (StandardKeyboardEvent.isComposingActive || StandardKeyboardEvent.recentlyComposed) {
+			return;
+		}
 		SuggestController.get(editor)?.cancelSuggestWidget();
 		const repl = getReplView(accessor.get(IViewsService));
 		repl?.acceptReplInput();

--- a/src/vs/workbench/contrib/search/browser/patternInputWidget.ts
+++ b/src/vs/workbench/contrib/search/browser/patternInputWidget.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as dom from '../../../../base/browser/dom.js';
-import { IKeyboardEvent } from '../../../../base/browser/keyboardEvent.js';
+import { IKeyboardEvent, StandardKeyboardEvent } from '../../../../base/browser/keyboardEvent.js';
 import { Toggle } from '../../../../base/browser/ui/toggle/toggle.js';
 import { IContextViewProvider } from '../../../../base/browser/ui/contextview/contextview.js';
 import { HistoryInputBox, IInputBoxStyles } from '../../../../base/browser/ui/inputbox/inputBox.js';
@@ -158,6 +158,26 @@ export class PatternInputWidget extends Widget {
 		this.inputFocusTracker = dom.trackFocus(this.inputBox.inputElement);
 		this.onkeyup(this.inputBox.inputElement, (keyboardEvent) => this.onInputKeyUp(keyboardEvent));
 
+		// Native keyup IME guard - intercepts Enter during composition before
+		// the Widget.onkeyup handler can process it. Required because global
+		// composition tracking via window-level events is unreliable in WKWebView/Tauri.
+		let localComposing = false;
+		this._register(dom.addDisposableListener(this.inputBox.inputElement, 'compositionstart', () => {
+			localComposing = true;
+		}));
+		this._register(dom.addDisposableListener(this.inputBox.inputElement, 'compositionend', () => {
+			setTimeout(() => { localComposing = false; }, 100);
+		}));
+		this._register(dom.addDisposableListener(this.inputBox.inputElement, 'keyup', (e: KeyboardEvent) => {
+			if (e.key === 'Enter' || e.keyCode === 13) {
+				if (localComposing || e.isComposing || StandardKeyboardEvent.isComposingActive || StandardKeyboardEvent.recentlyComposed) {
+					e.preventDefault();
+					e.stopPropagation();
+					e.stopImmediatePropagation();
+				}
+			}
+		}));
+
 		const controls = document.createElement('div');
 		controls.className = 'controls';
 		this.renderSubcontrols(controls);
@@ -172,6 +192,10 @@ export class PatternInputWidget extends Widget {
 	private onInputKeyUp(keyboardEvent: IKeyboardEvent) {
 		switch (keyboardEvent.keyCode) {
 			case KeyCode.Enter:
+				// Skip during IME composition (e.g. Japanese input confirming with Enter)
+				if (keyboardEvent.isComposing || StandardKeyboardEvent.isComposingActive || StandardKeyboardEvent.recentlyComposed) {
+					return;
+				}
 				this.onSearchSubmit();
 				this._onSubmit.fire(false);
 				return;

--- a/src/vs/workbench/contrib/search/browser/searchWidget.ts
+++ b/src/vs/workbench/contrib/search/browser/searchWidget.ts
@@ -5,7 +5,7 @@
 
 import * as nls from '../../../../nls.js';
 import * as dom from '../../../../base/browser/dom.js';
-import { IKeyboardEvent } from '../../../../base/browser/keyboardEvent.js';
+import { IKeyboardEvent, StandardKeyboardEvent } from '../../../../base/browser/keyboardEvent.js';
 import { ActionBar } from '../../../../base/browser/ui/actionbar/actionbar.js';
 import { Button, IButtonOptions } from '../../../../base/browser/ui/button/button.js';
 import { IFindInputOptions } from '../../../../base/browser/ui/findinput/findInput.js';
@@ -43,7 +43,7 @@ import { NotebookEditorInput } from '../../notebook/common/notebookEditorInput.j
 import { GroupModelChangeKind } from '../../../common/editor.js';
 import { SearchFindInput } from './searchFindInput.js';
 import { getDefaultHoverDelegate } from '../../../../base/browser/ui/hover/hoverDelegateFactory.js';
-import { IDisposable, MutableDisposable } from '../../../../base/common/lifecycle.js';
+import { DisposableStore, IDisposable, MutableDisposable } from '../../../../base/common/lifecycle.js';
 import { NotebookFindScopeType } from '../../notebook/common/notebookCommon.js';
 
 /** Specified in searchview.css */
@@ -473,6 +473,10 @@ export class SearchWidget extends Widget {
 		);
 
 		this._register(this.searchInput.onKeyDown((keyboardEvent: IKeyboardEvent) => this.onSearchInputKeyDown(keyboardEvent)));
+		// Native keydown IME guard - intercepts Enter during composition before
+		// the Widget.onkeydown handler can process it. Required because global
+		// composition tracking via window-level events is unreliable in WKWebView/Tauri.
+		this._register(this._createImeGuard(this.searchInput.inputBox.inputElement));
 		this.searchInput.setValue(options.value || '');
 		this.searchInput.setRegex(!!options.isRegex);
 		this.searchInput.setCaseSensitive(!!options.isCaseSensitive);
@@ -576,6 +580,8 @@ export class SearchWidget extends Widget {
 		}));
 
 		this._register(this.replaceInput.onKeyDown((keyboardEvent) => this.onReplaceInputKeyDown(keyboardEvent)));
+		// Native keydown IME guard for replace input
+		this._register(this._createImeGuard(this.replaceInput.inputBox.inputElement));
 		this.replaceInput.setValue(options.replaceValue || '');
 		this._register(this.replaceInput.inputBox.onDidChange(() => this._onReplaceValueChanged.fire()));
 		this._register(this.replaceInput.inputBox.onDidHeightChange(() => this._onDidHeightChange.fire()));
@@ -690,6 +696,10 @@ export class SearchWidget extends Widget {
 		}
 
 		if (keyboardEvent.equals(KeyCode.Enter)) {
+			// Skip during IME composition (e.g. Japanese input confirming with Enter)
+			if (keyboardEvent.isComposing || StandardKeyboardEvent.isComposingActive || StandardKeyboardEvent.recentlyComposed) {
+				return;
+			}
 			this.searchInput?.onSearchSubmit();
 			this.submitSearch();
 			keyboardEvent.preventDefault();
@@ -779,6 +789,10 @@ export class SearchWidget extends Widget {
 		}
 
 		if (keyboardEvent.equals(KeyCode.Enter)) {
+			// Skip during IME composition (e.g. Japanese input confirming with Enter)
+			if (keyboardEvent.isComposing || StandardKeyboardEvent.isComposingActive || StandardKeyboardEvent.recentlyComposed) {
+				return;
+			}
 			this.submitSearch();
 			keyboardEvent.preventDefault();
 		}
@@ -839,6 +853,33 @@ export class SearchWidget extends Widget {
 	toggleContextLines() {
 		this.showContextToggle.checked = !this.showContextToggle.checked;
 		this.onContextLinesChanged();
+	}
+
+	/**
+	 * Creates a native keydown IME guard for an input element.
+	 * Intercepts Enter during IME composition with stopImmediatePropagation
+	 * to prevent any handler from processing it. Uses local composition
+	 * tracking because global window-level tracking is unreliable in WKWebView/Tauri.
+	 */
+	private _createImeGuard(inputElement: HTMLElement): IDisposable {
+		const disposables = new DisposableStore();
+		let localComposing = false;
+		disposables.add(dom.addDisposableListener(inputElement, 'compositionstart', () => {
+			localComposing = true;
+		}));
+		disposables.add(dom.addDisposableListener(inputElement, 'compositionend', () => {
+			setTimeout(() => { localComposing = false; }, 100);
+		}));
+		disposables.add(dom.addDisposableListener(inputElement, 'keydown', (e: KeyboardEvent) => {
+			if (e.key === 'Enter' || e.keyCode === 13) {
+				if (localComposing || e.isComposing || StandardKeyboardEvent.isComposingActive || StandardKeyboardEvent.recentlyComposed) {
+					e.preventDefault();
+					e.stopPropagation();
+					e.stopImmediatePropagation();
+				}
+			}
+		}));
+		return disposables;
 	}
 
 	override dispose(): void {


### PR DESCRIPTION
## Summary

Add native keydown/keyup IME guards with local composition tracking and `stopImmediatePropagation` to all input widgets that previously triggered unintended actions when pressing Enter to confirm IME composition (e.g., Japanese input).

## Problem

In WKWebView/Tauri, `compositionstart`/`compositionend` events do not bubble reliably to the window level. This means the global `StandardKeyboardEvent.isComposingActive` tracking (registered via `initCompositionTracking` at window level) is unreliable. When users type Japanese text and press Enter to confirm the IME composition, the Enter key event triggers widget-specific actions (search submit, chat send, REPL execute, etc.) instead of just confirming the composition.

## Solution

Multi-layered IME defense:
1. **Native element-level listeners** registered BEFORE framework handlers, using `stopImmediatePropagation()` to prevent any subsequent handler from processing the event
2. **Local composition tracking** per input element (100ms grace period after `compositionend`)
3. **Fallback checks**: `e.isComposing`, `StandardKeyboardEvent.isComposingActive`, `StandardKeyboardEvent.recentlyComposed`
4. **Keybinding preconditions**: `EditorContextKeys.isComposing.negate()` for CodeEditor-based inputs

## Affected Components

| Component | File | Guard Type |
|-----------|------|-----------|
| Tree FindWidget | `abstractTree.ts` | Native keydown + local tracking |
| Search Widget | `searchWidget.ts` | `_createImeGuard()` helper for search & replace |
| Pattern Input | `patternInputWidget.ts` | Native keyup + local tracking |
| View Filter | `viewFilter.ts` | Native keydown + local tracking |
| Chat Submit/Queue/Steer | `chatExecuteActions.ts`, `chatQueueActions.ts` | Runtime guard + keybinding precondition |
| Chat Input | `chatInputPart.ts` | onKeyDown guard |
| Chat Carousel | `chatQuestionCarouselPart.ts` | Event handler guard |
| Debug REPL | `repl.ts` | Runtime guard |

## Testing

Manually verified:
- Japanese input (IME) confirmation with Enter does NOT trigger search/submit/filter
- Regular Enter (without IME) continues to work as expected

Closes #358