### PR TITLE
fix: prevent watermark text selection on splash screen

### DIFF
--- a/src/vs/code/tauri-browser/workbench/workbench-tauri.html
+++ b/src/vs/code/tauri-browser/workbench/workbench-tauri.html
@@ -102,6 +102,8 @@
 			opacity: 0.4;
 			margin-bottom: 24px;
 			user-select: none;
+			-webkit-user-select: none;
+			pointer-events: none;
 		}
 		.splash-spinner {
 			width: 28px;


### PR DESCRIPTION
## Summary
- Add `-webkit-user-select: none` and `pointer-events: none` to `.splash-watermark` CSS to prevent SVG text selection via Cmd+A on macOS WKWebView

Fixes #396

## Test plan
- [ ] Launch app and verify splash screen watermark `<eee/>` is not selectable via Cmd+A
- [ ] Verify splash screen still displays and fades out correctly
- [ ] Verify no visual changes to splash screen appearance

🤖 Generated with [Claude Code](https://claude.com/claude-code)