### PR TITLE
perf: skip unchanged file writes to prevent unnecessary Cargo rebuilds

### DIFF
--- a/build/next/index.ts
+++ b/build/next/index.ts
@@ -667,7 +667,15 @@ async function transpileFile(srcPath: string, destPath: string): Promise<void> {
 	});
 
 	await fs.promises.mkdir(path.dirname(destPath), { recursive: true });
-	await fs.promises.writeFile(destPath, result.code);
+	// Skip write when content is unchanged to avoid updating mtime,
+	// which would trigger Cargo's rerun-if-changed and cause full rebuilds.
+	let existing: string | null = null;
+	try {
+		existing = await fs.promises.readFile(destPath, 'utf-8');
+	} catch { /* file doesn't exist yet */ }
+	if (existing !== result.code) {
+		await fs.promises.writeFile(destPath, result.code);
+	}
 }
 
 async function transpile(outDir: string, excludeTests: boolean): Promise<void> {

--- a/scripts/bundle-node-modules.mjs
+++ b/scripts/bundle-node-modules.mjs
@@ -347,10 +347,31 @@ function collectExtensionDependencies() {
 }
 
 /**
- * Recursively copy a directory.
+ * Copy a file only if the destination content differs from the source.
+ * Avoids updating mtime on unchanged files so Cargo's rerun-if-changed
+ * does not trigger unnecessary rebuilds.
  * @param {string} src
  * @param {string} dest
- * @returns {number} number of files copied
+ * @returns {boolean} true if the file was actually written
+ */
+function copyFileIfChanged(src, dest) {
+	const srcContent = fs.readFileSync(src);
+	try {
+		const destContent = fs.readFileSync(dest);
+		if (srcContent.equals(destContent)) {
+			return false;
+		}
+	} catch { /* dest doesn't exist */ }
+	fs.mkdirSync(path.dirname(dest), { recursive: true });
+	fs.writeFileSync(dest, srcContent);
+	return true;
+}
+
+/**
+ * Recursively copy a directory, skipping files whose content is unchanged.
+ * @param {string} src
+ * @param {string} dest
+ * @returns {number} number of files written (changed or new)
  */
 function copyDirRecursive(src, dest) {
 	if (!fs.existsSync(src)) {
@@ -364,8 +385,9 @@ function copyDirRecursive(src, dest) {
 		if (entry.isDirectory()) {
 			count += copyDirRecursive(srcPath, destPath);
 		} else {
-			fs.copyFileSync(srcPath, destPath);
-			count++;
+			if (copyFileIfChanged(srcPath, destPath)) {
+				count++;
+			}
 		}
 	}
 	return count;
@@ -373,12 +395,12 @@ function copyDirRecursive(src, dest) {
 
 /**
  * Copy a single file, creating parent directories as needed.
+ * Only writes if the content differs from the destination.
  * @param {string} src
  * @param {string} dest
  */
 function copyFile(src, dest) {
-	fs.mkdirSync(path.dirname(dest), { recursive: true });
-	fs.copyFileSync(src, dest);
+	copyFileIfChanged(src, dest);
 }
 
 /**

--- a/scripts/generate-css-modules.mjs
+++ b/scripts/generate-css-modules.mjs
@@ -9,7 +9,7 @@
 // making them inaccessible via filesystem scanning at runtime. The manifest
 // is bundled as a Tauri resource so `list_css_modules` can read it in built apps.
 
-import { readdirSync, writeFileSync } from 'fs';
+import { readdirSync, readFileSync, writeFileSync } from 'fs';
 import { join, relative, sep } from 'path';
 
 function collectCssFiles(dir, root, result) {
@@ -26,5 +26,17 @@ function collectCssFiles(dir, root, result) {
 const modules = [];
 collectCssFiles('out', 'out', modules);
 modules.sort();
-writeFileSync('src-tauri/css-modules.json', JSON.stringify(modules));
-console.log(`Generated css-modules.json with ${modules.length} entries`);
+const content = JSON.stringify(modules);
+const destPath = 'src-tauri/css-modules.json';
+let skipped = false;
+try {
+	const existing = readFileSync(destPath, 'utf8');
+	if (existing === content) {
+		console.log(`css-modules.json unchanged (${modules.length} entries), skipping write`);
+		skipped = true;
+	}
+} catch { /* file doesn't exist yet */ }
+if (!skipped) {
+	writeFileSync(destPath, content);
+	console.log(`Generated css-modules.json with ${modules.length} entries`);
+}


### PR DESCRIPTION
## Summary

`tauri:dev` triggered a full Cargo rebuild on every run because build scripts (transpile, bundle-node-modules, generate-css-modules) unconditionally rewrote all output files even when content was identical. This updated the file mtimes, causing Cargo's `rerun-if-changed` mechanism to detect spurious changes and re-run the build script.

## Changes

- **`build/next/index.ts`**: `transpileFile()` now compares output content with the existing file before writing, skipping the write when unchanged
- **`scripts/bundle-node-modules.mjs`**: Added `copyFileIfChanged()` using `Buffer.equals()` for binary-safe comparison; `copyDirRecursive()` now returns count of files actually written
- **`scripts/generate-css-modules.mjs`**: Compares `JSON.stringify` output with existing file before writing

## How to Test

1. Run `npm run tauri:dev` — first run should compile normally
2. Exit and run `npm run tauri:dev` again — Cargo build should complete in ~2 seconds instead of ~50 seconds
3. Verify the app launches and functions correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)