### PR TITLE
fix: disable auto-save by default in Tauri desktop environment

### DIFF
--- a/src/vs/workbench/contrib/files/browser/files.contribution.ts
+++ b/src/vs/workbench/contrib/files/browser/files.contribution.ts
@@ -17,7 +17,7 @@ import { FileEditorInput } from './editors/fileEditorInput.js';
 import { BinaryFileEditor } from './editors/binaryFileEditor.js';
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { SyncDescriptor } from '../../../../platform/instantiation/common/descriptors.js';
-import { isNative, isWeb, isWindows } from '../../../../base/common/platform.js';
+import { isNative, isTauri, isWeb, isWindows } from '../../../../base/common/platform.js';
 import { ExplorerViewletViewsContribution } from './explorerViewlet.js';
 import { IEditorPaneRegistry, EditorPaneDescriptor } from '../../../browser/editor.js';
 import { ILabelService } from '../../../../platform/label/common/label.js';
@@ -267,7 +267,7 @@ configurationRegistry.registerConfiguration({
 				nls.localize({ comment: ['This is the description for a setting. Values surrounded by single quotes are not to be translated.'], key: 'files.autoSave.onFocusChange' }, "An editor with changes is automatically saved when the editor loses focus."),
 				nls.localize({ comment: ['This is the description for a setting. Values surrounded by single quotes are not to be translated.'], key: 'files.autoSave.onWindowChange' }, "An editor with changes is automatically saved when the window loses focus.")
 			],
-			'default': isWeb ? AutoSaveConfiguration.AFTER_DELAY : AutoSaveConfiguration.OFF,
+			'default': (isWeb && !isTauri) ? AutoSaveConfiguration.AFTER_DELAY : AutoSaveConfiguration.OFF,
 			'markdownDescription': nls.localize({ comment: ['This is the description for a setting. Values surrounded by single quotes are not to be translated.'], key: 'autoSave' }, "Controls [auto save](https://code.visualstudio.com/docs/editor/codebasics#_save-auto-save) of editors that have unsaved changes.", AutoSaveConfiguration.OFF, AutoSaveConfiguration.AFTER_DELAY, AutoSaveConfiguration.ON_FOCUS_CHANGE, AutoSaveConfiguration.ON_WINDOW_CHANGE, AutoSaveConfiguration.AFTER_DELAY),
 			scope: ConfigurationScope.LANGUAGE_OVERRIDABLE
 		},

--- a/src/vs/workbench/services/filesConfiguration/common/filesConfigurationService.ts
+++ b/src/vs/workbench/services/filesConfiguration/common/filesConfigurationService.ts
@@ -13,7 +13,7 @@ import { IConfigurationService } from '../../../../platform/configuration/common
 import { IFilesConfiguration, AutoSaveConfiguration, HotExitConfiguration, FILES_READONLY_INCLUDE_CONFIG, FILES_READONLY_EXCLUDE_CONFIG, IFileStatWithMetadata, IFileService, IBaseFileStat, hasReadonlyCapability, IFilesConfigurationNode } from '../../../../platform/files/common/files.js';
 import { equals } from '../../../../base/common/objects.js';
 import { URI } from '../../../../base/common/uri.js';
-import { isWeb } from '../../../../base/common/platform.js';
+import { isWeb, isTauri } from '../../../../base/common/platform.js';
 import { IWorkspaceContextService } from '../../../../platform/workspace/common/workspace.js';
 import { ResourceGlobMatcher } from '../../../common/resources.js';
 import { GlobalIdleValue } from '../../../../base/common/async.js';
@@ -120,7 +120,7 @@ export class FilesConfigurationService extends Disposable implements IFilesConfi
 
 	declare readonly _serviceBrand: undefined;
 
-	private static readonly DEFAULT_AUTO_SAVE_MODE = isWeb ? AutoSaveConfiguration.AFTER_DELAY : AutoSaveConfiguration.OFF;
+	private static readonly DEFAULT_AUTO_SAVE_MODE = (isWeb && !isTauri) ? AutoSaveConfiguration.AFTER_DELAY : AutoSaveConfiguration.OFF;
 	private static readonly DEFAULT_AUTO_SAVE_DELAY = 1000;
 
 	private static readonly READONLY_MESSAGES = {


### PR DESCRIPTION
## Summary

Tauri's WebView environment sets `isWeb=true`, which caused the VS Code Web default of `files.autoSave: afterDelay` to be applied. Since Tauri is a desktop app, it should default to `off` like Electron.

## Changes

- `filesConfigurationService.ts`: Changed `DEFAULT_AUTO_SAVE_MODE` from `isWeb ? AFTER_DELAY : OFF` to `(isWeb && !isTauri) ? AFTER_DELAY : OFF`
- `files.contribution.ts`: Applied the same condition to the configuration schema default value

## Root Cause

Two locations were using `isWeb` to determine the auto-save default:
1. `FilesConfigurationService.DEFAULT_AUTO_SAVE_MODE` (runtime fallback)
2. `files.autoSave` configuration schema registration (schema default)

Both now exclude Tauri from the web-only auto-save behavior.

## Testing

- Verified that editing a file shows the dirty indicator (●) in the tab
- Verified that files are not auto-saved without explicit Cmd+S
- TypeScript compilation passes with no errors