### PR TITLE
feat: relax REH version check from commit hash to semver major.minor

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,6 +31,7 @@ jobs:
       skip: ${{ steps.check.outputs.skip }}
       version: ${{ steps.check.outputs.version }}
       tag: ${{ steps.check.outputs.tag }}
+      reh_changed: ${{ steps.reh-diff.outputs.changed }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -89,6 +90,47 @@ jobs:
 
             core.info(`OK: ${tag} does not exist. Proceeding with release.`);
             core.setOutput('skip', 'false');
+
+      - name: Detect REH-related changes since last release
+        id: reh-diff
+        if: steps.check.outputs.skip != 'true'
+        shell: bash
+        run: |
+          # Find the latest release tag to compare against
+          PREV_TAG=$(git tag --sort=-version:refname | grep '^v' | head -n1)
+          if [ -z "$PREV_TAG" ]; then
+            echo "No previous tag found, REH build required"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Comparing HEAD against $PREV_TAG for REH-related paths..."
+
+          # Paths that affect REH server builds
+          REH_PATHS=(
+            "src/vs/server/"
+            "remote/"
+            "build/gulpfile.reh.ts"
+            "src/vs/platform/remote/"
+            "src/vs/workbench/services/remote/"
+            "extensions/open-remote-ssh/"
+            "src/vs/workbench/api/node/extensionHostProcess.ts"
+          )
+
+          DIFF_ARGS=""
+          for p in "${REH_PATHS[@]}"; do
+            DIFF_ARGS="$DIFF_ARGS $p"
+          done
+
+          CHANGES=$(git diff --name-only "$PREV_TAG"...HEAD -- $DIFF_ARGS)
+          if [ -z "$CHANGES" ]; then
+            echo "No REH-related changes detected. REH build will be skipped."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "REH-related changes detected:"
+            echo "$CHANGES"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
 
   generate-notes:
     name: Generate release notes
@@ -293,7 +335,7 @@ jobs:
   build-reh:
     name: Build REH Server (${{ matrix.os }}-${{ matrix.arch }})
     needs: [preflight, generate-notes, create-release]
-    if: needs.preflight.outputs.skip != 'true'
+    if: needs.preflight.outputs.skip != 'true' && needs.preflight.outputs.reh_changed != 'false'
     permissions:
       contents: write
     env:
@@ -487,7 +529,11 @@ jobs:
   upload-stable-assets:
     name: Upload fixed-name assets for README links
     needs: [preflight, publish-tauri, build-reh, create-release]
-    if: needs.preflight.outputs.skip != 'true'
+    if: |
+      !cancelled() &&
+      needs.preflight.outputs.skip != 'true' &&
+      needs.publish-tauri.result == 'success' &&
+      needs.create-release.result == 'success'
     permissions:
       contents: write
     runs-on: ubuntu-latest
@@ -496,6 +542,80 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      - name: Copy REH assets from previous release (when REH build skipped)
+        if: needs.preflight.outputs.reh_changed == 'false'
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const releaseId = Number(process.env.RELEASE_ID);
+            if (!releaseId || isNaN(releaseId)) {
+              core.setFailed('RELEASE_ID is not set or invalid');
+              return;
+            }
+
+            // Find the latest published (non-draft) release
+            const releases = await github.rest.repos.listReleases({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              per_page: 20,
+            });
+            const prevRelease = releases.data.find(r => !r.draft && !r.prerelease);
+            if (!prevRelease) {
+              core.setFailed('No previous release found to copy REH assets from');
+              return;
+            }
+            core.info(`Copying REH assets from previous release: ${prevRelease.tag_name}`);
+
+            const rehAssetNames = [
+              'vscodeee-reh-linux-x64.tar.gz',
+              'vscodeee-reh-linux-arm64.tar.gz',
+              'vscodeee-reh-linux-armhf.tar.gz',
+              'vscodeee-reh-darwin-arm64.tar.gz',
+              'vscodeee-reh-darwin-x64.tar.gz',
+            ];
+
+            for (const assetName of rehAssetNames) {
+              const srcAsset = prevRelease.assets.find(a => a.name === assetName);
+              if (!srcAsset) {
+                core.warning(`REH asset ${assetName} not found in previous release, skipping`);
+                continue;
+              }
+
+              // Download from previous release
+              const download = await github.rest.repos.getReleaseAsset({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                asset_id: srcAsset.id,
+                headers: { accept: 'application/octet-stream' },
+              });
+
+              // Delete if already exists in current release
+              const { data: currentRelease } = await github.rest.repos.getRelease({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                release_id: releaseId,
+              });
+              const existing = currentRelease.assets.find(a => a.name === assetName);
+              if (existing) {
+                await github.rest.repos.deleteReleaseAsset({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  asset_id: existing.id,
+                });
+              }
+
+              // Upload to current release
+              await github.rest.repos.uploadReleaseAsset({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                release_id: releaseId,
+                name: assetName,
+                data: Buffer.from(download.data),
+              });
+              core.info(`Copied ${assetName} from ${prevRelease.tag_name}`);
+            }
 
       - name: Upload fixed-name copies
         uses: actions/github-script@v9
@@ -563,7 +683,14 @@ jobs:
               core.info(`Uploaded ${fixedName} (from ${asset.name})`);
             }
 
+      - name: Fail if REH build failed
+        if: needs.build-reh.result == 'failure'
+        run: |
+          echo "::error::REH build failed. Not publishing release."
+          exit 1
+
       - name: Verify all expected assets and publish release
+        if: needs.build-reh.result != 'failure'
         uses: actions/github-script@v9
         env:
           TAG: ${{ needs.preflight.outputs.tag }}

--- a/src/vs/platform/remote/common/remoteAgentConnection.ts
+++ b/src/vs/platform/remote/common/remoteAgentConnection.ts
@@ -55,6 +55,7 @@ export interface SignRequest {
 export interface ConnectionTypeRequest {
 	type: 'connectionType';
 	commit?: string;
+	version?: string;
 	signedData: string;
 	desiredConnectionType?: ConnectionType;
 	args?: any;
@@ -75,6 +76,7 @@ export type HandshakeMessage = AuthRequest | SignRequest | ConnectionTypeRequest
 interface ISimpleConnectionOptions<T extends RemoteConnection = RemoteConnection> {
 	commit: string | undefined;
 	quality: string | undefined;
+	version: string | undefined;
 	connectTo: T;
 	connectionToken: string | undefined;
 	reconnectionToken: string;
@@ -284,6 +286,7 @@ async function connectToRemoteExtensionHostAgent<T extends RemoteConnection>(opt
 		const connTypeRequest: ConnectionTypeRequest = {
 			type: 'connectionType',
 			commit: options.commit,
+			version: options.version,
 			signedData: signed,
 			desiredConnectionType: connectionType
 		};
@@ -380,6 +383,7 @@ async function doConnectRemoteAgentTunnel(options: ISimpleConnectionOptions, sta
 export interface IConnectionOptions<T extends RemoteConnection = RemoteConnection> {
 	commit: string | undefined;
 	quality: string | undefined;
+	version: string | undefined;
 	addressProvider: IAddressProvider<T>;
 	remoteSocketFactoryService: IRemoteSocketFactoryService;
 	signService: ISignService;
@@ -392,6 +396,7 @@ async function resolveConnectionOptions<T extends RemoteConnection>(options: ICo
 	return {
 		commit: options.commit,
 		quality: options.quality,
+		version: options.version,
 		connectTo,
 		connectionToken: connectionToken,
 		reconnectionToken: reconnectionToken,

--- a/src/vs/platform/tunnel/node/tunnelService.ts
+++ b/src/vs/platform/tunnel/node/tunnelService.ts
@@ -206,6 +206,7 @@ export class BaseTunnelService extends AbstractTunnelService {
 			const options: IConnectionOptions = {
 				commit: this.productService.commit,
 				quality: this.productService.quality,
+				version: this.productService.version,
 				addressProvider: addressOrTunnelProvider,
 				remoteSocketFactoryService: this.remoteSocketFactoryService,
 				signService: this.signService,

--- a/src/vs/server/node/remoteExtensionHostAgentServer.ts
+++ b/src/vs/server/node/remoteExtensionHostAgentServer.ts
@@ -334,8 +334,18 @@ class RemoteExtensionHostAgentServer extends Disposable implements IServerAPI {
 
 				const rendererCommit = msg2.commit;
 				const myCommit = this._productService.commit;
-				if (rendererCommit && myCommit) {
-					// Running in the built version where commits are defined
+				const rendererVersion = (msg2 as ConnectionTypeRequest).version;
+				const myVersion = this._productService.version;
+
+				if (rendererVersion && myVersion) {
+					// Use semver major.minor comparison when version info is available
+					const rendererMajorMinor = rendererVersion.split('.').slice(0, 2).join('.');
+					const myMajorMinor = myVersion.split('.').slice(0, 2).join('.');
+					if (rendererMajorMinor !== myMajorMinor) {
+						return rejectWebSocketConnection(`Client refused: version mismatch (client: ${rendererVersion}, server: ${myVersion})`);
+					}
+				} else if (rendererCommit && myCommit) {
+					// Fallback to commit comparison for older clients that don't send version
 					if (rendererCommit !== myCommit) {
 						return rejectWebSocketConnection(`Client refused: version mismatch`);
 					}

--- a/src/vs/workbench/api/node/extHostTunnelService.ts
+++ b/src/vs/workbench/api/node/extHostTunnelService.ts
@@ -325,6 +325,7 @@ export class NodeExtHostTunnelService extends ExtHostTunnelService {
 				{
 					commit: this.initData.commit,
 					quality: this.initData.quality,
+					version: this.initData.version,
 					logService: this.logService,
 					ipcLogger: null,
 					// services and address providers have stubs since we don't need

--- a/src/vs/workbench/api/node/extensionHostProcess.ts
+++ b/src/vs/workbench/api/node/extensionHostProcess.ts
@@ -358,13 +358,24 @@ function connectToRenderer(protocol: IMessagePassingProtocol): Promise<IRenderer
 
 			const initData = <IExtensionHostInitData>JSON.parse(raw.toString());
 
-			const rendererCommit = initData.commit;
-			const myCommit = product.commit;
+			const rendererVersion = initData.version;
+			const myVersion = product.version;
 
-			if (rendererCommit && myCommit) {
-				// Running in the built version where commits are defined
-				if (rendererCommit !== myCommit) {
+			if (rendererVersion && myVersion) {
+				// Use semver major.minor comparison when version info is available
+				const rendererMajorMinor = rendererVersion.split('.').slice(0, 2).join('.');
+				const myMajorMinor = myVersion.split('.').slice(0, 2).join('.');
+				if (rendererMajorMinor !== myMajorMinor) {
 					nativeExit(ExtensionHostExitCode.VersionMismatch);
+				}
+			} else {
+				// Fallback to commit comparison for older clients
+				const rendererCommit = initData.commit;
+				const myCommit = product.commit;
+				if (rendererCommit && myCommit) {
+					if (rendererCommit !== myCommit) {
+						nativeExit(ExtensionHostExitCode.VersionMismatch);
+					}
 				}
 			}
 

--- a/src/vs/workbench/services/extensions/common/remoteExtensionHost.ts
+++ b/src/vs/workbench/services/extensions/common/remoteExtensionHost.ts
@@ -90,6 +90,7 @@ export class RemoteExtensionHost extends Disposable implements IExtensionHost {
 		const options: IConnectionOptions = {
 			commit: this._productService.commit,
 			quality: this._productService.quality,
+			version: this._productService.version,
 			addressProvider: {
 				getAddress: async () => {
 					const { authority } = await this.remoteAuthorityResolverService.resolveAuthority(this._initDataProvider.remoteAuthority);

--- a/src/vs/workbench/services/remote/common/abstractRemoteAgentService.ts
+++ b/src/vs/workbench/services/remote/common/abstractRemoteAgentService.ts
@@ -39,7 +39,7 @@ export abstract class AbstractRemoteAgentService extends Disposable implements I
 	) {
 		super();
 		if (this._environmentService.remoteAuthority) {
-			this._connection = this._register(new RemoteAgentConnection(this._environmentService.remoteAuthority, productService.commit, productService.quality, this.remoteSocketFactoryService, this._remoteAuthorityResolverService, signService, this._logService));
+			this._connection = this._register(new RemoteAgentConnection(this._environmentService.remoteAuthority, productService.commit, productService.quality, productService.version, this.remoteSocketFactoryService, this._remoteAuthorityResolverService, signService, this._logService));
 		} else {
 			this._connection = null;
 		}
@@ -163,6 +163,7 @@ class RemoteAgentConnection extends Disposable implements IRemoteAgentConnection
 		remoteAuthority: string,
 		private readonly _commit: string | undefined,
 		private readonly _quality: string | undefined,
+		private readonly _version: string | undefined,
 		private readonly _remoteSocketFactoryService: IRemoteSocketFactoryService,
 		private readonly _remoteAuthorityResolverService: IRemoteAuthorityResolverService,
 		private readonly _signService: ISignService,
@@ -221,6 +222,7 @@ class RemoteAgentConnection extends Disposable implements IRemoteAgentConnection
 		const options: IConnectionOptions = {
 			commit: this._commit,
 			quality: this._quality,
+			version: this._version,
 			addressProvider: {
 				getAddress: async () => {
 					if (firstCall) {


### PR DESCRIPTION
## Summary

REHビルド（~1h20min）をpatchリリース時にスキップ可能にすることで、CIパイプラインの効率を改善する。

## Changes

### ランタイム: バージョンチェック緩和
- `ConnectionTypeRequest`に`version`フィールドを追加し、クライアントからサーバーへバージョン情報を送信
- サーバー側（`remoteExtensionHostAgentServer.ts`）: commitハッシュ一致 → semver major.minor一致チェックに変更
- 拡張ホスト（`extensionHostProcess.ts`）: 同上
- 旧クライアント向けfallback: `version`フィールドがない場合は従来のcommit比較にフォールバック

### CI: REHビルドスキップ
- `preflight`ジョブにREH関連パスの変更検出ステップを追加
- 変更がない場合は`build-reh`ジョブ全体をスキップ
- スキップ時は前回リリースのREHアセットを新リリースにコピー
- `upload-stable-assets`を`!cancelled()`で実行し、REHスキップ時もリリース公開可能に

### REH関連パス（変更検出対象）
- `src/vs/server/`
- `remote/`
- `build/gulpfile.reh.ts`
- `src/vs/platform/remote/`
- `src/vs/workbench/services/remote/`
- `extensions/open-remote-ssh/`
- `src/vs/workbench/api/node/extensionHostProcess.ts`

## Impact

- patchリリース時: CI時間 ~1h20min短縮（REHビルドスキップ）
- minor/majorリリース時: 変更検出によりREHビルドは通常通り実行

Closes #364