### PR TITLE
fix: correct update download progress bar accumulation bug

### DIFF
--- a/src/vs/workbench/contrib/update/browser/update.ts
+++ b/src/vs/workbench/contrib/update/browser/update.ts
@@ -209,6 +209,7 @@ export class UpdateContribution extends Disposable implements IWorkbenchContribu
 	private readonly badgeDisposable = this._register(new MutableDisposable());
 	private downloadNotificationHandle: INotificationHandle | undefined;
 	private downloadNotificationExplicit: boolean = false;
+	private lastDownloadPct: number | undefined = undefined;
 	private updateStateContextKey: IContextKey<string>;
 	private majorMinorUpdateAvailableContextKey: IContextKey<boolean>;
 
@@ -270,12 +271,14 @@ export class UpdateContribution extends Disposable implements IWorkbenchContribu
 					});
 					this.downloadNotificationHandle = handle;
 					this.downloadNotificationExplicit = state.explicit;
-					this._register(handle.onDidClose(() => { this.downloadNotificationHandle = undefined; }));
+					this._register(handle.onDidClose(() => { this.downloadNotificationHandle = undefined; this.lastDownloadPct = undefined; }));
 				} else {
 					const pct = computeProgressPercent(state.downloadedBytes, state.totalBytes);
 					if (pct !== undefined) {
+						const delta = pct - (this.lastDownloadPct ?? 0);
 						this.downloadNotificationHandle.progress.total(100);
-						this.downloadNotificationHandle.progress.worked(pct);
+						this.downloadNotificationHandle.progress.worked(delta);
+						this.lastDownloadPct = pct;
 						this.downloadNotificationHandle.updateMessage(nls.localize('downloadingUpdateProgress', "Downloading update... {0}%", pct));
 					}
 				}
@@ -296,6 +299,7 @@ export class UpdateContribution extends Disposable implements IWorkbenchContribu
 						primary: [new Action('update.restart', nls.localize('restartToUpdateNow', "Restart to Update"), '', true, () => this.updateService.quitAndInstall())]
 					});
 					this.downloadNotificationHandle = undefined;
+					this.lastDownloadPct = undefined;
 				}
 				break;
 			}
@@ -312,6 +316,7 @@ export class UpdateContribution extends Disposable implements IWorkbenchContribu
 						this.downloadNotificationHandle.close();
 					}
 					this.downloadNotificationHandle = undefined;
+					this.lastDownloadPct = undefined;
 				}
 				break;
 			}


### PR DESCRIPTION
## Summary
- Fixed update download progress bar reaching 100% prematurely due to value accumulation in `NotificationViewItemProgress.worked()`
- Track previous percentage and pass delta instead of absolute value
- Reset tracking state on notification close, download complete, and download failure

## Root Cause
`NotificationViewItemProgress.worked()` accumulates values (`_state.worked += value`), but `UpdateContribution` was passing absolute percentages (e.g., 10%, 20%, 30%). This caused the bar to grow exponentially faster than actual download progress.

## Fix
Added `lastDownloadPct` field to track the previous percentage and compute the delta before calling `worked()`.

## Test plan
- [ ] Trigger an update download and verify progress bar grows proportionally from 0% to 100%
- [ ] Verify the percentage text in the toast matches the progress bar width
- [ ] Verify progress resets correctly when notification is closed manually
- [ ] Verify progress resets correctly when download completes
- [ ] Verify progress resets correctly when download fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)