### PR TITLE
fix: resolve hot exit backup and empty file save issues on reload

### DIFF
--- a/src/vs/workbench/services/files/tauri-browser/diskFileSystemProvider.ts
+++ b/src/vs/workbench/services/files/tauri-browser/diskFileSystemProvider.ts
@@ -280,8 +280,9 @@ export class TauriDiskFileSystemProvider extends AbstractDiskFileSystemProvider 
   }
 
   /**
-	 * Closes the file descriptor. If it was opened for writing and has pending
-	 * changes, the buffer is flushed to disk.
+	 * Closes the file descriptor. Always flushes write-mode handles to
+	 * ensure the file content on disk matches the handle buffer, including
+	 * empty content (file truncation).
 	 */
   async close(fd: number): Promise<void> {
     const handle = this.openFiles.get(fd);
@@ -293,7 +294,7 @@ export class TauriDiskFileSystemProvider extends AbstractDiskFileSystemProvider 
     }
 
     try {
-      if (handle.isWrite && handle.dirty) {
+      if (handle.isWrite) {
         await this.writeFile(handle.resource, handle.data, {
           create: true,
           overwrite: true,

--- a/src/vs/workbench/services/lifecycle/tauri-browser/lifecycleService.ts
+++ b/src/vs/workbench/services/lifecycle/tauri-browser/lifecycleService.ts
@@ -255,7 +255,7 @@ export class TauriLifecycleService extends AbstractLifecycleService {
 	 *
 	 * @param reason - The shutdown reason propagated to event listeners.
 	 */
-  private async handleShutdown(reason: ShutdownReason): Promise<void> {
+  private async handleShutdown(reason: ShutdownReason, options?: { skipRustClose?: boolean }): Promise<void> {
     this.logService.info('[lifecycle] Proceeding with shutdown');
 
     this._willShutdown = true;
@@ -316,12 +316,16 @@ export class TauriLifecycleService extends AbstractLifecycleService {
     // Fire final event
     this._onDidShutdown.fire();
 
-    // Tell Rust to save session, unregister, and destroy the window
-    this.logService.info('[lifecycle] Invoking lifecycle_close_confirmed');
-    try {
-      await invoke('lifecycle_close_confirmed');
-    } catch (error) {
-      this.logService.error('[lifecycle] Error invoking lifecycle_close_confirmed', error);
+    // Tell Rust to save session, unregister, and destroy the window.
+    // Skipped for expected shutdowns (e.g., reload) where the Tauri window
+    // stays alive and only the webview reloads.
+    if (!options?.skipRustClose) {
+      this.logService.info('[lifecycle] Invoking lifecycle_close_confirmed');
+      try {
+        await invoke('lifecycle_close_confirmed');
+      } catch (error) {
+        this.logService.error('[lifecycle] Error invoking lifecycle_close_confirmed', error);
+      }
     }
   }
 
@@ -351,13 +355,17 @@ export class TauriLifecycleService extends AbstractLifecycleService {
   /**
 	 * Compatibility with `BrowserHostService` which casts `ILifecycleService`
 	 * to `BrowserLifecycleService` and calls this method directly.
+	 *
+	 * For numeric reasons (RELOAD, LOAD, etc.), runs the full shutdown
+	 * lifecycle so that the backup tracker can persist unsaved changes
+	 * before the page is reloaded.
 	 */
   withExpectedShutdown(reason: ShutdownReason): Promise<void>;
   withExpectedShutdown(reason: { disableShutdownHandling: true }, callback: Function): void;
   withExpectedShutdown(reason: ShutdownReason | { disableShutdownHandling: true }, callback?: Function): Promise<void> | void {
     if (typeof reason === 'number') {
       this.shutdownReason = reason;
-      return this.storageService.flush(WillSaveStateReason.SHUTDOWN);
+      return this.performExpectedShutdown(reason);
     } else {
       this.ignoreBeforeUnload = true;
       try {
@@ -366,6 +374,31 @@ export class TauriLifecycleService extends AbstractLifecycleService {
         this.ignoreBeforeUnload = false;
       }
     }
+  }
+
+  /**
+	 * Runs the full shutdown lifecycle for expected shutdowns (reload, workspace switch).
+	 *
+	 * Unlike the Rust close-requested path, this does NOT invoke
+	 * `lifecycle_close_confirmed` because the Tauri window stays alive.
+	 * Only the webview reloads.
+	 *
+	 * Flow:
+	 * 1. {@link fireBeforeShutdown} — triggers backup tracker to create backups
+	 * 2. If vetoed, returns early (the subsequent `beforeunload` event will
+	 *    block the page reload since `_willShutdown` remains `false`).
+	 * 3. {@link handleShutdown} with `skipRustClose` — full shutdown sequence
+	 *    without destroying the Rust window.
+	 */
+  private async performExpectedShutdown(reason: ShutdownReason): Promise<void> {
+    const veto = await this.fireBeforeShutdown(reason);
+    if (veto) {
+      this.logService.info('[lifecycle] Expected shutdown was vetoed');
+      this._onShutdownVeto.fire();
+      return;
+    }
+
+    await this.handleShutdown(reason, { skipRustClose: true });
   }
 
   /**


### PR DESCRIPTION
## Summary

Two issues prevented Reload Window from preserving editor state correctly:

1. **Hot Exit backup not created on reload**: `TauriLifecycleService.withExpectedShutdown()` only flushed storage without firing `onBeforeShutdown`, so the backup tracker never ran and unsaved changes were lost.
2. **Empty file save not persisted**: `TauriDiskFileSystemProvider.close()` only flushed dirty handles, so saving an empty file via the FD-based write path left the original content on disk.

## Changes

- **`lifecycleService.ts`**: Added `performExpectedShutdown()` method that runs the full shutdown lifecycle (`fireBeforeShutdown` → `handleShutdown`) with a `skipRustClose` option to keep the Tauri window alive during reload. `withExpectedShutdown()` now calls this instead of only flushing storage.
- **`diskFileSystemProvider.ts`**: Changed `close()` to always flush write-mode handles (not just dirty ones), ensuring empty content (file truncation) is persisted correctly.

## How to Test

1. Open any text file, clear all text, run "Reload Window" from command palette → empty file should persist (not revert to original content)
2. Open any text file, clear all text, save with Cmd+S, run "Reload Window" → empty file should persist
3. Open any text file, edit partially (don't save), run "Reload Window" → unsaved changes should be restored
4. Normal window close (click X) should still show dirty file save dialog as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)