### PR TITLE
chore: release v0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.1] - 2026-05-03
+
+### Fixed
+
+- Revert `bundle.resources` to array notation and restore node_modules staging path to fix broken built-in extension resolution in production builds ([#416](https://github.com/j4rviscmd/vscodeee/pull/416))
+
+### Changed
+
+- Move symlink guard before skip-logic in `bundle-node-modules.mjs` so stale npm symlinks are always removed
+
 ## [0.11.0] - 2026-05-02
 
 ### Added

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-utils/schema.json",
   "productName": "VS Codeee",
   "mainBinaryName": "codeee",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "identifier": "com.vscodeee.app",
   "build": {
     "frontendDist": "../out",


### PR DESCRIPTION
## Summary

Patch release to fix broken built-in extension resolution in production builds caused by PR #414's map notation change.

## Changes

- Revert `bundle.resources` from map notation to array notation in `tauri.conf.json` ([#416](https://github.com/j4rviscmd/vscodeee/pull/416))
- Move symlink guard before skip-logic in `bundle-node-modules.mjs` ([#416](https://github.com/j4rviscmd/vscodeee/pull/416))
- Add `TARGET_DIR` existence check to skip condition ([#416](https://github.com/j4rviscmd/vscodeee/pull/416))

## How to Test

1. Download and install the built app from the release artifacts
2. Verify built-in extensions load correctly (no "unknown extension" errors)
3. Verify syntax highlighting and terminal work (depend on `vscode-oniguruma` and `xterm` from `node_modules`)

## Related

- Fixes regression introduced by [#414](https://github.com/j4rviscmd/vscodeee/pull/414)

🤖 Generated with [Claude Code](https://claude.com/claude-code)