### PR TITLE
chore: release v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-05-03
+
+### Added
+
+- Ack-based flow control backpressure for PTY output, matching VS Code's `FlowControlConstants` pattern (high watermark 100K, low watermark 5K) with 100ms deadlock-prevention timeout ([#425](https://github.com/j4rviscmd/vscodeee/pull/425))
+
 ## [0.11.2] - 2026-05-03
 
 ### Fixed

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-utils/schema.json",
   "productName": "VS Codeee",
   "mainBinaryName": "codeee",
-  "version": "0.11.2",
+  "version": "0.12.0",
   "identifier": "com.vscodeee.app",
   "build": {
     "frontendDist": "../out",


### PR DESCRIPTION
## Summary

Release v0.12.0 — version bump and CHANGELOG update.

## Related Issue

- #418

## Changes

- Bump version from `0.11.2` to `0.12.0` in `src-tauri/tauri.conf.json`
- Add v0.12.0 entry to CHANGELOG.md

## How to Test

1. Verify version in `src-tauri/tauri.conf.json` is `0.12.0`
2. Verify CHANGELOG.md has v0.12.0 entry with the PTY flow control feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)