### PR TITLE
🚀 Release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-05-01
+
+### Added
+
+- Relax REH version check from commit hash to semver major.minor ([#375](https://github.com/j4rviscmd/vscodeee/pull/375))
+
+### Fixed
+
+- Add IME composition guards to prevent Enter key from triggering actions during Japanese input
+- Add event coalescing and NFC normalization to Tauri file watcher ([#373](https://github.com/j4rviscmd/vscodeee/pull/373))
+
+### Changed
+
+- Disable auto-opening DevTools on debug startup ([#371](https://github.com/j4rviscmd/vscodeee/pull/371))
+
 ## [0.7.0] - 2026-04-30
 
 ### Added

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-utils/schema.json",
   "productName": "VS Codeee",
   "mainBinaryName": "codeee",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "identifier": "com.vscodeee.app",
   "build": {
     "frontendDist": "../out",


### PR DESCRIPTION
## Summary

Release v0.8.0 — bundles changes since v0.7.0.

## Changes

### Added
- Relax REH version check from commit hash to semver major.minor (#375)

### Fixed
- Add IME composition guards to prevent Enter key from triggering actions during Japanese input
- Add event coalescing and NFC normalization to Tauri file watcher (#373)

### Changed
- Disable auto-opening DevTools on debug startup (#371)

## How to Test

1. Verify app launches with version `0.8.0`
2. Test IME input in chat/editor — Enter should not trigger actions during composition
3. Test file watcher with files containing special Unicode characters (NFC/NFD)

🤖 Generated with [Claude Code](https://claude.com/claude-code)