### PR TITLE
chore: release v0.11.0 (re-release with #413, #414)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Show shutdown overlay during app closing for better UX feedback
+- Show splash screen immediately on Reload Window and quit ([#413](https://github.com/j4rviscmd/vscodeee/pull/413))
 
 ### Fixed
 
+- Align bundle.resources path with bundle-node-modules output directory ([#414](https://github.com/j4rviscmd/vscodeee/pull/414))
 - Preserve workspace on Reload Window ([#410](https://github.com/j4rviscmd/vscodeee/issues/410))
 - Resolve syntax error and EISDIR in bundle-node-modules.mjs ([#407](https://github.com/j4rviscmd/vscodeee/issues/407))
 - Use hash-based skip detection in bundle-node-modules ([#406](https://github.com/j4rviscmd/vscodeee/issues/406))


### PR DESCRIPTION
## Summary

Re-release v0.11.0 to include two PRs that were merged after the original release:

- **#413** feat: show splash screen immediately on Reload Window and quit
- **#414** fix: align bundle.resources path with bundle-node-modules output directory (Windows CI publish fix)

## Pre-merge Checklist

Before merging, the existing v0.11.0 release and tag must be deleted so the release workflow can create a new one:

```bash
gh release delete v0.11.0
git push origin :refs/tags/v0.11.0
```

## Changes

- Updated CHANGELOG.md with entries for #413 and #414

## How to Test

1. Verify Windows publish build succeeds after merging (the original v0.11.0 failed on Windows)
2. Verify splash screen appears on Reload Window and quit
3. Verify the published installer works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)