### PR TITLE
🚀 Release v0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.1] - 2026-05-02
+
+### Fixed
+
+- Prevent watermark text selection on splash screen ([00ebdcd](https://github.com/j4rviscmd/vscodeee/commit/00ebdcd))
+- Resolve hot exit backup and empty file save issues on reload ([#398](https://github.com/j4rviscmd/vscodeee/pull/398))
+- Restore rg binary execute permission stripped by Tauri bundler ([#395](https://github.com/j4rviscmd/vscodeee/pull/395))
+
 ## [0.10.0] - 2026-05-02
 
 ### Added

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-utils/schema.json",
   "productName": "VS Codeee",
   "mainBinaryName": "codeee",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "identifier": "com.vscodeee.app",
   "build": {
     "frontendDist": "../out",


### PR DESCRIPTION
## Summary

Patch release v0.10.1 with bug fixes since v0.10.0.

## Changes

- Fix watermark text selection on splash screen
- Fix hot exit backup and empty file save issues on reload (#398)
- Fix rg binary execute permission stripped by Tauri bundler (#395)

## How to Test

1. Verify splash screen watermark text cannot be selected
2. Verify hot exit backup files are correctly handled on reload
3. Verify ripgrep search works correctly in the built application

🤖 Generated with [Claude Code](https://claude.com/claude-code)