### PR TITLE
fix(ci): use full clone in publish workflow preflight for REH diff detection

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,6 +35,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Check for existing tag/release v__VERSION__
         id: check


### PR DESCRIPTION
## Summary

- Fix the `Detect REH-related changes since last release` step in the publish workflow that was failing with exit code 1
- Root cause: `actions/checkout@v6` used `fetch-depth: 1` (shallow clone), so `git diff "$PREV_TAG"...HEAD` failed because the tag's commit object wasn't available locally
- Fix: Add `fetch-depth: 0` to the preflight checkout step to fetch full history and tags

## Test

After merging, re-run the publish workflow to verify the fix.