### PR TITLE
fix: align bundle.resources path with bundle-node-modules output directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,14 +196,14 @@ jobs:
       # Create empty out/ directory so tauri::generate_context!() can resolve frontendDist: "../out"
       # Create empty css-modules.json so bundle.resources validation passes
       # Create empty node sidecar stub so externalBin validation passes
-      # Create empty node_modules/ stub so bundle.resources "node_modules/" validation passes
+      # Create empty node_modules/ stub so bundle.resources "target/debug/node_modules/" validation passes
       - name: Create build stubs
         run: |
           mkdir -p out
           echo '[]' > src-tauri/css-modules.json
           mkdir -p src-tauri/binaries
           touch src-tauri/binaries/node-x86_64-unknown-linux-gnu
-          mkdir -p src-tauri/node_modules
+          mkdir -p src-tauri/target/debug/node_modules
 
       - name: Install system dependencies
         run: |

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -52,7 +52,14 @@
     "createUpdaterArtifacts": true,
     "targets": "all",
     "externalBin": ["binaries/node"],
-    "resources": ["css-modules.json", "../product.json", "../package.json", "../out", "../.build/extensions", "node_modules/"],
+    "resources": {
+      "css-modules.json": "css-modules.json",
+      "../product.json": "product.json",
+      "../package.json": "package.json",
+      "../out": "out",
+      "../.build/extensions": ".build/extensions",
+      "target/debug/node_modules/": "node_modules/"
+    },
     "icon": [
       "icons/icon.icns",
       "icons/icon.ico",


### PR DESCRIPTION
## Summary

The `bundle-node-modules.mjs` refactoring (#406, #407) moved the staging directory from `src-tauri/node_modules` to `src-tauri/target/debug/node_modules`, but `tauri.conf.json` still referenced the old path via `"node_modules/"` in `bundle.resources`. This caused `resource path 'node_modules' doesn't exist` errors on Windows CI publish builds.

## Changes

- Switch `bundle.resources` from array to map notation so that `target/debug/node_modules/` is mapped to `node_modules/` in `$RESOURCE`, preserving both the `cargo clean` integration and runtime path resolution via the `vscode-file://` protocol handler
- Update CI stub creation path to match the new source location (`src-tauri/target/debug/node_modules`)

## How to Test

1. Verify Windows publish build succeeds: check that the `publish-tauri (windows-latest, --bundles nsis)` job completes without `resource path` errors
2. Verify the bundled app resolves `node_modules` at runtime: open the app and confirm syntax highlighting and terminal work (these depend on `vscode-oniguruma` and `xterm` from `node_modules`)
3. Verify CI lint job still passes: the stub directory is created at the correct path

🤖 Generated with [Claude Code](https://claude.com/claude-code)