### PR TITLE
fix: prevent duplicate workspace windows from UI open actions

### DIFF
--- a/src-tauri/src/cli/router.rs
+++ b/src-tauri/src/cli/router.rs
@@ -21,7 +21,7 @@ use crate::window::state::OpenWindowOptions;
 ///
 /// 1. **No paths** — focus the most recently active window
 /// 2. **Paths without flags** — workspace dedup via `WindowManager`
-/// 3. **`force_new_window`** — each path gets a new window regardless
+/// 3. **`-n` / `--new-window`** — sets `skip_dedup`, each path gets a new window regardless
 pub async fn route_gui_args(
     app_handle: &tauri::AppHandle,
     wm: &WindowManager,
@@ -57,6 +57,7 @@ pub async fn route_gui_args(
             remote_authority: None,
             force_new_window: args.force_new_window,
             force_reuse_window: args.force_reuse_window,
+            skip_dedup: args.force_new_window,
         };
 
         match wm.open_window(app_handle, &options).await {

--- a/src-tauri/src/commands/window.rs
+++ b/src-tauri/src/commands/window.rs
@@ -128,12 +128,16 @@ pub struct OpenWindowOptions {
     /// When `true`, always create a new window even if the workspace is already open.
     #[serde(default)]
     pub force_new_window: bool,
+    /// When `true`, skip workspace deduplication. Reserved for CLI `-n` flag.
+    /// Not sent by TypeScript UI calls (defaults to `false` via serde).
+    #[serde(default)]
+    pub skip_dedup: bool,
 }
 
 /// Open a new Tauri window.
 ///
 /// Delegates to `WindowManager` for label generation, workspace dedup,
-/// and registry tracking. If `force_new_window` is false and a window
+/// and registry tracking. If `skip_dedup` is false and a window
 /// already has the requested workspace open, that window is focused instead.
 #[tauri::command]
 pub async fn open_new_window(
@@ -147,6 +151,7 @@ pub async fn open_new_window(
         remote_authority: options.remote_authority.clone(),
         force_new_window: options.force_new_window,
         force_reuse_window: false,
+        skip_dedup: options.skip_dedup,
     };
 
     // Delegate to WindowManager — handles dedup, ID assignment, and registry

--- a/src-tauri/src/window/manager.rs
+++ b/src-tauri/src/window/manager.rs
@@ -78,7 +78,7 @@ impl WindowManager {
 
     /// Create and register a new window. Returns the window ID and label.
     ///
-    /// If `options.workspace_uri` or `options.folder_uri` is set and `force_new_window`
+    /// If `options.workspace_uri` or `options.folder_uri` is set and `skip_dedup`
     /// is false, returns an existing window that already has that workspace open.
     pub async fn open_window(
         &self,
@@ -87,8 +87,8 @@ impl WindowManager {
     ) -> Result<(WindowId, String), String> {
         use tauri::{Manager, WebviewUrl, WebviewWindowBuilder};
 
-        // Workspace deduplication: if not forcing, find existing window with same workspace
-        if !options.force_new_window {
+        // Workspace deduplication: unless explicitly bypassed (CLI -n), find existing
+        if !options.skip_dedup {
             let workspace_key = options
                 .folder_uri
                 .as_deref()

--- a/src-tauri/src/window/state.rs
+++ b/src-tauri/src/window/state.rs
@@ -77,6 +77,11 @@ pub struct OpenWindowOptions {
     /// When `true`, reuse the current window instead of opening a new one.
     #[serde(default)]
     pub force_reuse_window: bool,
+    /// When `true`, skip workspace deduplication and always create a new window.
+    /// Only set by the CLI router when `-n` / `--new-window` is passed.
+    /// The TypeScript UI never sets this, so dedup always runs from the workbench.
+    #[serde(default)]
+    pub skip_dedup: bool,
 }
 
 /// The `window.restoreWindows` setting values from VS Code's settings.json.


### PR DESCRIPTION
## Summary

Fixes a bug where the same workspace could be opened in multiple windows when using UI actions like "Open Recent" (Ctrl+Enter). The root cause was that `force_new_window` controlled both window creation mode and workspace deduplication, causing UI-initiated opens to bypass dedup entirely.

## Related Issue

Closes #379

## Changes

- Add `skip_dedup` flag to `OpenWindowOptions` (both state and command layer)
- Change dedup guard in `WindowManager::open_window()` from `force_new_window` to `skip_dedup`
- CLI `-n` / `--new-window` flag sets `skip_dedup: true` (preserves upstream VS Code behavior)
- TypeScript UI never sets `skip_dedup`, so dedup always runs via `#[serde(default)]`

## How to Test

1. Open a folder in window A
2. Command Palette → "Open Recent" → select the same folder → Ctrl+Enter
3. Expected: window A is focused (no new window)
4. CLI test: `codeee -n /path/to/project` should still open a new window (dedup bypassed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)