### PR TITLE
perf: skip unnecessary build steps in tauri:dev

### DIFF
--- a/build/next/index.ts
+++ b/build/next/index.ts
@@ -48,6 +48,7 @@ const options = {
 	nls: process.argv.includes('--nls'),
 	manglePrivates: process.argv.includes('--mangle-privates'),
 	excludeTests: process.argv.includes('--exclude-tests'),
+	force: process.argv.includes('--force'),
 	out: getArgValue('--out'),
 	target: getArgValue('--target') ?? 'desktop', // 'desktop' | 'server'
 	sourceMapBaseUrl: getArgValue('--source-map-base-url'),
@@ -300,6 +301,83 @@ async function cleanDir(dir: string): Promise<void> {
 	console.log(`[clean] ${dir}`);
 	await fs.promises.rm(fullPath, { recursive: true, force: true });
 	await fs.promises.mkdir(fullPath, { recursive: true });
+}
+
+// ============================================================================
+// Skip Logic (mtime-based incremental build)
+// ============================================================================
+
+const SKIP_MARKERS_DIR = path.join(REPO_ROOT, '.build', 'skip-markers');
+
+/** Escape special regex characters in a string for use in a RegExp constructor. */
+function escapeRegExp(s: string): string {
+	return s.replace(/[.*+?^${}()|[\]\\/]/g, '\\$&');
+}
+
+/**
+ * Check if any file under `sourceDir` has been modified after the marker's mtime.
+ * Returns true if a source file is newer than the stamp (rebuild needed).
+ *
+ * @param sourceDir - Directory to scan for changes
+ * @param stampPath - Path to the timestamp marker file
+ * @param ignorePatterns - Glob-like patterns to exclude from the check
+ */
+async function hasSourceChanged(sourceDir: string, stampPath: string, ignorePatterns?: string[]): Promise<boolean> {
+	let stampTime: number;
+	try {
+		stampTime = fs.statSync(stampPath).mtimeMs;
+	} catch {
+		return true; // no stamp → must build
+	}
+
+	const ignoreRe = ignorePatterns?.length
+		? new RegExp(ignorePatterns.map(escapeRegExp).join('|'))
+		: undefined;
+	const files = await globAsync('**/*', { cwd: sourceDir, nodir: true });
+	for (const file of files) {
+		if (ignoreRe && ignoreRe.test(file)) {
+			continue;
+		}
+		const filePath = path.join(sourceDir, file);
+		try {
+			const stat = fs.statSync(filePath);
+			if (stat.mtimeMs > stampTime) {
+				return true;
+			}
+		} catch {
+			// file may have been removed between glob and stat
+		}
+	}
+	return false;
+}
+
+/**
+ * Determine whether a build step can be skipped based on source file mtimes.
+ * Returns true when `--force` is not set, a stamp file exists, and no source
+ * file in any of `sourceDirs` has been modified since the stamp was written.
+ *
+ * @param stepName - Identifier used for the stamp file name (e.g. 'transpile')
+ * @param sourceDirs - Directories whose mtime is checked against the stamp
+ * @param ignorePatterns - Glob-like patterns to exclude from the mtime check
+ */
+async function canSkip(stepName: string, sourceDirs: string[], ignorePatterns?: string[]): Promise<boolean> {
+	if (options.force) {
+		return false;
+	}
+	const stampPath = path.join(SKIP_MARKERS_DIR, `${stepName}.stamp`);
+	if (!fs.existsSync(stampPath)) {
+		return false;
+	}
+	const results = await Promise.all(sourceDirs.map(d => hasSourceChanged(d, stampPath, ignorePatterns)));
+	return !results.some(Boolean);
+}
+
+/** Write a timestamp stamp file so future runs can skip this step via `canSkip()`. */
+function markComplete(stepName: string): void {
+	fs.mkdirSync(SKIP_MARKERS_DIR, { recursive: true });
+	const stampPath = path.join(SKIP_MARKERS_DIR, `${stepName}.stamp`);
+	fs.writeFileSync(stampPath, new Date().toISOString());
+	console.log(`[skip] ${stepName} marked complete`);
 }
 
 /**
@@ -1716,12 +1794,16 @@ Examples:
 
 async function main(): Promise<void> {
 	const t1 = Date.now();
+	let skipped = false;
 
 	try {
 		switch (command) {
 			case 'transpile':
 				if (options.watch) {
 					await watch();
+				} else if (await canSkip('transpile', [path.join(REPO_ROOT, SRC_DIR)])) {
+					console.log('✅ [transpile] Skipped (no source changes)');
+					skipped = true;
 				} else {
 					const outDir = options.out ?? OUT_DIR;
 					await cleanDir(outDir);
@@ -1738,14 +1820,21 @@ async function main(): Promise<void> {
 					await copyCodiconFont(outDir);
 					await buildConsoleInterceptor(outDir);
 					console.log(`[transpile] Done in ${Date.now() - t1}ms`);
+					markComplete('transpile');
 				}
 				break;
 
 		case 'transpile-extensions': {
-				console.log(`[transpile-extensions] Transpiling built-in extensions...`);
-				const t1 = Date.now();
-				await transpileExtensions();
-				console.log(`[transpile-extensions] Done in ${Date.now() - t1}ms`);
+				if (await canSkip('transpile-extensions', [path.join(REPO_ROOT, 'extensions')], ['dist/', '/out/', 'node_modules/'])) {
+					console.log('✅ [transpile-extensions] Skipped (no source changes)');
+					skipped = true;
+				} else {
+					console.log(`[transpile-extensions] Transpiling built-in extensions...`);
+					const t1 = Date.now();
+					await transpileExtensions();
+					console.log(`[transpile-extensions] Done in ${Date.now() - t1}ms`);
+					markComplete('transpile-extensions');
+				}
 				break;
 			}
 
@@ -1758,10 +1847,16 @@ async function main(): Promise<void> {
 			}
 
 			case 'package-extensions': {
-				console.log(`[package-extensions] Packaging built-in extensions for Tauri...`);
-				const t1 = Date.now();
-				await packageExtensions();
-				console.log(`[package-extensions] Done in ${Date.now() - t1}ms`);
+				if (await canSkip('package-extensions', [path.join(REPO_ROOT, 'extensions')], ['dist/', '/out/', 'node_modules/'])) {
+					console.log('✅ [package-extensions] Skipped (no source changes)');
+					skipped = true;
+				} else {
+					console.log(`[package-extensions] Packaging built-in extensions for Tauri...`);
+					const t1 = Date.now();
+					await packageExtensions();
+					console.log(`[package-extensions] Done in ${Date.now() - t1}ms`);
+					markComplete('package-extensions');
+				}
 				break;
 			}
 
@@ -1774,7 +1869,7 @@ async function main(): Promise<void> {
 				process.exit(command ? 1 : 0);
 		}
 
-		if (!options.watch) {
+		if (!options.watch && !skipped) {
 			console.log(`\n✓ Total: ${Date.now() - t1}ms`);
 		}
 	} catch (err) {

--- a/build/next/index.ts
+++ b/build/next/index.ts
@@ -1802,6 +1802,7 @@ async function main(): Promise<void> {
 				if (options.watch) {
 					await watch();
 				} else if (await canSkip('transpile', [path.join(REPO_ROOT, SRC_DIR)])) {
+					// allow-any-unicode-next-line
 					console.log('✅ [transpile] Skipped (no source changes)');
 					skipped = true;
 				} else {
@@ -1826,6 +1827,7 @@ async function main(): Promise<void> {
 
 		case 'transpile-extensions': {
 				if (await canSkip('transpile-extensions', [path.join(REPO_ROOT, 'extensions')], ['dist/', '/out/', 'node_modules/'])) {
+					// allow-any-unicode-next-line
 					console.log('✅ [transpile-extensions] Skipped (no source changes)');
 					skipped = true;
 				} else {
@@ -1848,6 +1850,7 @@ async function main(): Promise<void> {
 
 			case 'package-extensions': {
 				if (await canSkip('package-extensions', [path.join(REPO_ROOT, 'extensions')], ['dist/', '/out/', 'node_modules/'])) {
+					// allow-any-unicode-next-line
 					console.log('✅ [package-extensions] Skipped (no source changes)');
 					skipped = true;
 				} else {

--- a/build/npm/postinstall.ts
+++ b/build/npm/postinstall.ts
@@ -442,7 +442,7 @@ function configureGitSettings() {
  */
 async function main() {
 	if (!process.env['VSCODE_FORCE_INSTALL'] && isUpToDate()) {
-		log('.', 'All dependencies up to date, skipping postinstall.');
+		console.log('✅ [postinstall] Dependencies up to date');
 		configureGitSettings();
 		return;
 	}

--- a/build/npm/postinstall.ts
+++ b/build/npm/postinstall.ts
@@ -442,6 +442,7 @@ function configureGitSettings() {
  */
 async function main() {
 	if (!process.env['VSCODE_FORCE_INSTALL'] && isUpToDate()) {
+		// allow-any-unicode-next-line
 		console.log('✅ [postinstall] Dependencies up to date');
 		configureGitSettings();
 		return;

--- a/build/npm/preinstall.ts
+++ b/build/npm/preinstall.ts
@@ -56,6 +56,7 @@ if (npmVersionMatch) {
 // Fast path: if nothing changed since last successful install, skip everything.
 // This makes `npm i` near-instant when dependencies haven't changed.
 if (!process.env['VSCODE_FORCE_INSTALL'] && isUpToDate()) {
+	// allow-any-unicode-next-line
 	console.log('✅ [preinstall] Dependencies up to date');
 	process.exit(0);
 }

--- a/build/npm/preinstall.ts
+++ b/build/npm/preinstall.ts
@@ -56,7 +56,7 @@ if (npmVersionMatch) {
 // Fast path: if nothing changed since last successful install, skip everything.
 // This makes `npm i` near-instant when dependencies haven't changed.
 if (!process.env['VSCODE_FORCE_INSTALL'] && isUpToDate()) {
-	console.log(`\x1b[32mAll dependencies up to date.\x1b[0m ${forceInstallMessage}`);
+	console.log('✅ [preinstall] Dependencies up to date');
 	process.exit(0);
 }
 

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
 		"symlink-local-component-explorer": "npm install ../vscode-packages/js-component-explorer/packages/explorer ../vscode-packages/js-component-explorer/packages/cli --no-save && cd build/rspack && npm install ../../../vscode-packages/js-component-explorer/packages/webpack-plugin ../../../vscode-packages/js-component-explorer/packages/explorer --no-save && cd ../vite && npm install ../../../vscode-packages/js-component-explorer/packages/vite-plugin ../../../vscode-packages/js-component-explorer/packages/explorer --no-save",
 		"install-latest-component-explorer": "npm install @vscode/component-explorer@next @vscode/component-explorer-cli@next && cd build/rspack && npm install @vscode/component-explorer-webpack-plugin@next @vscode/component-explorer@next && cd ../vite && npm install @vscode/component-explorer-vite-plugin@next @vscode/component-explorer@next",
 		"tauri": "tauri",
-		"tauri:dev": "npm install && bash scripts/check-csp-hash.sh && node scripts/download-node.mjs && node scripts/bundle-node-modules.mjs && node build/next/index.ts transpile && node build/next/index.ts transpile-extensions && node build/next/index.ts package-extensions && node scripts/generate-css-modules.mjs && tauri dev",
+		"tauri:dev": "npm install --silent || npm install && bash scripts/check-csp-hash.sh && node scripts/download-node.mjs && node scripts/bundle-node-modules.mjs && node build/next/index.ts transpile && node build/next/index.ts transpile-extensions && node build/next/index.ts package-extensions && node scripts/generate-css-modules.mjs && tauri dev",
 		"tauri:build": "npm install && bash scripts/check-csp-hash.sh && tauri build"
 	},
 	"dependencies": {

--- a/scripts/bundle-node-modules.mjs
+++ b/scripts/bundle-node-modules.mjs
@@ -446,6 +446,7 @@ function main() {
 		const stampTime = fs.statSync(stampPath).mtimeMs;
 		const lockfile = path.join(REPO_ROOT, 'package-lock.json');
 		if (!fs.existsSync(lockfile) || fs.statSync(lockfile).mtimeMs <= stampTime) {
+			// allow-any-unicode-next-line
 			console.log('✅ [bundle-node-modules] Skipped (no changes)');
 			return;
 		}

--- a/scripts/bundle-node-modules.mjs
+++ b/scripts/bundle-node-modules.mjs
@@ -422,7 +422,11 @@ function copyPackage(pkgName) {
 /**
  * Main entry point for the node_modules bundling script.
  *
- * Executes two phases:
+ * Skip logic: if `--force` is not set and a stamp file exists that is newer
+ * than `package-lock.json`, the entire step is skipped. This avoids redundant
+ * copies when neither dependencies nor the bundling logic have changed.
+ *
+ * Executes two phases when a rebuild is needed:
  * 1. Copies core modules (specific files/directories) listed in `CORE_MODULES`
  *    from `node_modules/` to `src-tauri/node_modules/`.
  * 2. Auto-discovers all extension dependencies (including transitive ones) via
@@ -432,7 +436,21 @@ function copyPackage(pkgName) {
  * Supports a `--clean` flag to remove the staging directory before bundling.
  * Logs progress, skipped modules, and final statistics (file count, total size).
  */
+const SKIP_MARKERS_DIR = path.join(REPO_ROOT, '.build', 'skip-markers');
+
 function main() {
+	const force = process.argv.includes('--force');
+	const stampPath = path.join(SKIP_MARKERS_DIR, 'bundle-node-modules.stamp');
+
+	if (!force && fs.existsSync(stampPath)) {
+		const stampTime = fs.statSync(stampPath).mtimeMs;
+		const lockfile = path.join(REPO_ROOT, 'package-lock.json');
+		if (!fs.existsSync(lockfile) || fs.statSync(lockfile).mtimeMs <= stampTime) {
+			console.log('✅ [bundle-node-modules] Skipped (no changes)');
+			return;
+		}
+	}
+
 	console.log('[bundle-node-modules] Bundling required node_modules for Tauri build...');
 
 	// Guard: If TARGET_DIR is a symlink (e.g. -> ../node_modules created by
@@ -607,6 +625,10 @@ function main() {
 	if (skipped > 0) {
 		console.log(`[bundle-node-modules] ${skipped} module(s) not found (may be optional)`);
 	}
+
+	// Mark as complete for skip detection on next run
+	fs.mkdirSync(SKIP_MARKERS_DIR, { recursive: true });
+	fs.writeFileSync(stampPath, new Date().toISOString());
 }
 
 main();

--- a/scripts/check-csp-hash.sh
+++ b/scripts/check-csp-hash.sh
@@ -72,6 +72,7 @@ print(match.group(1))
 
 # Compare
 if [ "$COMPUTED_HASH" = "$CSP_HASH" ]; then
+// allow-any-unicode-next-line
     echo "✅ [check-csp-hash] Hash matches"
     exit 0
 else

--- a/scripts/check-csp-hash.sh
+++ b/scripts/check-csp-hash.sh
@@ -72,7 +72,7 @@ print(match.group(1))
 
 # Compare
 if [ "$COMPUTED_HASH" = "$CSP_HASH" ]; then
-    echo "[OK] CSP hash matches: sha256-$CSP_HASH"
+    echo "✅ [check-csp-hash] Hash matches"
     exit 0
 else
     echo "ERROR: CSP hash mismatch in webWorkerExtensionHostIframe.html" >&2

--- a/scripts/download-node.mjs
+++ b/scripts/download-node.mjs
@@ -222,8 +222,7 @@ async function main() {
 		const sizeMB = stat.size / 1024 / 1024;
 
 		if (stat.size >= MIN_VALID_SIZE) {
-			console.log(`[download-node] Node.js binary already exists: ${destPath} (${sizeMB.toFixed(1)} MB)`);
-			console.log(`[download-node] Delete it to re-download.`);
+			console.log(`✅ [download-node] Already exists (${sizeMB.toFixed(1)} MB)`);
 			return;
 		}
 

--- a/scripts/download-node.mjs
+++ b/scripts/download-node.mjs
@@ -222,6 +222,7 @@ async function main() {
 		const sizeMB = stat.size / 1024 / 1024;
 
 		if (stat.size >= MIN_VALID_SIZE) {
+// allow-any-unicode-next-line
 			console.log(`✅ [download-node] Already exists (${sizeMB.toFixed(1)} MB)`);
 			return;
 		}

--- a/scripts/generate-css-modules.mjs
+++ b/scripts/generate-css-modules.mjs
@@ -32,6 +32,7 @@ let skipped = false;
 try {
 	const existing = readFileSync(destPath, 'utf8');
 	if (existing === content) {
+		// allow-any-unicode-next-line
 		console.log(`✅ [generate-css-modules] Unchanged (${modules.length} entries)`);
 		skipped = true;
 	}

--- a/scripts/generate-css-modules.mjs
+++ b/scripts/generate-css-modules.mjs
@@ -32,7 +32,7 @@ let skipped = false;
 try {
 	const existing = readFileSync(destPath, 'utf8');
 	if (existing === content) {
-		console.log(`css-modules.json unchanged (${modules.length} entries), skipping write`);
+		console.log(`✅ [generate-css-modules] Unchanged (${modules.length} entries)`);
 		skipped = true;
 	}
 } catch { /* file doesn't exist yet */ }


### PR DESCRIPTION
## Summary

Skip build steps that haven't changed since the last successful run in the `tauri:dev` pipeline, significantly reducing iteration time when no source files were modified.

## Related Issue

Closes #394

## Changes

- Add mtime-based incremental build detection to `build/next/index.ts` for `transpile`, `transpile-extensions`, and `package-extensions` commands
- Add stamp file skip logic to `scripts/bundle-node-modules.mjs` with `package-lock.json` mtime comparison
- Add `--force` flag to override skip detection when a clean rebuild is needed
- Unify all skip messages with ✅ prefix for clean, scannable output
- Suppress `npm install` noise with `--silent` flag (errors re-displayed on failure)

## How to Test

1. Run `npm run tauri:dev` — first run builds normally
2. Stop and run `npm run tauri:dev` again — all build steps should show ✅ skip messages
3. Modify any file under `src/` and run again — only `transpile` should rebuild
4. Run `node build/next/index.ts transpile --force` — forced rebuild regardless of stamp

🤖 Generated with [Claude Code](https://claude.com/claude-code)