### PR TITLE
feat: add status text labels to workspace splash and shutdown overlay

### DIFF
--- a/src/vs/code/tauri-browser/workbench/workbench-tauri.html
+++ b/src/vs/code/tauri-browser/workbench/workbench-tauri.html
@@ -1,5 +1,19 @@
 <!-- Copyright (c) VS Codeee Contributors. All rights reserved. -->
 <!-- Licensed under the MIT License. See License.txt in the project root for license information. -->
+
+<!--
+  workbench-tauri.html — Entry-point HTML for the VS Codeee workbench running inside a Tauri 2.0 webview.
+
+  Responsibilities:
+  - Defines Content-Security-Policy (CSP) scoped to Tauri's custom protocols
+    (tauri:, vscode-file:, vscode-webview:, vscode-remote-resource:).
+  - Loads the console-interceptor script that forwards browser console output
+    to the Rust backend terminal for unified logging.
+  - Renders a splash screen overlay (spinner + <eee/> watermark) displayed
+    while the workbench bootstrap and workbench JS load asynchronously.
+  - Loads workbench-tauri.js as the bootstrap entry point, which sets up NLS,
+    CSS import maps, and dynamically imports the workbench module.
+-->
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -113,6 +127,16 @@
 			border-radius: 50%;
 			animation: splash-spin 0.8s linear infinite;
 		}
+		.splash-status {
+			opacity: 0.4;
+			margin-top: 16px;
+			font-family: -apple-system, BlinkMacSystemFont, 'Segoe WPC', 'Segoe UI', system-ui, 'Ubuntu', 'Droid Sans', sans-serif;
+			font-size: 12px;
+			color: #CCCCCC;
+			user-select: none;
+			-webkit-user-select: none;
+			pointer-events: none;
+		}
 	</style>
 	</head>
 <body aria-label="">
@@ -121,6 +145,7 @@
 			<text x="130" y="148" text-anchor="middle" font-family="'SF Mono','Menlo','Consolas','Courier New',monospace" font-size="52" font-weight="600" fill="#808080">&lt;eee/&gt;</text>
 		</svg>
 		<div class="splash-spinner"></div>
+		<div class="splash-status">loading...</div>
 	</div>
 </body>
 

--- a/src/vs/workbench/services/lifecycle/tauri-browser/lifecycleService.ts
+++ b/src/vs/workbench/services/lifecycle/tauri-browser/lifecycleService.ts
@@ -61,6 +61,14 @@ export class TauriLifecycleService extends AbstractLifecycleService {
   /** When `true`, the next `beforeunload` event is silently ignored (used by `withExpectedShutdown`). */
   private ignoreBeforeUnload = false;
 
+  /**
+	 * Creates a new Tauri lifecycle service and registers close-requested
+	 * and beforeunload listeners immediately.
+	 *
+	 * @param logService - The log service for lifecycle diagnostics.
+	 * @param storageService - The storage service used to persist shutdown reason
+	 *   and flush state during shutdown.
+	 */
   constructor(
     @ILogService logService: ILogService,
     @IStorageService storageService: IStorageService,
@@ -138,7 +146,7 @@ export class TauriLifecycleService extends AbstractLifecycleService {
    * window is destroyed by Rust after `lifecycle_close_confirmed`, or the
    * page reloads during an expected shutdown.
    */
-  private showShutdownOverlay(): void {
+  private showShutdownOverlay(statusText: string): void {
     const doc = mainWindow.document;
 
     // Inject the spinner keyframe animation
@@ -184,8 +192,18 @@ export class TauriLifecycleService extends AbstractLifecycleService {
       animation: shutdown-spin 0.8s linear infinite;
     `;
 
+    const status = doc.createElement('div');
+    status.style.cssText = `
+      opacity: 0.4; margin-top: 16px;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe WPC', 'Segoe UI', system-ui, 'Ubuntu', 'Droid Sans', sans-serif;
+      font-size: 12px; color: #CCCCCC;
+      user-select: none; -webkit-user-select: none; pointer-events: none;
+    `;
+    status.textContent = statusText;
+
     overlay.appendChild(svg);
     overlay.appendChild(spinner);
+    overlay.appendChild(status);
     doc.body.appendChild(overlay);
   }
 
@@ -318,7 +336,10 @@ export class TauriLifecycleService extends AbstractLifecycleService {
     this.logService.info('[lifecycle] Proceeding with shutdown');
 
     if (!options?.skipOverlay) {
-      this.showShutdownOverlay();
+      const statusText = (reason === ShutdownReason.RELOAD || reason === ShutdownReason.LOAD)
+        ? localize('lifecycleReloading', "reloading...")
+        : localize('lifecycleShuttingDown', "shutting down...");
+      this.showShutdownOverlay(statusText);
     }
 
     this._willShutdown = true;
@@ -395,7 +416,15 @@ export class TauriLifecycleService extends AbstractLifecycleService {
   // --- Public API ---
 
   /**
-	 * Programmatic shutdown (e.g., from reload or workspace switch).
+	 * Initiates a programmatic shutdown without async veto support.
+		 *
+		 * Unlike the Rust close-requested path ({@link handleCloseRequested}),
+		 * this method skips `fireBeforeShutdown` entirely and proceeds directly
+		 * to the shutdown sequence. Used internally for workspace switches and
+		 * reload operations where the caller has already handled veto logic.
+		 *
+		 * Flushes storage before invoking {@link handleShutdown} to ensure
+		 * UI state is persisted.
 	 */
   async shutdown(): Promise<void> {
     this.logService.info('[lifecycle] Programmatic shutdown triggered');
@@ -454,7 +483,7 @@ export class TauriLifecycleService extends AbstractLifecycleService {
       return;
     }
 
-    await this.handleShutdown(reason, { skipRustClose: true, skipOverlay: true });
+    await this.handleShutdown(reason, { skipRustClose: true });
   }
 
   /**


### PR DESCRIPTION
## Summary

- Add context-aware status text ("loading...", "reloading...", "shutting down...") to the startup splash screen and shutdown overlay
- Show shutdown overlay during reload window (previously skipped), displaying "reloading..." to prevent premature force-quit
- User-facing status text in the lifecycle service is externalized via `localize()` for i18n support

Closes #428

## Test plan

- [ ] Verify startup splash shows "loading..." text below spinner
- [ ] Verify shutdown overlay shows "shutting down..." when closing window
- [ ] Verify reload window shows "reloading..." overlay (stage 1) then "loading..." splash (stage 2)
- [ ] Verify workspace state is saved correctly during normal close after overlay appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)