### PR TITLE
fix: suppress stale IME composition keydown events in WKWebView/Tauri

### DIFF
--- a/src/vs/editor/browser/controller/editContext/textArea/textAreaEditContextInput.ts
+++ b/src/vs/editor/browser/controller/editContext/textArea/textAreaEditContextInput.ts
@@ -167,6 +167,7 @@ export class TextAreaInput extends Disposable {
 
 	private _hasFocus: boolean;
 	private _currentComposition: CompositionContext | null;
+	private _compositionEndTime: number = 0;
 
 	constructor(
 		private readonly _host: ITextAreaInputHost,
@@ -202,6 +203,14 @@ export class TextAreaInput extends Disposable {
 				|| (this._currentComposition && e.keyCode === KeyCode.Backspace)) {
 				// Stop propagation for keyDown events if the IME is processing key input
 				e.stopPropagation();
+			}
+
+			// WKWebView/Tauri: keydown with browserKeyCode=229 (KEY_IN_COMPOSITION) can fire
+			// AFTER compositionend due to event ordering differences. Suppress these stale
+			// composition-key events to prevent unintended actions (e.g. newline on Enter).
+			if (_e.keyCode === 229 && this._compositionEndTime > 0 && (Date.now() - this._compositionEndTime) < 300) {
+				e.stopPropagation();
+				e.preventDefault();
 			}
 
 			if (e.equals(KeyCode.Escape)) {
@@ -299,6 +308,7 @@ export class TextAreaInput extends Disposable {
 				return;
 			}
 			this._currentComposition = null;
+			this._compositionEndTime = Date.now();
 
 			if (this._browser.isAndroid) {
 				// On Android, the data sent with the composition update event is unusable.
@@ -329,6 +339,13 @@ export class TextAreaInput extends Disposable {
 			this._textArea.setIgnoreSelectionChangeTime('received input event');
 
 			if (this._currentComposition) {
+				return;
+			}
+
+			// WKWebView/Tauri: After compositionend, a newline `input` event may arrive
+			// from the Enter key that confirmed the composition. Suppress it if composition
+			// ended very recently to prevent an unwanted newline insertion.
+			if (this._compositionEndTime > 0 && (Date.now() - this._compositionEndTime) < 300) {
 				return;
 			}
 


### PR DESCRIPTION
## Summary

- Fixes IME composition confirmation (Enter key) incorrectly inserting a newline in markdown files in the Tauri/WKWebView environment
- In WKWebView, `keydown` events with `browserKeyCode=229` (KEY_IN_COMPOSITION) fire **after** `compositionend`, causing the Enter keypress to propagate to the editor's command system and trigger unintended newline insertion
- Tracks `compositionend` timing and suppresses stale composition-key events within a 300ms window in both `keydown` and `input` handlers

## Root Cause

WKWebView event ordering differs from Chromium:
1. `compositionend` fires (clears composition state)
2. `keydown` with `browserKeyCode=229`, `code=Enter` fires (~9ms later)
3. Since composition state is already cleared, this keydown is not caught by the existing `KEY_IN_COMPOSITION` guard
4. The keydown propagates to the command system → newline inserted

## Test Plan

- [x] Open a markdown file, type Japanese text with IME, press Enter to confirm composition → no unwanted newline
- [x] Normal text editing (non-IME) still works correctly
- [x] Non-markdown files (txt, json) still work correctly with IME

🤖 Generated with [Claude Code](https://claude.com/claude-code)