### PR TITLE
🚀 Release v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-05-04
+
+### Added
+
+- Add status text labels to workspace splash and shutdown overlay
+
 ## [0.12.1] - 2026-05-03
 
 ### Fixed

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-utils/schema.json",
   "productName": "VS Codeee",
   "mainBinaryName": "codeee",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "identifier": "com.vscodeee.app",
   "build": {
     "frontendDist": "../out",


### PR DESCRIPTION
## Summary

Release v0.13.0 — minor version bump with new feature additions.

## Changes

- Add status text labels to workspace splash and shutdown overlay

## How to Test

1. Launch the application
2. Verify workspace splash screen shows status text labels
3. Verify shutdown overlay shows status text labels
4. Confirm version is updated to 0.13.0 in `src-tauri/tauri.conf.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)