### PR TITLE
fix: use shell comment syntax for unicode suppression in check-csp-hash.sh

### DIFF
--- a/scripts/check-csp-hash.sh
+++ b/scripts/check-csp-hash.sh
@@ -72,7 +72,7 @@ print(match.group(1))
 
 # Compare
 if [ "$COMPUTED_HASH" = "$CSP_HASH" ]; then
-// allow-any-unicode-next-line
+# allow-any-unicode-next-line
     echo "✅ [check-csp-hash] Hash matches"
     exit 0
 else


### PR DESCRIPTION
## Summary
- Fix `// allow-any-unicode-next-line` in shell script to use `#` comment syntax instead
- The `//` was interpreted as a directory path, causing `tauri:dev` to fail with "line 75: //: Is a directory"

## Test plan
- [x] `npm run gulp hygiene` passes
- [ ] `npm run tauri:dev` runs without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)