### PR TITLE
feat: implement multi-window quit with proper ShutdownReason handling

### DIFF
--- a/src-tauri/src/commands/native_host/lifecycle.rs
+++ b/src-tauri/src/commands/native_host/lifecycle.rs
@@ -91,6 +91,9 @@ pub fn close_window(window: tauri::Window) -> Result<(), NativeHostError> {
 /// Saves the session snapshot, unregisters the window from the manager,
 /// cancels the safety-net close timeout, and destroys the window.
 ///
+/// When a coordinated quit is in progress and this was the last window,
+/// exits the application process via `app.exit(0)`.
+///
 /// # Parameters
 ///
 /// * `window` - The Tauri window to close.
@@ -102,6 +105,7 @@ pub fn close_window(window: tauri::Window) -> Result<(), NativeHostError> {
 /// Returns [`NativeHostError::Window`] if destroying the window fails.
 #[tauri::command]
 pub async fn lifecycle_close_confirmed(
+    app: tauri::AppHandle,
     window: tauri::Window,
     window_manager: tauri::State<'_, std::sync::Arc<crate::window::manager::WindowManager>>,
     pending_closes: tauri::State<'_, std::sync::Arc<crate::window::events::PendingCloses>>,
@@ -116,19 +120,46 @@ pub async fn lifecycle_close_confirmed(
 
     window
         .destroy()
-        .map_err(|e| NativeHostError::Window(e.to_string()))
+        .map_err(|e| NativeHostError::Window(e.to_string()))?;
+
+    // If a coordinated quit is active and all windows are now closed,
+    // run the shutdown sequence and exit the process.
+    if let Some(quit_state) =
+        app.try_state::<std::sync::Arc<crate::window::quit_state::QuitState>>()
+    {
+        if quit_state.is_active() && window_manager.count().await == 0 {
+            log::info!(target: "vscodeee::lifecycle", "All windows closed during quit — exiting application");
+            quit_state.cancel(); // Clear flag before exit
+
+            // Run shutdown cleanup (kill child processes)
+            if let Some(coordinator) =
+                app.try_state::<std::sync::Arc<crate::shutdown::ShutdownCoordinator>>()
+            {
+                coordinator.shutdown_all();
+            }
+
+            app.exit(0);
+        }
+    }
+
+    Ok(())
 }
 
 /// Signal that a window close was vetoed by the TypeScript layer.
 ///
 /// Cancels the safety-net close timeout so the window is not force-destroyed.
+/// If a coordinated quit is in progress, clears the quit flag so that other
+/// windows that have already confirmed are not affected (Phase 1 behavior:
+/// windows that already closed stay closed, but the vetoing window remains).
 ///
 /// # Parameters
 ///
+/// * `app` - The Tauri app handle, used to access QuitState.
 /// * `window` - The Tauri window whose close was vetoed.
 /// * `pending_closes` - Safety-net tracker, cancelled to prevent force-destroy.
 #[tauri::command]
 pub fn lifecycle_close_vetoed(
+    app: tauri::AppHandle,
     window: tauri::Window,
     pending_closes: tauri::State<'_, std::sync::Arc<crate::window::events::PendingCloses>>,
 ) -> Result<(), NativeHostError> {
@@ -136,6 +167,17 @@ pub fn lifecycle_close_vetoed(
     log::info!(target: "vscodeee::lifecycle", "Close vetoed for window '{label}'");
 
     pending_closes.cancel(&label);
+
+    // If quit was in progress, cancel it — this window decided to stay open.
+    if let Some(quit_state) =
+        app.try_state::<std::sync::Arc<crate::window::quit_state::QuitState>>()
+    {
+        if quit_state.is_active() {
+            log::info!(target: "vscodeee::lifecycle", "Quit cancelled by veto from window '{label}'");
+            quit_state.cancel();
+        }
+    }
+
     Ok(())
 }
 
@@ -144,6 +186,9 @@ pub fn lifecycle_close_vetoed(
 /// Persists the current session to disk and triggers the `ShutdownCoordinator`
 /// to kill all registered child processes (extension hosts, PTY instances,
 /// file watchers) in the correct order.
+///
+/// This helper is shared by `quit_app`, `exit_app`, and `quit_all_windows`
+/// (when no windows are open) to avoid duplicating the teardown logic.
 ///
 /// # Parameters
 ///
@@ -165,6 +210,11 @@ async fn save_and_shutdown(
 
 /// Quit the application gracefully, saving the session first.
 ///
+/// **WARNING**: This bypasses the TypeScript lifecycle handshake. Prefer
+/// `quit_all_windows` which gives each window a chance to veto (e.g., save
+/// dirty files). This command exists for edge cases where an immediate exit
+/// is required.
+///
 /// # Parameters
 ///
 /// * `app` - The Tauri app handle, used to exit the process.
@@ -176,6 +226,78 @@ pub async fn quit_app(
 ) -> Result<(), NativeHostError> {
     save_and_shutdown(&app, &window_manager).await;
     app.exit(0);
+    Ok(())
+}
+
+/// Quit the application through the proper lifecycle handshake.
+///
+/// Sets the quit-in-progress flag and triggers `window.close()` on all
+/// registered windows. Each window will receive a `CloseRequested` event
+/// with `reason: "quit"`, allowing the TypeScript lifecycle service to use
+/// `ShutdownReason.QUIT` for correct dialog messages and Hot Exit behavior.
+///
+/// If any window vetoes (e.g., user clicks "Cancel" on a dirty-file dialog),
+/// the quit is cancelled. If all windows confirm, the application exits
+/// after the last window is destroyed (handled in `lifecycle_close_confirmed`).
+///
+/// # Parameters
+///
+/// * `app` - The Tauri app handle, used to iterate windows and trigger close.
+/// * `window_manager` - Shared window registry, used to get all window labels.
+/// * `quit_state` - Shared quit coordination state.
+#[tauri::command]
+pub async fn quit_all_windows(
+    app: tauri::AppHandle,
+    window_manager: tauri::State<'_, std::sync::Arc<crate::window::manager::WindowManager>>,
+    quit_state: tauri::State<'_, std::sync::Arc<crate::window::quit_state::QuitState>>,
+) -> Result<(), NativeHostError> {
+    let labels = window_manager.all_labels().await;
+
+    if labels.is_empty() {
+        // No windows open — just exit directly.
+        log::info!(target: "vscodeee::lifecycle", "quit_all_windows: no windows, exiting immediately");
+        save_and_shutdown(&app, &window_manager).await;
+        app.exit(0);
+        return Ok(());
+    }
+
+    log::info!(
+        target: "vscodeee::lifecycle",
+        "quit_all_windows: initiating quit for {} window(s)",
+        labels.len()
+    );
+
+    // Mark quit as in progress BEFORE triggering close on windows.
+    // The CloseRequested handler checks this flag to set reason="quit".
+    quit_state.start();
+
+    // Trigger close on each window — this fires CloseRequested which is
+    // intercepted by handle_window_event, starting the lifecycle handshake
+    // with reason="quit" for each window.
+    let mut any_close_triggered = false;
+    for label in &labels {
+        if let Some(ww) = app.get_webview_window(label) {
+            if let Err(e) = ww.close() {
+                log::error!(
+                    target: "vscodeee::lifecycle",
+                    "quit_all_windows: failed to close window '{label}': {e}"
+                );
+            } else {
+                any_close_triggered = true;
+            }
+        }
+    }
+
+    // If no window close was triggered at all, cancel the quit flag
+    // so subsequent individual closes don't get reason="quit".
+    if !any_close_triggered {
+        log::warn!(
+            target: "vscodeee::lifecycle",
+            "quit_all_windows: no window close triggered — cancelling quit"
+        );
+        quit_state.cancel();
+    }
+
     Ok(())
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -175,6 +175,9 @@ pub fn run(gui_args: Option<cli::dispatch::ParsedGuiArgs>) {
     #[cfg(debug_assertions)]
     let builder = builder.plugin(tauri_plugin_mcp_bridge::init());
 
+    // Quit coordination — tracks whether a multi-window quit is in progress
+    let quit_state = Arc::new(window::quit_state::QuitState::new());
+
     builder
         .manage(pty::manager::PtyManager::new())
         .manage(commands::file_watcher::FileWatcherState::new())
@@ -183,6 +186,7 @@ pub fn run(gui_args: Option<cli::dispatch::ParsedGuiArgs>) {
         .manage(Arc::clone(&window_manager))
         .manage(Arc::clone(&pending_closes))
         .manage(Arc::clone(&pending_shows))
+        .manage(Arc::clone(&quit_state))
         .manage(commands::updater::UpdaterState::default())
         .manage(shutdown::ShutdownCoordinator::new())
         .on_window_event(window::events::handle_window_event)
@@ -278,6 +282,7 @@ pub fn run(gui_args: Option<cli::dispatch::ParsedGuiArgs>) {
             commands::native_host::lifecycle_close_confirmed,
             commands::native_host::lifecycle_close_vetoed,
             commands::native_host::quit_app,
+            commands::native_host::quit_all_windows,
             commands::native_host::exit_app,
             commands::native_host::save_session,
             commands::native_host::relaunch_app,

--- a/src-tauri/src/window/events.rs
+++ b/src-tauri/src/window/events.rs
@@ -325,7 +325,7 @@ pub fn handle_window_event(window: &tauri::Window, event: &tauri::WindowEvent) {
             .to_string();
 
             // Register a cancel channel for the safety-net timeout.
-            let cancel_rx = pending.register(&label_c);
+            let cancel_rx = pending_closes.register(&label_c);
 
             tauri::async_runtime::spawn(async move {
                 if let Some(id) = wm.id_for_label(&label_c).await {

--- a/src-tauri/src/window/events.rs
+++ b/src-tauri/src/window/events.rs
@@ -316,7 +316,7 @@ pub fn handle_window_event(window: &tauri::Window, event: &tauri::WindowEvent) {
             // Check if a coordinated quit is in progress to set the correct reason.
             let reason = if handle
                 .try_state::<Arc<super::quit_state::QuitState>>()
-                .map_or(false, |qs| qs.is_active())
+                .is_some_and(|qs| qs.is_active())
             {
                 "quit"
             } else {

--- a/src-tauri/src/window/events.rs
+++ b/src-tauri/src/window/events.rs
@@ -18,38 +18,42 @@ use tokio::sync::oneshot;
 
 use super::manager::WindowManager;
 
-/// Tracks pending close handshakes so that a safety-net timeout can be
-/// cancelled when the TypeScript layer confirms or vetoes the close.
+/// Generic tracker for pending one-shot handshakes (close or ready-to-show).
 ///
 /// Each window label maps to a [`oneshot::Sender`] that, when dropped or
 /// sent, cancels the corresponding timeout task.
-pub struct PendingCloses {
+struct PendingTracker {
     inner: Mutex<HashMap<String, oneshot::Sender<()>>>,
 }
 
-impl PendingCloses {
-    /// Creates a new empty `PendingCloses` tracker.
-    pub fn new() -> Self {
+impl PendingTracker {
+    /// Creates a new empty `PendingTracker`.
+    fn new() -> Self {
         Self {
             inner: Mutex::new(HashMap::new()),
         }
     }
 
-    /// Register a pending close for the given window label.
+    /// Register a pending handshake for the given window label.
+    ///
+    /// If a previous entry already exists for this label (e.g., the user
+    /// clicks close twice quickly), the old sender is dropped which
+    /// automatically cancels the old timeout.
+    ///
     /// Returns the receiver that the timeout task should await.
-    pub fn register(&self, label: &str) -> oneshot::Receiver<()> {
+    fn register(&self, label: &str) -> oneshot::Receiver<()> {
         let (tx, rx) = oneshot::channel();
         let mut map = self.inner.lock().unwrap();
-        // If a previous pending close exists for this label (unlikely but
+        // If a previous pending entry exists for this label (unlikely but
         // possible if the user clicks close twice quickly), the old sender
         // is dropped which cancels the old timeout.
         map.insert(label.to_string(), tx);
         rx
     }
 
-    /// Cancel a pending close for the given window label.
-    /// Returns `true` if a pending close was found and cancelled.
-    pub fn cancel(&self, label: &str) -> bool {
+    /// Cancel a pending handshake for the given window label.
+    /// Returns `true` if a pending entry was found and cancelled.
+    fn cancel(&self, label: &str) -> bool {
         let mut map = self.inner.lock().unwrap();
         if let Some(tx) = map.remove(label) {
             let _ = tx.send(());
@@ -57,6 +61,41 @@ impl PendingCloses {
         } else {
             false
         }
+    }
+}
+
+/// Tracks pending close handshakes so that a safety-net timeout can be
+/// cancelled when the TypeScript layer confirms or vetoes the close.
+pub struct PendingCloses(PendingTracker);
+
+impl PendingCloses {
+    /// Creates a new empty `PendingCloses` tracker.
+    ///
+    /// Each registered window maps to a [`oneshot::Sender`] that, when
+    /// dropped or sent, cancels the corresponding safety-net timeout task.
+    pub fn new() -> Self {
+        Self(PendingTracker::new())
+    }
+
+    /// Register a pending close handshake for the given window label.
+    ///
+    /// Returns the [`oneshot::Receiver`] that the safety-net timeout task
+    /// should await. If the TypeScript layer calls `lifecycle_close_confirmed`
+    /// or `lifecycle_close_vetoed` before the timeout fires, the receiver
+    /// resolves and the timeout is cancelled.
+    pub fn register(&self, label: &str) -> oneshot::Receiver<()> {
+        self.0.register(label)
+    }
+
+    /// Cancel a pending close handshake for the given window label.
+    ///
+    /// Called when the TypeScript layer invokes `lifecycle_close_confirmed`
+    /// or `lifecycle_close_vetoed`, signalling that the window has responded
+    /// and the safety-net timeout should not force-destroy it.
+    ///
+    /// Returns `true` if a pending entry was found and cancelled.
+    pub fn cancel(&self, label: &str) -> bool {
+        self.0.cancel(label)
     }
 }
 
@@ -74,39 +113,30 @@ const SHOW_TIMEOUT: Duration = Duration::from_secs(30);
 /// Each window starts hidden (`visible: false`). When the TypeScript workbench
 /// calls `notify_ready`, the pending show is cancelled. If TS never responds
 /// (crash/hang), the safety-net timeout shows the window anyway.
-pub struct PendingShows {
-    inner: Mutex<HashMap<String, oneshot::Sender<()>>>,
-}
+pub struct PendingShows(PendingTracker);
 
 impl PendingShows {
     /// Creates a new empty `PendingShows` tracker.
+    ///
+    /// Each registered window maps to a [`oneshot::Sender`] that, when
+    /// dropped or sent, cancels the corresponding safety-net timeout task.
     pub fn new() -> Self {
-        Self {
-            inner: Mutex::new(HashMap::new()),
-        }
+        Self(PendingTracker::new())
     }
 
-    /// Register a pending show for the given window label.
-    /// Returns the receiver that the safety timeout task should await.
+    /// Register a pending show handshake for the given window label.
+    ///
+    /// Returns the [`oneshot::Receiver`] that the safety-net timeout task
+    /// should await. If the TypeScript layer calls `notify_ready` before the
+    /// timeout fires, the receiver resolves and the timeout is cancelled.
     pub fn register(&self, label: &str) -> oneshot::Receiver<()> {
-        let (tx, rx) = oneshot::channel();
-        let mut map = self.inner.lock().unwrap();
-        // If a previous pending show exists for this label, the old sender
-        // is dropped which cancels the old timeout.
-        map.insert(label.to_string(), tx);
-        rx
+        self.0.register(label)
     }
 
     /// Cancel a pending show for the given window label.
     /// Called when the TypeScript layer invokes `notify_ready`.
     pub fn cancel(&self, label: &str) -> bool {
-        let mut map = self.inner.lock().unwrap();
-        if let Some(tx) = map.remove(label) {
-            let _ = tx.send(());
-            true
-        } else {
-            false
-        }
+        self.0.cancel(label)
     }
 
     /// Spawn a safety timeout task for the given window.
@@ -165,10 +195,16 @@ struct FullscreenPayload {
 /// Includes the window label so each TypeScript window can filter
 /// events not intended for it (Tauri 2's `listen` delivers to all
 /// windows by default).
+///
+/// The `reason` field distinguishes between a single-window close ("close")
+/// and an application-wide quit ("quit") so the TypeScript lifecycle service
+/// can use the correct `ShutdownReason`.
 #[derive(Clone, serde::Serialize)]
 struct CloseRequestedPayload {
     window_id: u32,
     label: String,
+    /// "close" for individual window close, "quit" for application quit.
+    reason: String,
 }
 
 /// Event name constants emitted to the WebView.
@@ -207,6 +243,11 @@ pub mod event_names {
 
 /// Emit a state-change event to both the specific window and globally when a
 /// boolean property transitions between `current` and `previous`.
+///
+/// When the property changes from `false` to `true`, `enter_event` is emitted
+/// to both the target window and globally. When it changes from `true` to
+/// `false`, `leave_event` is emitted instead. No event is emitted if the
+/// state has not changed.
 fn emit_state_change(
     handle: &tauri::AppHandle,
     label: &str,
@@ -267,10 +308,21 @@ pub fn handle_window_event(window: &tauri::Window, event: &tauri::WindowEvent) {
 
             let wm = handle.state::<Arc<WindowManager>>();
             let wm = wm.inner().clone();
-            let pending = handle.state::<Arc<PendingCloses>>();
-            let pending = pending.inner().clone();
+            let pending_closes = handle.state::<Arc<PendingCloses>>();
+            let pending_closes = pending_closes.inner().clone();
             let label_c = label.clone();
             let handle_c = handle.clone();
+
+            // Check if a coordinated quit is in progress to set the correct reason.
+            let reason = if handle
+                .try_state::<Arc<super::quit_state::QuitState>>()
+                .map_or(false, |qs| qs.is_active())
+            {
+                "quit"
+            } else {
+                "close"
+            }
+            .to_string();
 
             // Register a cancel channel for the safety-net timeout.
             let cancel_rx = pending.register(&label_c);
@@ -285,6 +337,7 @@ pub fn handle_window_event(window: &tauri::Window, event: &tauri::WindowEvent) {
                         CloseRequestedPayload {
                             window_id: id,
                             label: label_c.clone(),
+                            reason,
                         },
                     );
                 } else {
@@ -314,6 +367,22 @@ pub fn handle_window_event(window: &tauri::Window, event: &tauri::WindowEvent) {
                         wm.unregister(&label_c).await;
                         if let Some(w) = handle_c.get_webview_window(&label_c) {
                             let _ = w.destroy();
+                        }
+
+                        // If quit is in progress and this was the last window, exit the app.
+                        if let Some(quit_state) =
+                            handle_c.try_state::<std::sync::Arc<super::quit_state::QuitState>>()
+                        {
+                            if quit_state.is_active() && wm.count().await == 0 {
+                                log::info!(target: "vscodeee::lifecycle", "Last window force-destroyed during quit — exiting application");
+                                quit_state.cancel();
+                                if let Some(coordinator) =
+                                    handle_c.try_state::<std::sync::Arc<crate::shutdown::ShutdownCoordinator>>()
+                                {
+                                    coordinator.shutdown_all();
+                                }
+                                handle_c.exit(0);
+                            }
                         }
                     }
                 }

--- a/src-tauri/src/window/manager.rs
+++ b/src-tauri/src/window/manager.rs
@@ -29,6 +29,7 @@ pub struct WindowManager {
     last_active: RwLock<Option<WindowId>>,
 }
 
+/// Default implementation delegates to [`WindowManager::new`].
 impl Default for WindowManager {
     fn default() -> Self {
         Self::new()
@@ -216,6 +217,16 @@ impl WindowManager {
     /// Get all registered windows.
     pub async fn get_all(&self) -> Vec<WindowInfo> {
         self.windows.read().await.values().cloned().collect()
+    }
+
+    /// Get all registered window labels.
+    pub async fn all_labels(&self) -> Vec<String> {
+        self.windows
+            .read()
+            .await
+            .values()
+            .map(|w| w.label.clone())
+            .collect()
     }
 
     /// Get the total number of registered windows.

--- a/src-tauri/src/window/mod.rs
+++ b/src-tauri/src/window/mod.rs
@@ -5,13 +5,26 @@
 
 //! Window management module — the Tauri equivalent of Electron's `WindowsMainService`.
 //!
-//! Provides a centralized window registry, event forwarding, and session persistence.
-//! Each WebviewWindow gets a unique monotonic ID that never collides, even across
-//! open/close cycles.
+//! Provides a centralized window registry, event forwarding, session persistence,
+//! and quit coordination. Each WebviewWindow gets a unique monotonic ID that never
+//! collides, even across open/close cycles.
+//!
+//! # Submodules
+//!
+//! - [`manager`] — Centralized window registry with ID/label mapping and workspace deduplication.
+//! - [`events`] — Bridges Tauri native window events to the WebView via scoped Tauri events.
+//! - [`quit_state`] — Tracks whether a multi-window coordinated quit is in progress.
+//! - [`chrome`] — Platform-specific window chrome configuration (decorations, title bar).
+//! - [`restore`] — Computes the window restore plan from settings and session data.
+//! - [`restore_geometry`] — Validates restored window geometry against current display configuration.
+//! - [`session`] — Session persistence to `sessions.json`.
+//! - [`settings`] — User window settings (restore mode, fullscreen behavior).
+//! - [`state`] — Shared types for window state (`WindowInfo`, `OpenWindowOptions`, etc.).
 
 pub mod chrome;
 pub mod events;
 pub mod manager;
+pub mod quit_state;
 pub mod restore;
 pub mod restore_geometry;
 pub mod session;

--- a/src-tauri/src/window/quit_state.rs
+++ b/src-tauri/src/window/quit_state.rs
@@ -1,0 +1,51 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) VS Codeee Contributors. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+//! Quit coordination state — tracks whether a multi-window quit is in progress.
+//!
+//! When `quit_all_windows` is invoked, the `QuitState` is set to active. The
+//! `CloseRequested` handler checks this flag to include `reason: "quit"` in the
+//! event payload sent to the TypeScript lifecycle service.
+//!
+//! If any window vetoes, the quit is cancelled (flag cleared). When the last
+//! window confirms close during an active quit, `app.exit(0)` is called.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// Shared state tracking whether a coordinated quit is in progress.
+///
+/// Managed as Tauri state so it's accessible from both the event handler
+/// (`handle_window_event`) and the command handlers (`lifecycle_close_confirmed`,
+/// `lifecycle_close_vetoed`).
+#[derive(Debug)]
+pub struct QuitState {
+    /// `true` when `quit_all_windows` has been triggered and we're waiting
+    /// for all windows to confirm their close handshake.
+    in_progress: AtomicBool,
+}
+
+impl QuitState {
+    /// Creates a new `QuitState` with quit not in progress.
+    pub fn new() -> Self {
+        Self {
+            in_progress: AtomicBool::new(false),
+        }
+    }
+
+    /// Mark quit as in progress.
+    pub fn start(&self) {
+        self.in_progress.store(true, Ordering::SeqCst);
+    }
+
+    /// Clear the quit-in-progress flag (e.g., when a window vetoes).
+    pub fn cancel(&self) {
+        self.in_progress.store(false, Ordering::SeqCst);
+    }
+
+    /// Check whether a quit is currently in progress.
+    pub fn is_active(&self) -> bool {
+        self.in_progress.load(Ordering::SeqCst)
+    }
+}

--- a/src/vs/platform/native/tauri-browser/nativeHostService.ts
+++ b/src/vs/platform/native/tauri-browser/nativeHostService.ts
@@ -365,30 +365,37 @@ export class TauriNativeHostService extends Disposable implements INativeHostSer
     return invoke<boolean>('is_always_on_top');
   }
 
+  /** Toggles the window's always-on-top (pinned) state via the Rust backend. */
   async toggleWindowAlwaysOnTop(_options?: INativeHostOptions): Promise<void> {
     return invoke('toggle_always_on_top');
   }
 
+  /** Sets the window's always-on-top (pinned) state via the Rust backend. */
   async setWindowAlwaysOnTop(alwaysOnTop: boolean, _options?: INativeHostOptions): Promise<void> {
     return invoke('set_always_on_top', { alwaysOnTop });
   }
 
+  /** Updates the native window control overlay. No-op in Tauri (Phase 1). */
   async updateWindowControls(_options: INativeHostOptions & { height?: number; backgroundColor?: string; foregroundColor?: string; dimmed?: boolean }): Promise<void> {
     // No-op for Phase 1
   }
 
+  /** Updates the native window accent color. No-op in Tauri (Phase 1). */
   async updateWindowAccentColor(_color: 'default' | 'off' | string, _inactiveColor: string | undefined): Promise<void> {
     // No-op for Phase 1
   }
 
+  /** Sets the minimum inner size of the window via the Rust backend. */
   async setMinimumSize(width: number | undefined, height: number | undefined): Promise<void> {
     await invoke('set_minimum_size', { width: width ?? 0, height: height ?? 0 });
   }
 
+  /** Saves the window splash screen configuration. No-op in Tauri (Phase 1). */
   async saveWindowSplash(_splash: IPartsSplash): Promise<void> {
     // No-op for Phase 1
   }
 
+  /** Controls whether background rendering is throttled. No-op in Tauri (Phase 1). */
   async setBackgroundThrottling(_allowed: boolean): Promise<void> {
     // No-op for Phase 1
   }
@@ -537,6 +544,7 @@ export class TauriNativeHostService extends Disposable implements INativeHostSer
     return { dark, highContrast };
   }
 
+  /** Returns whether the Windows Subsystem for Linux (WSL) feature is installed via the Rust backend. */
   async hasWSLFeatureInstalled(): Promise<boolean> {
     return invoke<boolean>('has_wsl_feature_installed');
   }
@@ -545,6 +553,12 @@ export class TauriNativeHostService extends Disposable implements INativeHostSer
 
   // #region Screenshots
 
+  /**
+   * Captures a screenshot of the specified screen rectangle via the Rust backend.
+   *
+   * @param _rect - The screen rectangle to capture. If omitted, captures the full screen.
+   * @returns The screenshot as a `VSBuffer`, or `undefined` if capture fails.
+   */
   async getScreenshot(_rect?: IRectangle): Promise<VSBuffer | undefined> {
     const result = await invoke<Uint8Array | null>('capture_screenshot', {
       rect: _rect ? { x: _rect.x, y: _rect.y, width: _rect.width, height: _rect.height } : null,
@@ -559,6 +573,7 @@ export class TauriNativeHostService extends Disposable implements INativeHostSer
 
   // #region Process
 
+  /** Returns the operating system process ID (PID) of the current application via the Rust backend. */
   async getProcessId(): Promise<number | undefined> {
     return invoke<number>('get_process_id');
   }
@@ -686,9 +701,15 @@ export class TauriNativeHostService extends Disposable implements INativeHostSer
     return invoke('close_window');
   }
 
-  /** Quits the application via the Tauri backend. */
+  /**
+   * Quits the application through the proper lifecycle handshake.
+   *
+   * Triggers `quit_all_windows` which closes all windows with
+   * `ShutdownReason.QUIT`, allowing each to veto (e.g., save dirty files).
+   * After all windows confirm, the Rust backend exits the process.
+   */
   async quit(): Promise<void> {
-    return invoke('quit_app');
+    return invoke('quit_all_windows');
   }
 
   /** Exits the application with the given exit code, saving the session first. */
@@ -700,6 +721,11 @@ export class TauriNativeHostService extends Disposable implements INativeHostSer
 
   // #region Development
 
+  /**
+   * Opens the browser DevTools for the current window via the Rust backend.
+   *
+   * Silently ignores errors in release builds where DevTools are unavailable.
+   */
   async openDevTools(_options?: Partial<OpenDevToolsOptions> & INativeHostOptions): Promise<void> {
     try {
       await invoke('open_devtools');
@@ -708,6 +734,11 @@ export class TauriNativeHostService extends Disposable implements INativeHostSer
     }
   }
 
+  /**
+   * Toggles the browser DevTools for the current window via the Rust backend.
+   *
+   * Silently ignores errors in release builds where DevTools are unavailable.
+   */
   async toggleDevTools(_options?: INativeHostOptions): Promise<void> {
     try {
       await invoke('toggle_devtools');
@@ -716,19 +747,25 @@ export class TauriNativeHostService extends Disposable implements INativeHostSer
     }
   }
 
+  /** Opens a window showing GPU information. No-op in Tauri (Phase 1). */
   async openGPUInfoWindow(): Promise<void> { }
+  /** Opens DevTools in a separate window with the given URL. No-op in Tauri (Phase 1). */
   async openDevToolsWindow(_url: string): Promise<void> { }
+  /** Opens a window for content tracing. No-op in Tauri (Phase 1). */
   async openContentTracingWindow(): Promise<void> { }
+  /** Stops performance tracing. No-op in Tauri (Phase 1). */
   async stopTracing(): Promise<void> { }
 
   // #endregion
 
   // #region Perf Introspection
 
+  /** Profiles the renderer process for the given session and duration. Returns an empty profile stub in Tauri (Phase 1). */
   async profileRenderer(_session: string, _duration: number): Promise<IV8Profile> {
     return { nodes: [], startTime: 0, endTime: 0, samples: [], timeDeltas: [] };
   }
 
+  /** Starts performance tracing with the given categories. No-op in Tauri (Phase 1). */
   async startTracing(_categories: string): Promise<void> { }
 
   // #endregion
@@ -760,6 +797,7 @@ export class TauriNativeHostService extends Disposable implements INativeHostSer
     }
   }
 
+  /** Looks up Kerberos authorization for the given URL. Not implemented in Tauri — always returns `undefined`. */
   async lookupKerberosAuthorization(_url: string): Promise<string | undefined> {
     return undefined;
   }

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { isStandalone } from '../../base/browser/browser.js';
-import { isLinux, isMacintosh, isNative, isWeb, isWindows } from '../../base/common/platform.js';
+import { isLinux, isMacintosh, isNative, isTauri, isWeb, isWindows } from '../../base/common/platform.js';
 import { localize } from '../../nls.js';
 import { Extensions as ConfigurationExtensions, ConfigurationScope, IConfigurationRegistry } from '../../platform/configuration/common/configurationRegistry.js';
 import product from '../../platform/product/common/product.js';
@@ -925,7 +925,7 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 						localize('window.confirmBeforeClose.never.web', "Never explicitly ask for confirmation unless data loss is imminent.") :
 						localize('window.confirmBeforeClose.never', "Never explicitly ask for confirmation.")
 				],
-				'default': (isWeb && !isStandalone()) ? 'keyboardOnly' : 'never', // on by default in web, unless PWA, never on desktop
+				'default': (isWeb && !isStandalone() && !isTauri) ? 'keyboardOnly' : 'never', // on by default in web (not Tauri), unless PWA, never on desktop
 				'markdownDescription': isWeb ?
 					localize('confirmBeforeCloseWeb', "Controls whether to show a confirmation dialog before closing the browser tab or window. Note that even if enabled, browsers may still decide to close a tab or window without confirmation and that this setting is only a hint that may not work in all cases.") :
 					localize('confirmBeforeClose', "Controls whether to show a confirmation dialog before closing a window or quitting the application."),
@@ -1100,6 +1100,13 @@ Registry.as<IConfigurationMigrationRegistry>(Extensions.ConfigurationMigration)
 		}
 	}]);
 
+/**
+ * VSCodeEE-specific workbench editor settings.
+ *
+ * These settings extend the standard VS Code configuration with behaviors
+ * specific to the Tauri-based VSCodeEE fork. Settings are scoped under the
+ * `vscodeee` prefix to distinguish them from upstream VS Code settings.
+ */
 // VSCodeEE: Workbench editor settings
 registry.registerConfiguration({
 	'id': 'vscodeee',

--- a/src/vs/workbench/services/lifecycle/tauri-browser/lifecycleService.ts
+++ b/src/vs/workbench/services/lifecycle/tauri-browser/lifecycleService.ts
@@ -85,12 +85,13 @@ export class TauriLifecycleService extends AbstractLifecycleService {
     // close request (e.g., closing an SSH window must not cascade to
     // the main window).
     const currentLabel = new URL(document.location.href).searchParams.get('windowLabel') ?? 'main';
-    listen<{ window_id: number; label: string }>('vscodeee:lifecycle:close-requested', (event) => {
+    listen<{ window_id: number; label: string; reason?: string }>('vscodeee:lifecycle:close-requested', (event) => {
       if (event.payload.label !== currentLabel) {
         return; // Not our window — ignore
       }
-      this.logService.info(`[lifecycle] Tauri close-requested received (window_id: ${event.payload.window_id}, label: ${event.payload.label})`);
-      this.handleCloseRequested();
+      const reason = event.payload.reason === 'quit' ? ShutdownReason.QUIT : ShutdownReason.CLOSE;
+      this.logService.info(`[lifecycle] Tauri close-requested received (window_id: ${event.payload.window_id}, label: ${event.payload.label}, reason: ${event.payload.reason ?? 'close'})`);
+      this.handleCloseRequested(reason);
     }).then(unlisten => {
       this.tauriCloseListener = unlisten;
     });
@@ -138,13 +139,14 @@ export class TauriLifecycleService extends AbstractLifecycleService {
 	 *    shutdown sequence.
 	 *
 	 * Errors during the veto phase are treated as vetoes to prevent data loss.
+	 *
+	 * @param reason - The shutdown reason: CLOSE for individual window close,
+	 *   QUIT for application-wide quit (affects dialog messages and Hot Exit).
 	 */
-  private async handleCloseRequested(): Promise<void> {
+  private async handleCloseRequested(reason: ShutdownReason = ShutdownReason.CLOSE): Promise<void> {
     if (this._willShutdown) {
       return; // already shutting down
     }
-
-    const reason = ShutdownReason.CLOSE;
 
     try {
       const veto = await this.fireBeforeShutdown(reason);

--- a/src/vs/workbench/tauri-browser/actions/nativeActions.ts
+++ b/src/vs/workbench/tauri-browser/actions/nativeActions.ts
@@ -14,13 +14,15 @@ import { ServicesAccessor } from '../../../platform/instantiation/common/instant
 // #region Quit
 
 /**
- * Quits the application by closing the current window through the lifecycle handshake.
+ * Quits the application by closing ALL windows through the lifecycle handshake.
  *
- * IMPORTANT: Must use `closeWindow()` instead of `quit()`.
- * `quit()` calls Rust `quit_app` which bypasses the TypeScript lifecycle
- * (handleShutdown → flush(SHUTDOWN) → CommandsHistory.saveState()), causing
- * storage data that is only written during shutdown to be lost.
- * `closeWindow()` triggers `CloseRequested` → lifecycle handshake → proper flush.
+ * Calls `quit()` which invokes Rust `quit_all_windows`:
+ * 1. Sets QuitState.in_progress in Rust
+ * 2. Triggers `window.close()` on each window
+ * 3. Each window receives CloseRequested with reason="quit"
+ * 4. TypeScript lifecycle runs with ShutdownReason.QUIT (correct dialog text, Hot Exit)
+ * 5. After all windows confirm → app.exit(0)
+ * 6. If any window vetoes → quit cancelled, that window stays
  */
 class QuitAction extends Action2 {
   constructor() {
@@ -44,12 +46,9 @@ class QuitAction extends Action2 {
   async run(accessor: ServicesAccessor): Promise<void> {
     const nativeHostService = accessor.get(INativeHostService);
 
-    // Use closeWindow() to trigger the full lifecycle handshake:
-    // CloseRequested → handleCloseRequested() → handleShutdown()
-    // → flush(SHUTDOWN) → onDidShutdown → lifecycle_close_confirmed.
-    // Do NOT use quit() — it calls Rust quit_app which skips the
-    // TypeScript lifecycle and loses shutdown-only storage data.
-    await nativeHostService.closeWindow();
+    // quit() now calls quit_all_windows which goes through the full
+    // lifecycle handshake for each window with ShutdownReason.QUIT.
+    await nativeHostService.quit();
   }
 }
 
@@ -59,7 +58,12 @@ registerAction2(QuitAction);
 
 // #region Close Window
 
-/** Closes the current window via the Tauri backend. */
+/**
+ * Action that closes the current window via the Tauri backend.
+ *
+ * Registered with keybinding `CmdOrCtrl+W` and accessible from the command palette.
+ * Delegates to `INativeHostService.closeWindow()` which invokes the Rust `close_window` command.
+ */
 class CloseWindowAction extends Action2 {
   constructor() {
     super({
@@ -86,7 +90,12 @@ registerAction2(CloseWindowAction);
 
 // #region Window Management
 
-/** Minimizes the current window. */
+/**
+ * Action that minimizes the current window.
+ *
+ * Accessible from the command palette under the View category.
+ * Delegates to `INativeHostService.minimizeWindow()`.
+ */
 class MinimizeWindowAction extends Action2 {
   constructor() {
     super({
@@ -105,7 +114,12 @@ class MinimizeWindowAction extends Action2 {
 
 registerAction2(MinimizeWindowAction);
 
-/** Maximizes the current window. */
+/**
+ * Action that maximizes the current window.
+ *
+ * Accessible from the command palette under the View category.
+ * Delegates to `INativeHostService.maximizeWindow()`.
+ */
 class MaximizeWindowAction extends Action2 {
   constructor() {
     super({
@@ -124,7 +138,13 @@ class MaximizeWindowAction extends Action2 {
 
 registerAction2(MaximizeWindowAction);
 
-/** Toggles the maximized state of the current window. */
+/**
+ * Action that toggles the maximized state of the current window.
+ *
+ * Queries `INativeHostService.isMaximized()` and calls either
+ * `unmaximizeWindow()` or `maximizeWindow()` depending on the current state.
+ * Accessible from the command palette under the View category.
+ */
 class ToggleMaximizedWindowAction extends Action2 {
   constructor() {
     super({
@@ -154,7 +174,12 @@ registerAction2(ToggleMaximizedWindowAction);
 
 import { IWindowZoomService } from '../../services/zoom/common/zoom.js';
 
-/** Increases the workbench zoom level by 1. */
+/**
+ * Action that increases the workbench zoom level by 1.
+ *
+ * Registered with keybinding `CmdOrCtrl+=`.
+ * Delegates to `IWindowZoomService.applyZoomDelta(1)`.
+ */
 class ZoomInAction extends Action2 {
   constructor() {
     super({
@@ -177,7 +202,12 @@ class ZoomInAction extends Action2 {
 
 registerAction2(ZoomInAction);
 
-/** Decreases the workbench zoom level by 1. */
+/**
+ * Action that decreases the workbench zoom level by 1.
+ *
+ * Registered with keybinding `CmdOrCtrl+-`.
+ * Delegates to `IWindowZoomService.applyZoomDelta(-1)`.
+ */
 class ZoomOutAction extends Action2 {
   constructor() {
     super({
@@ -200,7 +230,12 @@ class ZoomOutAction extends Action2 {
 
 registerAction2(ZoomOutAction);
 
-/** Resets the workbench zoom level to the default. */
+/**
+ * Action that resets the workbench zoom level to the default.
+ *
+ * Registered with keybindings `CmdOrCtrl+Numpad0` (primary) and `CmdOrCtrl+Digit0` (secondary).
+ * Delegates to `IWindowZoomService.resetZoom()`.
+ */
 class ZoomResetAction extends Action2 {
   constructor() {
     super({
@@ -228,7 +263,12 @@ registerAction2(ZoomResetAction);
 
 // #region Relaunch
 
-/** Relaunches the application via the Tauri backend. */
+/**
+ * Action that relaunches the application via the Tauri backend.
+ *
+ * Accessible from the command palette under the View category.
+ * Delegates to `INativeHostService.relaunch()` which invokes the Rust `relaunch_app` command.
+ */
 class RelaunchAction extends Action2 {
   constructor() {
     super({


### PR DESCRIPTION
## Summary

Implements Phase 1 of the quit lifecycle fix: Cmd+Q now closes all windows (not just the active one) and passes `ShutdownReason.QUIT` through the full TypeScript lifecycle handshake for correct dialog text and Hot Exit behavior.

Closes #376

## Changes

- Add `quit_all_windows` Rust command with `QuitState` coordination flag
- Emit `reason: "quit"` vs `"close"` in close-requested payload for correct `ShutdownReason` selection
- Route `QuitAction` through `nativeHostService.quit()` → `quit_all_windows`
- Cancel coordinated quit when any window vetoes (dirty-file save dialog cancelled)
- Exit process after last window confirms during quit
- Handle safety-net timeout: force-destroy triggers app exit when it was the last window
- Default `window.confirmBeforeClose` to `'never'` for Tauri (browser's `beforeunload` does not exist in Tauri)

## How to Test

1. `npm run tauri:dev`
2. Open multiple windows (Cmd+Shift+N)
3. **Cmd+Q** → all windows close, process exits ✅
4. Set `files.hotExit: "off"`, open a file with unsaved changes
5. **Cmd+Q** → save dialog appears → Cancel → window stays ✅
6. **Cmd+Q** again → save dialog reappears → Don't Save → process exits ✅
7. **X button** → single window closes, other windows unaffected ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)