### PR TITLE
fix: resolve startup freeze by offloading file I/O and watcher init from main thread

### DIFF
--- a/src-tauri/src/commands/file_watcher.rs
+++ b/src-tauri/src/commands/file_watcher.rs
@@ -18,56 +18,95 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Mutex;
 use std::time::Duration;
-use tauri::Emitter;
+use tauri::{Emitter, Manager};
 
 /// File change type matching VS Code's `FileChangeType` enum.
+///
+/// The discriminant values correspond to the numeric codes expected by the
+/// TypeScript side so that deserialization works without explicit mapping.
 #[allow(dead_code)]
 #[derive(Serialize, Clone, Debug)]
 pub enum FileChangeType {
+    /// An existing file was modified or its metadata changed.
     Updated = 0,
+    /// A new file was created.
     Added = 1,
+    /// A file was removed.
     Deleted = 2,
 }
 
-/// A single file change event sent to the WebView.
+/// A single file change event emitted to the WebView via `vscode:fs_change`.
+///
+/// Serialized as camelCase to match the TypeScript `IFileChange` interface
+/// consumed by `AbstractFileService` on the workbench side.
 #[derive(Serialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct FileChange {
+    /// Absolute file path of the changed resource.
     pub resource: String,
+    /// Numeric change type: `0` = Updated, `1` = Added, `2` = Deleted.
+    /// Matches `FileChangeType` discriminant values.
     pub r#type: u8,
+    /// Optional correlation ID to link the event back to a specific watcher request.
+    /// Skipped during serialization when `None`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub c_id: Option<i32>,
 }
 
-/// Request to start watching a path.
+/// Request to start watching a file or directory for changes.
+///
+/// Deserialized from the `invoke("fs_watch_start", request)` payload sent
+/// by the TypeScript `TauriFileWatcher` service.
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct WatchRequest {
+    /// Unique watcher identifier used to stop or look up this watcher later.
     pub id: u64,
+    /// Absolute path to the file or directory to watch.
     pub path: String,
+    /// Whether to watch recursively (all subdirectories) or only the top level.
     pub recursive: bool,
+    /// Glob patterns for paths to exclude from change notifications.
     pub excludes: Vec<String>,
+    /// Optional correlation ID forwarded to emitted `FileChange` events,
+    /// allowing the caller to associate changes with a specific watch request.
     #[serde(default)]
     pub correlation_id: Option<i32>,
 }
 
 /// Managed state for the file watcher system.
+///
+/// Registered as Tauri managed state so that both command handlers and the
+/// shutdown coordinator can access the active watcher map.
+///
+/// The inner `Mutex<HashMap>` maps watcher IDs to their debouncer handles.
+/// Dropping a `WatcherHandle` automatically stops the watcher and terminates
+/// the background thread.
 pub struct FileWatcherState {
+    /// Map of watcher ID to debouncer handle. Protected by a mutex because
+    /// command handlers and shutdown can access concurrently.
     watchers: Mutex<HashMap<u64, WatcherHandle>>,
 }
 
-/// Holds the debouncer instance. When dropped, the debouncer is stopped
-/// and the background thread terminates.
+/// Holds the debouncer instance for a single watcher.
+///
+/// When dropped, the debouncer is stopped and the background thread terminates.
+/// The underscore-prefixed `_debouncer` field signals that the value is held
+/// solely for its `Drop` side effect.
 struct WatcherHandle {
+    /// The debounced file watcher. Kept alive for the duration of the watch.
+    /// Dropping this field stops the watcher and releases the background thread.
     _debouncer: notify_debouncer_full::Debouncer<
         notify::RecommendedWatcher,
         notify_debouncer_full::RecommendedCache,
     >,
+    /// Correlation ID associated with this watcher, forwarded to emitted events.
     #[allow(dead_code)]
     correlation_id: Option<i32>,
 }
 
 impl FileWatcherState {
+    /// Create a new empty file watcher state.
     pub fn new() -> Self {
         Self {
             watchers: Mutex::new(HashMap::new()),
@@ -105,11 +144,19 @@ fn debounced_event_to_change_type(kind: &notify::EventKind) -> Option<u8> {
     }
 }
 
+/// Check whether a path matches any of the exclude glob patterns.
+///
+/// Used to filter out noise from change notifications (e.g., `.git` objects,
+/// `node_modules`, build artifacts).
 fn should_exclude(path: &std::path::Path, excludes: &[globset::GlobMatcher]) -> bool {
     let path_str = path.to_string_lossy();
     excludes.iter().any(|m| m.is_match(path_str.as_ref()))
 }
 
+/// Compile glob patterns into `GlobMatcher` instances for efficient matching.
+///
+/// Silently skips patterns that fail to parse (invalid globs are ignored rather
+/// than causing the watch to fail entirely).
 fn build_glob_matchers(patterns: &[String]) -> Vec<globset::GlobMatcher> {
     patterns
         .iter()
@@ -154,10 +201,14 @@ fn process_debounced_events(
 /// The debounce timeout (500ms) ensures that related events from atomic file
 /// replacements are always captured in the same batch, regardless of OS-level
 /// event delivery timing.
+///
+/// This is an async command because `Debouncer::watch()` calls
+/// `FileIdMap::add_root()` which enumerates the directory tree and calls
+/// `stat()` on every entry. On large directories this can take seconds,
+/// so it MUST NOT run on the main thread.
 #[tauri::command]
-pub fn fs_watch_start(
+pub async fn fs_watch_start(
     app_handle: tauri::AppHandle,
-    state: tauri::State<'_, FileWatcherState>,
     request: WatchRequest,
 ) -> Result<(), String> {
     let path = PathBuf::from(&request.path);
@@ -200,38 +251,53 @@ pub fn fs_watch_start(
     let excludes = build_glob_matchers(&request.excludes);
 
     let app = app_handle.clone();
-    let cid = correlation_id;
 
-    // Create a debounced watcher with 500ms timeout.
-    // This timeout is chosen to be long enough to capture DELETE+CREATE pairs
-    // from git operations (which may be split across FSEvents callbacks on macOS),
-    // while still being responsive enough for normal editing workflows.
-    let mut debouncer = new_debouncer(
-        Duration::from_millis(500),
-        None, // tick_rate: auto (1/4 of timeout = 125ms)
-        move |result: DebounceEventResult| match result {
-            Ok(events) => {
-                let changes = process_debounced_events(&events, &excludes, cid);
-                if !changes.is_empty() {
-                    let _ = app.emit("vscode:fs_change", &changes);
+    // Create debouncer + start watching on a background thread.
+    // `Debouncer::watch()` calls `FileIdMap::add_root()` which enumerates
+    // the directory tree and calls `stat()` on every entry — this can take
+    // seconds on large directories and MUST NOT block the main thread.
+    let debouncer_result: Result<
+        notify_debouncer_full::Debouncer<
+            notify::RecommendedWatcher,
+            notify_debouncer_full::RecommendedCache,
+        >,
+        String,
+    > = tauri::async_runtime::spawn_blocking(move || {
+        let mut debouncer = new_debouncer(
+            Duration::from_millis(500),
+            None, // tick_rate: auto (1/4 of timeout = 125ms)
+            move |result: DebounceEventResult| match result {
+                Ok(events) => {
+                    let changes = process_debounced_events(&events, &excludes, correlation_id);
+                    if !changes.is_empty() {
+                        let _ = app.emit("vscode:fs_change", &changes);
+                    }
                 }
-            }
-            Err(errors) => {
-                for error in &errors {
-                    log::warn!(
-                        target: "vscodeee::file_watcher",
-                        "Watcher error: {error}"
-                    );
+                Err(errors) => {
+                    for error in &errors {
+                        log::warn!(
+                            target: "vscodeee::file_watcher",
+                            "Watcher error: {error}"
+                        );
+                    }
                 }
-            }
-        },
-    )
-    .map_err(|e| format!("Failed to create debounced watcher: {e}"))?;
+            },
+        )
+        .map_err(|e| format!("Failed to create debounced watcher: {e}"))?;
 
-    debouncer
-        .watch(&watch_path, watch_mode)
-        .map_err(|e| format!("Failed to watch path {}: {e}", watch_path.display()))?;
+        debouncer
+            .watch(&watch_path, watch_mode)
+            .map_err(|e| format!("Failed to watch path {}: {e}", watch_path.display()))?;
 
+        Ok(debouncer)
+    })
+    .await
+    .map_err(|e| format!("Watcher setup panicked: {e}"))?;
+
+    let debouncer = debouncer_result?;
+
+    // Register watcher in state (lightweight HashMap insert).
+    let state = app_handle.state::<FileWatcherState>();
     let mut watchers = state.watchers.lock().map_err(|e| e.to_string())?;
     watchers.insert(
         watch_id,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,37 +3,55 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-/// Tauri commands exposed to the WebView via `invoke()`
+/// Tauri commands exposed to the WebView via `invoke()`.
 mod commands;
 
 /// Shutdown coordination — ordered cleanup of child processes and threads.
+///
+/// Ensures that extension hosts, PTY instances, and file watchers are torn
+/// down in the correct sequence during application exit.
 mod shutdown;
 
-/// Custom protocol handlers for vscode-file:// etc.
+/// Custom protocol handlers for `vscode-file://` URIs.
+///
+/// Implements the same security model as Electron's `ProtocolMainService`:
+/// root validation, CORS, COOP/COEP, and MIME type resolution.
 mod protocol;
 
-/// IPC infrastructure — channel routing and event bus for VS Code's binary protocol.
+/// IPC infrastructure — channel routing and event bus for VS Code's binary IPC protocol.
+///
+/// Replaces Electron's `ipcMain` / `ipcRenderer` with a Tauri-native
+/// implementation supporting multiplexed named channels and event bus semantics.
 mod ipc;
 
-/// Window management — registry, event forwarding, and session persistence.
+/// Window management — centralized registry, event forwarding, and session persistence.
+///
+/// Manages multi-window lifecycle including creation, close negotiation,
+/// fullscreen state, and session-based window restoration.
 mod window;
 
 /// Extension Host sidecar management — spawn Node.js, communicate via named pipe.
+///
 /// TODO(Phase 1-2): Replace PoC direct handshake with WebSocket relay + TypeScript IExtensionHost impl
 mod exthost;
 
-/// Logging configuration — tauri-plugin-log with AI-agent-readable format.
+/// Logging configuration — `tauri-plugin-log` with structured, AI-agent-readable format.
 mod logging;
 
 /// System event monitoring — OS-level events (suspend, resume, lock, battery)
-/// forwarded to the WebView via Tauri's app.emit() mechanism.
+/// forwarded to the WebView via Tauri's `app.emit()` mechanism.
 mod system_events;
 
 /// PTY (pseudo-terminal) management — spawn shells, relay I/O to xterm.js via Tauri events.
-/// Phase 0-4: Uses portable-pty for direct Rust PTY management.
+///
+/// Phase 0-4: Uses `portable-pty` for direct Rust PTY management with
+/// persistent state storage for terminal sessions across restarts.
 mod pty;
 
-/// CLI argument handling for the `eee` command.
+/// CLI argument handling for the `eee` launcher command.
+///
+/// Public because it is shared with the single-instance plugin callback
+/// to route forwarded CLI arguments from a second process instance.
 pub mod cli;
 
 /// Build and run the Tauri application.
@@ -59,7 +77,7 @@ pub mod cli;
 ///    `FileWatcherState`, `ExtHostState`, `ShutdownCoordinator`, etc.) so they
 ///    are accessible from Tauri command handlers.
 /// 5. **Custom protocol** — Register the `vscode-file://` scheme for secure
-///    access to local files ([`protocol::handle_vscode_file_protocol`]).
+///    access to local files ([`protocol::handle_vscode_file_protocol_async`]).
 /// 6. **Command handlers** — Register all Tauri commands callable from the
 ///    WebView via `invoke()`.
 /// 7. **Setup closure** — Executed once before the event loop starts:
@@ -190,19 +208,21 @@ pub fn run(gui_args: Option<cli::dispatch::ParsedGuiArgs>) {
         .manage(commands::updater::UpdaterState::default())
         .manage(shutdown::ShutdownCoordinator::new())
         .on_window_event(window::events::handle_window_event)
-        .register_uri_scheme_protocol("vscode-file", move |ctx, request| {
+        .register_asynchronous_uri_scheme_protocol("vscode-file", move |ctx, request, responder| {
             // On first call the state will have been initialized by setup().
             // If somehow called before setup (shouldn't happen), return 503.
             match state_for_handler.get() {
                 Some(state) => {
                     let handler =
-                        protocol::handle_vscode_file_protocol::<tauri::Wry>(Arc::clone(state));
-                    handler(ctx, request)
+                        protocol::handle_vscode_file_protocol_async::<tauri::Wry>(Arc::clone(state));
+                    handler(ctx, request, responder)
                 }
-                None => tauri::http::Response::builder()
-                    .status(503)
-                    .body(b"Protocol not yet initialized".to_vec())
-                    .unwrap(),
+                None => responder.respond(
+                    tauri::http::Response::builder()
+                        .status(503)
+                        .body(b"Protocol not yet initialized".to_vec())
+                        .unwrap(),
+                ),
             }
         })
         .invoke_handler(tauri::generate_handler![

--- a/src-tauri/src/protocol/headers.rs
+++ b/src-tauri/src/protocol/headers.rs
@@ -33,20 +33,20 @@ pub type Header = (String, String);
 ///
 /// Returns the origin string to use in `Access-Control-Allow-Origin` if allowed,
 /// or the default `tauri://localhost` if the origin is absent or not recognized.
-fn resolve_cors_origin(request_origin: Option<&str>) -> &str {
-    match request_origin {
-        Some(origin) => {
-            for prefix in ALLOWED_ORIGIN_PREFIXES {
-                if origin == *prefix || origin.starts_with(&format!("{prefix}:")) {
-                    return origin;
-                }
-            }
-            // Unknown origin — fall back to default (won't match, effectively denying CORS)
-            "tauri://localhost"
+pub(crate) fn resolve_cors_origin(request_origin: Option<&str>) -> &str {
+    let origin = match request_origin {
+        Some(origin) => origin,
+        None => return "tauri://localhost",
+    };
+
+    for prefix in ALLOWED_ORIGIN_PREFIXES {
+        if origin == *prefix || origin.starts_with(&format!("{prefix}:")) {
+            return origin;
         }
-        // No Origin header — use default (same-origin requests from Tauri WebView)
-        None => "tauri://localhost",
     }
+
+    // Unknown origin — fall back to default (won't match, effectively denying CORS)
+    "tauri://localhost"
 }
 
 /// Compute the security headers for a given file path.
@@ -57,11 +57,7 @@ fn resolve_cors_origin(request_origin: Option<&str>) -> &str {
 /// - Whether this is a development build (gets Cache-Control: no-cache)
 ///
 /// All responses get CORS headers allowing validated origins.
-pub fn headers_for_path(
-    path: &Path,
-    is_dev_build: bool,
-    request_origin: Option<&str>,
-) -> Vec<Header> {
+pub fn headers_for_path(path: &Path, request_origin: Option<&str>) -> Vec<Header> {
     let mut headers = Vec::with_capacity(6);
 
     // Always add CORS with the resolved origin
@@ -95,12 +91,17 @@ pub fn headers_for_path(
         ));
     }
 
-    // Cache-Control for dev builds
-    if is_dev_build {
+    // Cache-Control: static assets (JS/CSS/etc.) are immutable per build
+    // and MUST be cached to avoid flooding WKWebView's main thread with
+    // hundreds of response deliveries through the custom protocol handler.
+    // HTML entry points use no-cache to ensure the latest workbench is loaded.
+    if is_workbench_html {
         headers.push((
             "Cache-Control".to_string(),
             "no-cache, no-store".to_string(),
         ));
+    } else {
+        headers.push(("Cache-Control".to_string(), "max-age=604800".to_string()));
     }
 
     headers
@@ -122,7 +123,7 @@ mod tests {
     #[test]
     fn always_includes_cors() {
         let path = PathBuf::from("/app/out/vs/base/style.css");
-        let headers = headers_for_path(&path, false, None);
+        let headers = headers_for_path(&path, None);
         let map = header_map(&headers);
         assert_eq!(
             map.get("Access-Control-Allow-Origin"),
@@ -133,7 +134,7 @@ mod tests {
     #[test]
     fn cors_echoes_allowed_dev_origin() {
         let path = PathBuf::from("/app/out/vs/base/style.css");
-        let headers = headers_for_path(&path, false, Some("http://127.0.0.1:1430"));
+        let headers = headers_for_path(&path, Some("http://127.0.0.1:1430"));
         let map = header_map(&headers);
         assert_eq!(
             map.get("Access-Control-Allow-Origin"),
@@ -144,7 +145,7 @@ mod tests {
     #[test]
     fn cors_echoes_localhost_dev_origin() {
         let path = PathBuf::from("/app/out/vs/base/style.css");
-        let headers = headers_for_path(&path, false, Some("http://localhost:5173"));
+        let headers = headers_for_path(&path, Some("http://localhost:5173"));
         let map = header_map(&headers);
         assert_eq!(
             map.get("Access-Control-Allow-Origin"),
@@ -155,7 +156,7 @@ mod tests {
     #[test]
     fn cors_rejects_unknown_origin() {
         let path = PathBuf::from("/app/out/vs/base/style.css");
-        let headers = headers_for_path(&path, false, Some("https://evil.example.com"));
+        let headers = headers_for_path(&path, Some("https://evil.example.com"));
         let map = header_map(&headers);
         // Falls back to tauri://localhost (won't match the attacker's origin)
         assert_eq!(
@@ -167,7 +168,7 @@ mod tests {
     #[test]
     fn cors_echoes_tauri_origin() {
         let path = PathBuf::from("/app/out/vs/base/style.css");
-        let headers = headers_for_path(&path, false, Some("tauri://localhost"));
+        let headers = headers_for_path(&path, Some("tauri://localhost"));
         let map = header_map(&headers);
         assert_eq!(
             map.get("Access-Control-Allow-Origin"),
@@ -178,7 +179,7 @@ mod tests {
     #[test]
     fn workbench_html_gets_coop_coep() {
         let path = PathBuf::from("/app/out/vs/workbench/workbench.html");
-        let headers = headers_for_path(&path, false, None);
+        let headers = headers_for_path(&path, None);
         let map = header_map(&headers);
 
         assert_eq!(map.get("Cross-Origin-Opener-Policy"), Some(&"same-origin"));
@@ -195,7 +196,7 @@ mod tests {
     #[test]
     fn non_workbench_file_no_coop_coep() {
         let path = PathBuf::from("/app/out/vs/editor/editor.main.js");
-        let headers = headers_for_path(&path, false, None);
+        let headers = headers_for_path(&path, None);
         let map = header_map(&headers);
 
         assert!(!map.contains_key("Cross-Origin-Opener-Policy"));
@@ -204,25 +205,25 @@ mod tests {
     }
 
     #[test]
-    fn dev_build_gets_cache_control() {
+    fn js_gets_long_cache() {
         let path = PathBuf::from("/app/out/vs/base/common/network.js");
-        let headers = headers_for_path(&path, true, None);
+        let headers = headers_for_path(&path, None);
+        let map = header_map(&headers);
+        assert_eq!(map.get("Cache-Control"), Some(&"max-age=604800"));
+    }
+
+    #[test]
+    fn html_gets_no_cache() {
+        let path = PathBuf::from("/app/out/vs/code/browser/workbench/workbench.html");
+        let headers = headers_for_path(&path, None);
         let map = header_map(&headers);
         assert_eq!(map.get("Cache-Control"), Some(&"no-cache, no-store"));
     }
 
     #[test]
-    fn production_build_no_cache_control() {
-        let path = PathBuf::from("/app/out/vs/base/common/network.js");
-        let headers = headers_for_path(&path, false, None);
-        let map = header_map(&headers);
-        assert!(!map.contains_key("Cache-Control"));
-    }
-
-    #[test]
     fn index_html_treated_as_workbench() {
         let path = PathBuf::from("/app/workbench/index.html");
-        let headers = headers_for_path(&path, false, None);
+        let headers = headers_for_path(&path, None);
         let map = header_map(&headers);
         assert!(map.contains_key("Cross-Origin-Opener-Policy"));
     }

--- a/src-tauri/src/protocol/mod.rs
+++ b/src-tauri/src/protocol/mod.rs
@@ -38,12 +38,10 @@ use roots::ValidRoots;
 /// Shared protocol state, managed as Tauri app state.
 ///
 /// Wrapped in `Arc` so it can be cheaply cloned into the protocol handler
-/// closure registered with `register_uri_scheme_protocol`.
+/// closure registered with `register_asynchronous_uri_scheme_protocol`.
 pub struct ProtocolState {
     /// The set of valid file system roots and allowed extensions.
     pub roots: ValidRoots,
-    /// Whether this is a development (non-built) build — affects caching headers.
-    pub is_dev: bool,
 }
 
 /// Initialize [`ProtocolState`] with the standard VS Code root directories.
@@ -96,38 +94,51 @@ pub fn init_protocol_state(app: &tauri::App) -> Arc<ProtocolState> {
         roots.add_root(&extensions_dir);
     }
 
-    // Detect dev build: if Tauri was invoked via `cargo tauri dev`, the
-    // TAURI_DEV environment variable is set.
-    let is_dev = cfg!(debug_assertions);
-
-    let state = Arc::new(ProtocolState { roots, is_dev });
+    let state = Arc::new(ProtocolState { roots });
 
     log::info!(
         target: "vscodeee::protocol",
         "Initialized with {} root(s), dev={}",
         state.roots.root_count(),
-        state.is_dev
+        cfg!(debug_assertions)
     );
 
     state
 }
 
-/// Handle a `vscode-file://vscode-app/<path>` request.
+/// Handle a `vscode-file://vscode-app/<path>` request synchronously.
 ///
-/// This is the main entry point registered with Tauri's
-/// `register_uri_scheme_protocol`. It:
+/// Kept for reference / tests. Use [`handle_vscode_file_protocol_async`]
+/// in production to avoid blocking the main thread.
+#[cfg(test)]
+fn handle_vscode_file_protocol_sync(
+    state: &ProtocolState,
+    raw_uri: &str,
+    request_origin: Option<&str>,
+    _app_handle: &tauri::AppHandle,
+) -> Response<Vec<u8>> {
+    match serve_file(state, raw_uri, request_origin) {
+        Ok(response) => response,
+        Err(ProtocolError::NotFound(_)) => error_response(404, b"Not Found", request_origin),
+        Err(e) => {
+            log::error!(target: "vscodeee::protocol", "{e}");
+            error_response(e.status_code(), e.reason().as_bytes(), request_origin)
+        }
+    }
+}
+
+/// Async variant of the protocol handler for `register_asynchronous_uri_scheme_protocol`.
 ///
-/// 1. Parses and canonicalizes the URI.
-/// 2. Validates the path against registered roots + extension whitelist.
-/// 3. Reads the file and returns it with appropriate security headers.
-/// 4. If the file is not found on disk, falls back to Tauri's embedded
-///    asset resolver (for production builds where `frontendDist` assets
-///    are bundled into the binary).
-pub fn handle_vscode_file_protocol<R: tauri::Runtime>(
+/// Spawns a thread for each request so the main thread is never blocked by
+/// file I/O. The synchronous handler saturated the main thread when the
+/// workbench loaded hundreds of modules, freezing the WebView.
+pub fn handle_vscode_file_protocol_async<R: tauri::Runtime>(
     state: Arc<ProtocolState>,
-) -> impl Fn(UriSchemeContext<'_, R>, Request<Vec<u8>>) -> Response<Vec<u8>> + Send + Sync + 'static
+) -> impl Fn(UriSchemeContext<'_, R>, Request<Vec<u8>>, tauri::UriSchemeResponder) + Send + Sync + 'static
 {
-    move |ctx: UriSchemeContext<'_, R>, request: Request<Vec<u8>>| {
+    move |ctx: UriSchemeContext<'_, R>,
+          request: Request<Vec<u8>>,
+          responder: tauri::UriSchemeResponder| {
         let raw_uri = request.uri().to_string();
         let request_origin = request
             .headers()
@@ -135,46 +146,63 @@ pub fn handle_vscode_file_protocol<R: tauri::Runtime>(
             .and_then(|v| v.to_str().ok())
             .map(|s| s.to_string());
 
-        match serve_file(&state, &raw_uri, request_origin.as_deref()) {
-            Ok(response) => response,
-            Err(ProtocolError::NotFound(_)) => {
-                // File not found on disk — try embedded asset fallback.
-                // In production builds, frontendDist assets are embedded in the
-                // binary and not available on the filesystem.
-                log::debug!(
-                    target: "vscodeee::protocol",
-                    "File not found on disk, trying embedded asset: {raw_uri}"
-                );
-                match serve_embedded_asset(
-                    ctx.app_handle(),
-                    &raw_uri,
-                    request_origin.as_deref(),
-                    state.is_dev,
-                ) {
-                    Ok(response) => response,
-                    Err(fallback_err) => {
-                        log::warn!(
-                            target: "vscodeee::protocol",
-                            "Embedded asset fallback also failed: {fallback_err}"
-                        );
-                        error_response(
-                            fallback_err.status_code(),
-                            fallback_err.reason().as_bytes(),
-                            request_origin.as_deref(),
-                        )
+        // Fast-path: serve from disk on a background thread.
+        let state_clone = Arc::clone(&state);
+        let app_handle = ctx.app_handle().clone();
+        std::thread::spawn(move || {
+            let response = match serve_file(&state_clone, &raw_uri, request_origin.as_deref()) {
+                Ok(response) => response,
+                Err(ProtocolError::NotFound(_)) => {
+                    log::debug!(
+                        target: "vscodeee::protocol",
+                        "File not found on disk, trying embedded asset: {raw_uri}"
+                    );
+                    match serve_embedded_asset(&app_handle, &raw_uri, request_origin.as_deref()) {
+                        Ok(response) => response,
+                        Err(fallback_err) => {
+                            log::warn!(
+                                target: "vscodeee::protocol",
+                                "Embedded asset fallback also failed: {fallback_err}"
+                            );
+                            error_response(
+                                fallback_err.status_code(),
+                                fallback_err.reason().as_bytes(),
+                                request_origin.as_deref(),
+                            )
+                        }
                     }
                 }
-            }
-            Err(e) => {
-                log::error!(target: "vscodeee::protocol", "{e}");
-                error_response(
-                    e.status_code(),
-                    e.reason().as_bytes(),
-                    request_origin.as_deref(),
-                )
-            }
-        }
+                Err(e) => {
+                    log::error!(target: "vscodeee::protocol", "{e}");
+                    error_response(
+                        e.status_code(),
+                        e.reason().as_bytes(),
+                        request_origin.as_deref(),
+                    )
+                }
+            };
+            responder.respond(response);
+        });
     }
+}
+
+/// Build a 200 OK response with the given MIME type, security headers, and body.
+fn build_ok_response(
+    mime_type: &str,
+    security_headers: &[headers::Header],
+    body: Vec<u8>,
+) -> Result<Response<Vec<u8>>, ProtocolError> {
+    let mut builder = Response::builder()
+        .status(200)
+        .header("Content-Type", mime_type);
+
+    for (key, value) in security_headers {
+        builder = builder.header(key.as_str(), value.as_str());
+    }
+
+    builder
+        .body(body)
+        .map_err(|e| ProtocolError::Internal(format!("failed to build response: {e}")))
 }
 
 /// Internal file-serving logic, separated for testability.
@@ -205,20 +233,10 @@ fn serve_file(
 
     // 4. Compute headers (pass request origin for dynamic CORS)
     let mime_type = mime::mime_from_path(&canonical_path);
-    let security_headers = headers::headers_for_path(&canonical_path, state.is_dev, request_origin);
+    let security_headers = headers::headers_for_path(&canonical_path, request_origin);
 
     // 5. Build response
-    let mut builder = Response::builder()
-        .status(200)
-        .header("Content-Type", mime_type);
-
-    for (key, value) in &security_headers {
-        builder = builder.header(key.as_str(), value.as_str());
-    }
-
-    builder
-        .body(content)
-        .map_err(|e| ProtocolError::Internal(format!("failed to build response: {e}")))
+    build_ok_response(mime_type, &security_headers, content)
 }
 
 /// Extract the Tauri embedded asset key from a decoded URI path.
@@ -254,7 +272,6 @@ fn serve_embedded_asset<R: tauri::Runtime>(
     app_handle: &tauri::AppHandle<R>,
     raw_uri: &str,
     request_origin: Option<&str>,
-    is_dev: bool,
 ) -> Result<Response<Vec<u8>>, ProtocolError> {
     // 1. Parse URI without filesystem canonicalization
     let decoded_path = uri::parse_vscode_file_uri_raw(raw_uri)?;
@@ -282,19 +299,9 @@ fn serve_embedded_asset<R: tauri::Runtime>(
     // Use a synthetic path for header computation so COOP/COEP etc. are applied correctly
     let path = std::path::PathBuf::from(asset_key);
     let mime_type = mime::mime_from_path(&path);
-    let security_headers = headers::headers_for_path(&path, is_dev, request_origin);
+    let security_headers = headers::headers_for_path(&path, request_origin);
 
-    let mut builder = Response::builder()
-        .status(200)
-        .header("Content-Type", mime_type);
-
-    for (key, value) in &security_headers {
-        builder = builder.header(key.as_str(), value.as_str());
-    }
-
-    builder
-        .body(asset.bytes().to_vec())
-        .map_err(|e| ProtocolError::Internal(format!("failed to build response: {e}")))
+    build_ok_response(mime_type, &security_headers, asset.bytes().to_vec())
 }
 
 /// Build a minimal error response with CORS headers.
@@ -302,14 +309,7 @@ fn serve_embedded_asset<R: tauri::Runtime>(
 /// CORS headers are required even on error responses, otherwise WKWebView's
 /// fetch() will report "Load failed" instead of the actual status code.
 fn error_response(status: u16, body: &[u8], request_origin: Option<&str>) -> Response<Vec<u8>> {
-    // Use the same CORS origin resolution as success responses
-    let dummy_path = std::path::PathBuf::from("error");
-    let cors_headers = headers::headers_for_path(&dummy_path, false, request_origin);
-    let cors_origin = cors_headers
-        .iter()
-        .find(|(k, _)| k == "Access-Control-Allow-Origin")
-        .map(|(_, v)| v.as_str())
-        .unwrap_or("tauri://localhost");
+    let cors_origin = headers::resolve_cors_origin(request_origin);
 
     Response::builder()
         .status(status)
@@ -332,10 +332,7 @@ mod tests {
     fn test_state_with_root(root: &std::path::Path) -> ProtocolState {
         let roots = ValidRoots::new();
         roots.add_root(root);
-        ProtocolState {
-            roots,
-            is_dev: true,
-        }
+        ProtocolState { roots }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Switch `vscode-file://` protocol handler from synchronous `register_uri_scheme_protocol` to asynchronous `register_asynchronous_uri_scheme_protocol` with per-request background threads, preventing the main thread from being blocked by file I/O during workbench module loading
- Make `fs_watch_start` an async command using `spawn_blocking` to move `Debouncer::watch()` directory enumeration (`FileIdMap::add_root` → `stat()` on every entry) off the main thread — this was consuming 73% of main thread time per `sample` profiling
- Add `Cache-Control` headers (`max-age=604800` for static assets, `no-cache, no-store` for HTML entry points) to prevent WKWebView from re-requesting hundreds of modules on each load

## Root Cause

macOS `sample` profiling revealed two synchronous bottlenecks saturating the main thread during startup:

1. **Protocol handler**: `WKURLSchemeTask` responses were delivered synchronously; with ~500+ ESM modules to load, the main thread was blocked
2. **File watcher init**: `Debouncer::watch()` → `FileIdMap::add_root()` called `stat()` on every file in watched directories on the main thread

## Test Plan

- [x] `cargo build` passes
- [x] `cargo clippy` passes
- [x] `cargo test -p vscodeee` passes (all protocol/watcher tests)
- [x] Manual: app starts without freeze with no workspace open
- [x] Manual: file watcher still detects changes correctly
- [x] Manual: embedded asset fallback works for production builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)