### PR TITLE
perf: fix progressive performance degradation

### DIFF
--- a/src-tauri/src/commands/spawn_exthost.rs
+++ b/src-tauri/src/commands/spawn_exthost.rs
@@ -68,6 +68,8 @@ struct ExtHostInstance {
     sidecar: crate::exthost::sidecar::ExtHostSidecar,
     /// Handle to the WebSocket relay task.
     relay_task: tokio::task::JoinHandle<()>,
+    /// Handle to the background watchdog task that polls the child process.
+    watchdog_task: tokio::task::JoinHandle<()>,
 }
 
 /// Managed state for tracking multiple running Extension Host instances.
@@ -109,6 +111,7 @@ impl ExtHostState {
                 target: "vscodeee::commands::spawn_exthost",
                 "Killing ExtHost instance {id} (shutdown)"
             );
+            inst.watchdog_task.abort();
             inst.relay_task.abort();
             let _ = inst.sidecar.child.kill().await;
             let _ = inst.sidecar.child.wait().await;
@@ -236,54 +239,61 @@ async fn spawn_exthost_with_relay_unix(
     let ws_port = relay_handle.port;
 
     // Store instance for later cleanup
-    {
-        let mut instances = exthost_state.instances.lock().await;
-        instances.insert(
-            instance_id,
-            ExtHostInstance {
-                sidecar,
-                relay_task: relay_handle.task,
-            },
-        );
-    }
+    let state_arc = Arc::clone(&exthost_state);
 
     // Spawn a background watchdog that polls the ExtHost process every 500ms.
     // If the child exits unexpectedly (e.g. crash, OOM), an error is logged
     // and the instance is removed from state. The watchdog terminates when
     // the process exits or the instance is cleaned up.
-    let state_clone = Arc::clone(&exthost_state);
-    tokio::spawn(async move {
-        // Give the process a moment to start, then check periodically
-        tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
-        loop {
-            tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
-            let mut instances = state_clone.instances.lock().await;
-            if let Some(ref mut inst) = instances.get_mut(&instance_id) {
-                match inst.sidecar.child.try_wait() {
-                    Ok(Some(status)) => {
-                        log::error!(
-                            target: "vscodeee::commands::spawn_exthost",
-                            "ExtHost instance {instance_id} (PID={pid}) EXITED with status: {status}"
-                        );
-                        if let Some(dead) = instances.remove(&instance_id) {
-                            dead.relay_task.abort();
+    let watchdog_task = {
+        let state_clone = Arc::clone(&exthost_state);
+        tokio::spawn(async move {
+            // Give the process a moment to start, then check periodically
+            tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+            loop {
+                tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+                let mut instances = state_clone.instances.lock().await;
+                if let Some(ref mut inst) = instances.get_mut(&instance_id) {
+                    match inst.sidecar.child.try_wait() {
+                        Ok(Some(status)) => {
+                            log::error!(
+                                target: "vscodeee::commands::spawn_exthost",
+                                "ExtHost instance {instance_id} (PID={pid}) EXITED with status: {status}"
+                            );
+                            if let Some(dead) = instances.remove(&instance_id) {
+                                dead.watchdog_task.abort();
+                                dead.relay_task.abort();
+                            }
+                            break;
                         }
-                        break;
+                        Ok(None) => {}
+                        Err(e) => {
+                            log::error!(
+                                target: "vscodeee::commands::spawn_exthost",
+                                "Failed to check ExtHost instance {instance_id} status: {e}"
+                            );
+                            break;
+                        }
                     }
-                    Ok(None) => {}
-                    Err(e) => {
-                        log::error!(
-                            target: "vscodeee::commands::spawn_exthost",
-                            "Failed to check ExtHost instance {instance_id} status: {e}"
-                        );
-                        break;
-                    }
+                } else {
+                    break;
                 }
-            } else {
-                break;
             }
-        }
-    });
+        })
+    };
+
+    // Store instance for later cleanup
+    {
+        let mut instances = state_arc.instances.lock().await;
+        instances.insert(
+            instance_id,
+            ExtHostInstance {
+                sidecar,
+                relay_task: relay_handle.task,
+                watchdog_task,
+            },
+        );
+    }
 
     log::info!(
         target: "vscodeee::commands::spawn_exthost",
@@ -326,6 +336,7 @@ pub async fn kill_exthost(
                 target: "vscodeee::commands::spawn_exthost",
                 "Killing ExtHost instance {instance_id}"
             );
+            inst.watchdog_task.abort();
             inst.relay_task.abort();
             let _ = inst.sidecar.child.kill().await;
             let _ = inst.sidecar.child.wait().await;
@@ -366,6 +377,7 @@ pub async fn kill_all_exthosts(
                 target: "vscodeee::commands::spawn_exthost",
                 "Killing ExtHost instance {id} (shutdown)"
             );
+            inst.watchdog_task.abort();
             inst.relay_task.abort();
             let _ = inst.sidecar.child.kill().await;
             let _ = inst.sidecar.child.wait().await;

--- a/src-tauri/src/pty/instance.rs
+++ b/src-tauri/src/pty/instance.rs
@@ -130,10 +130,12 @@ impl PtyInstance {
     /// * `config` — Shell, working directory, and terminal dimensions
     /// * `app_handle` — Tauri app handle for emitting events
     /// * `auto_reply` — Shared auto-reply interceptor (optional, pass None to disable)
+    /// * `on_exit` — Callback invoked once when the reader thread detects shell exit
     pub fn spawn(
         config: PtyConfig,
         app_handle: tauri::AppHandle,
         auto_reply: Option<Arc<AutoReplyInterceptor>>,
+        on_exit: Option<Box<dyn FnOnce() + Send>>,
     ) -> Result<Self, String> {
         let pty_system = native_pty_system();
 
@@ -264,6 +266,11 @@ impl PtyInstance {
                         break;
                     }
                 }
+            }
+
+            // Notify the manager that this PTY has exited so it can clean up.
+            if let Some(callback) = on_exit {
+                callback();
             }
         });
 

--- a/src-tauri/src/pty/manager.rs
+++ b/src-tauri/src/pty/manager.rs
@@ -24,7 +24,7 @@ use super::state::TerminalStateStore;
 /// This is registered as Tauri managed state and accessed via
 /// `app_handle.state::<PtyManager>()` in command handlers.
 pub struct PtyManager {
-    instances: Mutex<HashMap<u32, PtyInstance>>,
+    instances: Arc<Mutex<HashMap<u32, PtyInstance>>>,
     next_id: AtomicU32,
     /// Shared auto-reply interceptor for all PTY instances.
     auto_reply: Arc<AutoReplyInterceptor>,
@@ -36,7 +36,7 @@ impl PtyManager {
     /// Create a new, empty PTY manager.
     pub fn new() -> Self {
         Self {
-            instances: Mutex::new(HashMap::new()),
+            instances: Arc::new(Mutex::new(HashMap::new())),
             next_id: AtomicU32::new(1),
             auto_reply: Arc::new(AutoReplyInterceptor::new()),
             state_store: Mutex::new(None),
@@ -84,7 +84,24 @@ impl PtyManager {
             env,
         };
 
-        let instance = PtyInstance::spawn(config, app_handle, Some(Arc::clone(&self.auto_reply)))?;
+        // Clone the Arc so the cleanup closure can remove the instance from the map
+        // when the reader thread detects shell exit.
+        let instances_ref = Arc::clone(&self.instances);
+        let cleanup_id = id;
+        let on_exit: Box<dyn FnOnce() + Send> = Box::new(move || {
+            if let Ok(mut instances) = instances_ref.lock() {
+                if instances.remove(&cleanup_id).is_some() {
+                    log::info!(target: "vscodeee::pty::manager", "Auto-cleaned PTY instance {cleanup_id}");
+                }
+            }
+        });
+
+        let instance = PtyInstance::spawn(
+            config,
+            app_handle,
+            Some(Arc::clone(&self.auto_reply)),
+            Some(on_exit),
+        )?;
 
         let mut instances = self
             .instances

--- a/src/vs/workbench/services/storage/tauri-browser/tauriStorageService.ts
+++ b/src/vs/workbench/services/storage/tauri-browser/tauriStorageService.ts
@@ -11,6 +11,7 @@ import { ILogService } from '../../../../platform/log/common/log.js';
 import { isUserDataProfile, IUserDataProfile } from '../../../../platform/userDataProfile/common/userDataProfile.js';
 import { IAnyWorkspaceIdentifier } from '../../../../platform/workspace/common/workspace.js';
 import { IUserDataProfileService } from '../../userDataProfile/common/userDataProfile.js';
+import { getActiveWindow } from '../../../../base/browser/dom.js';
 import { TauriFileStorageDatabase } from './fileStorageDatabase.js';
 import { IBrowserWorkbenchEnvironmentService } from '../../environment/browser/environmentService.js';
 
@@ -179,7 +180,7 @@ export class TauriStorageService extends AbstractStorageService {
   }
 
   protected override shouldFlushWhenIdle(): boolean {
-    return true;
+    return getActiveWindow().document.hasFocus();
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes progressive performance degradation that worsens over time by addressing three root causes:

1. **TauriStorageService**: `shouldFlushWhenIdle()` always returned `true`, causing unconditional 5-second flush cycles that trigger 50+ `onWillSaveState` listeners. Now checks `document.hasFocus()` to skip flushes when the window is unfocused (same pattern as upstream `BrowserStorageService`).

2. **PTY instance cleanup**: Shell exit was detected by the reader thread but the instance was never removed from `PtyManager`'s HashMap, causing a memory leak on repeated terminal open/close. Added `on_exit` callback that auto-removes the instance.

3. **ExtHost watchdog task**: Watchdog `JoinHandle` was not stored, preventing proper cleanup on kill. Now stored in `ExtHostInstance` and aborted on all cleanup paths.

## Changes

- `tauriStorageService.ts`: `shouldFlushWhenIdle()` now returns `getActiveWindow().document.hasFocus()`
- `pty/instance.rs`: Added `on_exit: Option<Box<dyn FnOnce() + Send>>` parameter to `spawn()`, called after reader thread exits
- `pty/manager.rs`: Changed `instances` to `Arc<Mutex<>>` to share with cleanup closure
- `spawn_exthost.rs`: Added `watchdog_task` field to `ExtHostInstance`, abort on all kill paths

## How to Test

1. Launch app, verify normal operation (settings save, extensions work)
2. Open/close terminal 3-5 times, verify no performance degradation
3. Switch away from the window for 30+ seconds, switch back — verify no data loss
4. Use app for 15+ minutes — verify no progressive slowdown