### PR TITLE
feat: add splash screen with theme-aware colors and spinner overlay

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -67,6 +67,12 @@ pub struct WindowConfiguration {
     /// Determined by `cfg!(debug_assertions)` — a compile-time constant.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub is_dev_build: Option<bool>,
+    /// Cached theme background color from previous session (e.g. `"#1E1E1E"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub theme_background: Option<String>,
+    /// Cached theme foreground color from previous session (e.g. `"#CCCCCC"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub theme_foreground: Option<String>,
 }
 
 /// Retrieve native host environment information.
@@ -172,6 +178,9 @@ pub async fn get_window_configuration(
     let restored_workspace_uri: Option<String> = None; // workspace files handled separately
     let is_dev_build = cfg!(debug_assertions).then_some(true);
 
+    // Read cached theme colors from previous session for splash screen.
+    let (theme_background, theme_foreground) = read_theme_cache(&app_handle);
+
     Ok(WindowConfiguration {
         window_id,
         log_level: 1, // Info
@@ -181,6 +190,8 @@ pub async fn get_window_configuration(
         restored_folder_uri,
         restored_workspace_uri,
         is_dev_build,
+        theme_background,
+        theme_foreground,
     })
 }
 
@@ -234,6 +245,26 @@ pub struct ProductPackageJson {
     pub package: serde_json::Value,
 }
 
+/// Read and return the contents of `product.json` and `package.json`.
+///
+/// Locates the project root by checking the current working directory first
+/// (development mode: `src-tauri/../`), then falls back to Tauri's resource
+/// directory (production: `_up_/` subdirectory for `../` resource paths).
+///
+/// Additionally injects the git commit hash and version from `package.json`
+/// into `product.json` if they are not already set, ensuring the client
+/// and any remote extension host agree on the same codebase version.
+///
+/// # Returns
+///
+/// A [`ProductPackageJson`] containing the parsed `product.json` and
+/// `package.json` as raw JSON values.
+///
+/// # Errors
+///
+/// Returns a `String` error if:
+/// - The project root cannot be determined (neither CWD nor resource_dir works).
+/// - Either JSON file cannot be read or parsed.
 #[tauri::command]
 pub fn get_product_json(app_handle: tauri::AppHandle) -> Result<ProductPackageJson, String> {
     use tauri::Manager;
@@ -373,4 +404,87 @@ pub fn list_css_modules(app_handle: tauri::AppHandle) -> Vec<String> {
     }
 
     Vec::new()
+}
+
+// ── Theme color cache for splash screen ──────────────────────────────────
+
+use tauri::Manager;
+
+/// Cached theme colors persisted between sessions for the splash screen.
+#[derive(serde::Serialize, serde::Deserialize, Default)]
+struct ThemeColorCache {
+    background: String,
+    foreground: String,
+}
+
+/// Resolve the filesystem path for the splash-screen theme color cache file.
+///
+/// The cache file (`splash-theme-cache.json`) is stored in the application
+/// data directory so that theme colors persist across application restarts.
+///
+/// # Arguments
+///
+/// * `app_handle` - The Tauri application handle used to resolve `app_data_dir`.
+///
+/// # Returns
+///
+/// `Some(PathBuf)` pointing to the cache file, or `None` if the application
+/// data directory cannot be resolved.
+fn theme_cache_path(app_handle: &tauri::AppHandle) -> Option<std::path::PathBuf> {
+    app_handle
+        .path()
+        .app_data_dir()
+        .ok()
+        .map(|d| d.join("splash-theme-cache.json"))
+}
+
+/// Read cached theme colors from the splash-screen theme cache.
+///
+/// Returns the background and foreground color strings that were persisted
+/// by [`cache_theme_colors`] during the previous session. If the cache file
+/// does not exist, cannot be parsed, or contains an empty background color,
+/// returns `(None, None)`.
+///
+/// # Arguments
+///
+/// * `app_handle` - The Tauri application handle used to locate the cache file.
+///
+/// # Returns
+///
+/// A tuple of `(background, foreground)` color strings, or `(None, None)` if
+/// no valid cache is available.
+fn read_theme_cache(app_handle: &tauri::AppHandle) -> (Option<String>, Option<String>) {
+    let path = match theme_cache_path(app_handle) {
+        Some(p) => p,
+        None => return (None, None),
+    };
+    let cache: ThemeColorCache = std::fs::read_to_string(&path)
+        .ok()
+        .and_then(|json| serde_json::from_str(&json).ok())
+        .unwrap_or_default();
+    if cache.background.is_empty() {
+        (None, None)
+    } else {
+        (Some(cache.background), Some(cache.foreground))
+    }
+}
+
+/// Cache theme colors for the next startup's splash screen.
+///
+/// Called from TypeScript after the workbench finishes loading, before
+/// `hideSplash()`. Persists the active theme's background and foreground
+/// colors so the splash screen can use them on next launch.
+#[tauri::command]
+pub fn cache_theme_colors(
+    app_handle: tauri::AppHandle,
+    background: String,
+    foreground: String,
+) -> Result<(), String> {
+    let path = theme_cache_path(&app_handle).ok_or("Cannot resolve app_data_dir")?;
+    let cache = ThemeColorCache {
+        background,
+        foreground,
+    };
+    let json = serde_json::to_string(&cache).map_err(|e| e.to_string())?;
+    std::fs::write(path, json).map_err(|e| e.to_string())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -229,6 +229,7 @@ pub fn run(gui_args: Option<cli::dispatch::ParsedGuiArgs>) {
             commands::get_native_host_info,
             commands::get_window_configuration,
             commands::list_css_modules,
+            commands::cache_theme_colors,
             commands::get_product_json,
             commands::extensions::list_builtin_extensions,
             commands::ipc_channel::ipc_message,
@@ -475,6 +476,12 @@ pub fn run(gui_args: Option<cli::dispatch::ParsedGuiArgs>) {
                 let chrome = window::chrome::WindowChromeConfig::for_platform();
                 if let Some(window) = app.get_webview_window("main") {
                     let _ = window.set_decorations(chrome.decorations);
+                    // Show the window immediately so the user sees the splash
+                    // overlay (spinner + watermark) rendered by inline HTML/CSS.
+                    // hideSplash() in workbench-tauri.ts removes the overlay
+                    // after the workbench finishes loading.
+                    let _ = window.show();
+                    let _ = window.set_focus();
                 }
             }
 

--- a/src-tauri/src/window/manager.rs
+++ b/src-tauri/src/window/manager.rs
@@ -142,6 +142,17 @@ impl WindowManager {
             let _ = _window.set_decorations(true);
         }
 
+        // Defer showing the window to allow tauri-plugin-window-state to
+        // restore the saved geometry first. Without this delay the window
+        // appears at the builder default (1200×800) and then "stretches"
+        // when the plugin applies the restored size.
+        let win = _window.clone();
+        tauri::async_runtime::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            let _ = win.show();
+            let _ = win.set_focus();
+        });
+
         // Register in state
         let workspace_uri = options
             .folder_uri
@@ -387,6 +398,14 @@ impl WindowManager {
         {
             let _ = _window.set_decorations(true);
         }
+
+        // Defer showing the window to allow tauri-plugin-window-state to
+        // restore the saved geometry first (same reason as open_window).
+        let win = _window.clone();
+        tauri::async_runtime::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            let _ = win.show();
+        });
 
         let effective_uri = folder_uri
             .map(String::from)

--- a/src/vs/code/tauri-browser/workbench/workbench-tauri.html
+++ b/src/vs/code/tauri-browser/workbench/workbench-tauri.html
@@ -78,8 +78,48 @@
 			setTimeout(tryInstall, 50);
 		})();
 	</script>
+	<style>
+		@keyframes splash-spin {
+			to { transform: rotate(360deg); }
+		}
+		#splash {
+			position: fixed;
+			inset: 0;
+			display: flex;
+			flex-direction: column;
+			align-items: center;
+			justify-content: center;
+			background-color: rgba(30, 30, 30, 0.75);
+			backdrop-filter: blur(20px);
+			-webkit-backdrop-filter: blur(20px);
+			z-index: 99999;
+			transition: opacity 0.3s ease-out;
+		}
+		#splash.fade-out {
+			opacity: 0;
+		}
+		.splash-watermark {
+			opacity: 0.4;
+			margin-bottom: 24px;
+			user-select: none;
+		}
+		.splash-spinner {
+			width: 28px;
+			height: 28px;
+			border: 2px solid rgba(204, 204, 204, 0.2);
+			border-top-color: #CCCCCC;
+			border-radius: 50%;
+			animation: splash-spin 0.8s linear infinite;
+		}
+	</style>
 	</head>
 <body aria-label="">
+	<div id="splash">
+		<svg class="splash-watermark" width="120" height="120" viewBox="0 0 260 260" xmlns="http://www.w3.org/2000/svg">
+			<text x="130" y="148" text-anchor="middle" font-family="'SF Mono','Menlo','Consolas','Courier New',monospace" font-size="52" font-weight="600" fill="#808080">&lt;eee/&gt;</text>
+		</svg>
+		<div class="splash-spinner"></div>
+	</div>
 </body>
 
 <!-- Bootstrap (non-module): sets up NLS, CSS import maps, then dynamically imports workbench -->

--- a/src/vs/code/tauri-browser/workbench/workbench-tauri.ts
+++ b/src/vs/code/tauri-browser/workbench/workbench-tauri.ts
@@ -67,6 +67,25 @@
 
   //#endregion
 
+  //#region Hide Splash
+
+  /**
+		 * Remove the splash overlay with a fade-out transition.
+		 *
+		 * Called after the workbench finishes loading but before `notify_ready`.
+		 * The splash div is removed from the DOM after the CSS opacity
+		 * transition completes (300ms).
+		 */
+  function hideSplash(): void {
+    const splash = document.getElementById('splash');
+    if (splash) {
+      splash.classList.add('fade-out');
+      setTimeout(() => splash.remove(), 300);
+    }
+  }
+
+  //#endregion
+
   //#region Tauri API — use window.__TAURI__ directly (no npm imports)
 
   /**
@@ -118,6 +137,8 @@
     restoredFolderUri?: string;
     restoredWorkspaceUri?: string;
     isDevBuild?: boolean;
+    themeBackground?: string;
+    themeForeground?: string;
   }
 
   /**
@@ -136,6 +157,15 @@
 
   const windowConfig = await tauri.core.invoke<ITauriWindowConfig>('get_window_configuration');
   const hostInfo = await tauri.core.invoke<ITauriHostInfo>('get_native_host_info');
+
+  // Apply cached theme colors to the splash overlay so it matches
+  // the user's active theme instead of the hardcoded default.
+  if (windowConfig.themeBackground) {
+    const splash = document.getElementById('splash');
+    if (splash) {
+      splash.style.backgroundColor = windowConfig.themeBackground + 'BF'; // 0.75 alpha
+    }
+  }
 
   /**
  * Merged configuration object passed to `TauriDesktopMain`.
@@ -310,15 +340,26 @@
     const main = new desktopModule.TauriDesktopMain(tauriConfig, folderParam ?? undefined, workspaceParam ?? undefined, remoteAuthorityParam ?? undefined);
     await main.open();
 
+    // Cache current theme colors for next startup's splash screen.
+    try {
+      const style = getComputedStyle(document.body);
+      const bg = style.getPropertyValue('--vscode-editor-background').trim() || '#1E1E1E';
+      const fg = style.getPropertyValue('--vscode-editor-foreground').trim() || '#CCCCCC';
+      await tauri.core.invoke('cache_theme_colors', { background: bg, foreground: fg });
+    } catch { /* best-effort */ }
+
     // Notify the Rust backend that the workbench is ready to be shown.
-    // The window is created hidden (visible: false) and only becomes
-    // visible after this call, preventing the "stretching on restore"
-    // effect where the window resizes from default to saved geometry.
+    // The splash overlay is hidden first so the workbench is fully
+    // visible when the geometry validation in notify_ready runs.
+    hideSplash();
     await tauri.core.invoke('notify_ready');
 
     performance.mark('code/didStartWorkbench');
   } catch (error) {
     console.error('[Tauri Bootstrap] Failed to load workbench:', error);
+
+    // Hide splash so the error message is visible
+    hideSplash();
 
     // Show error in the body so the user sees something
     // eslint-disable-next-line no-restricted-syntax

--- a/src/vs/code/tauri-browser/workbench/workbench-tauri.ts
+++ b/src/vs/code/tauri-browser/workbench/workbench-tauri.ts
@@ -77,6 +77,7 @@
 		 * transition completes (300ms).
 		 */
   function hideSplash(): void {
+    // eslint-disable-next-line no-restricted-syntax
     const splash = window.document.getElementById('splash');
     if (splash) {
       splash.classList.add('fade-out');
@@ -161,6 +162,7 @@
   // Apply cached theme colors to the splash overlay so it matches
   // the user's active theme instead of the hardcoded default.
   if (windowConfig.themeBackground) {
+    // eslint-disable-next-line no-restricted-syntax
     const splash = window.document.getElementById('splash');
     if (splash) {
       splash.style.backgroundColor = windowConfig.themeBackground + 'BF'; // 0.75 alpha

--- a/src/vs/code/tauri-browser/workbench/workbench-tauri.ts
+++ b/src/vs/code/tauri-browser/workbench/workbench-tauri.ts
@@ -77,7 +77,7 @@
 		 * transition completes (300ms).
 		 */
   function hideSplash(): void {
-    const splash = document.getElementById('splash');
+    const splash = window.document.getElementById('splash');
     if (splash) {
       splash.classList.add('fade-out');
       setTimeout(() => splash.remove(), 300);
@@ -161,7 +161,7 @@
   // Apply cached theme colors to the splash overlay so it matches
   // the user's active theme instead of the hardcoded default.
   if (windowConfig.themeBackground) {
-    const splash = document.getElementById('splash');
+    const splash = window.document.getElementById('splash');
     if (splash) {
       splash.style.backgroundColor = windowConfig.themeBackground + 'BF'; // 0.75 alpha
     }
@@ -342,7 +342,7 @@
 
     // Cache current theme colors for next startup's splash screen.
     try {
-      const style = getComputedStyle(document.body);
+      const style = getComputedStyle(window.document.body);
       const bg = style.getPropertyValue('--vscode-editor-background').trim() || '#1E1E1E';
       const fg = style.getPropertyValue('--vscode-editor-foreground').trim() || '#CCCCCC';
       await tauri.core.invoke('cache_theme_colors', { background: bg, foreground: fg });


### PR DESCRIPTION
## Summary

Adds an immediately-visible splash screen during the 5-10 second startup delay, replacing the previous invisible window state. The splash uses the user's active theme background color via a persisted cache.

## Related Issue

Closes #389

## Changes

- Add inline CSS splash overlay (`#splash`) with rotating spinner and `<eee/>` letterpress watermark SVG to `workbench-tauri.html`
- Show the main window immediately in `setup()` after chrome application, matching the splash-visible design
- Add `cache_theme_colors` command to persist theme background/foreground colors to `splash-theme-cache.json` between sessions
- Read cached theme colors in `get_window_configuration` and apply them to the splash overlay at startup
- Add `hideSplash()` with 300ms fade-out transition, called before `notify_ready`
- Show dynamic windows (`open_window` / `create_restored_window`) with 50ms deferred `show()` to allow `tauri-plugin-window-state` geometry restoration, preventing the "stretching" animation
- Use `backdrop-filter: blur(20px)` on splash so the workbench theme colors show through, minimizing the visual diff on splash dismissal

## Screenshots / Recording

N/A (visual splash screen changes)

## How to Test

1. Run `npm run tauri:dev` and verify the splash screen appears immediately on launch
2. Change the color theme to a light theme, close and relaunch — verify the splash background adapts to the cached theme color on second launch
3. Open a new window via Open Recent (Ctrl+Enter) — verify the splash appears without a stretching animation
4. Verify the splash fades out smoothly when the workbench finishes loading

🤖 Generated with [Claude Code](https://claude.com/claude-code)