### PR TITLE
fix: improve About dialog with custom menu and fork version display

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -356,10 +356,20 @@ pub fn get_product_json(app_handle: tauri::AppHandle) -> Result<ProductPackageJs
         }
     }
 
-    // Inject extension host runtime info for About dialog display.
-    // Detect by looking for the bundled Bun sidecar next to the executable.
-    let runtime_label = detect_runtime_label();
+    // Inject Tauri app version and extension host runtime for the About dialog.
     if let Some(obj) = product.as_object_mut() {
+        let tauri_version = app_handle
+            .config()
+            .version
+            .clone()
+            .unwrap_or_else(|| "0.0.0".to_string());
+        obj.insert(
+            "tauriAppVersion".to_string(),
+            serde_json::Value::String(tauri_version),
+        );
+
+        // Detect by looking for the bundled Bun sidecar next to the executable.
+        let runtime_label = detect_runtime_label();
         obj.insert(
             "extensionHostRuntime".to_string(),
             serde_json::Value::String(runtime_label),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -206,6 +206,7 @@ pub fn run(gui_args: Option<cli::dispatch::ParsedGuiArgs>) {
         .manage(commands::updater::UpdaterState::default())
         .manage(shutdown::ShutdownCoordinator::new())
         .on_window_event(window::events::handle_window_event)
+        .on_menu_event(window::menu::on_menu_event)
         .register_asynchronous_uri_scheme_protocol("vscode-file", move |ctx, request, responder| {
             // On first call the state will have been initialized by setup().
             // If somehow called before setup (shouldn't happen), return 503.
@@ -390,6 +391,9 @@ pub fn run(gui_args: Option<cli::dispatch::ParsedGuiArgs>) {
             use tauri::Manager;
 
             log::info!(target: "vscodeee", "Tauri app started");
+
+            // ── Application menu ──
+            window::menu::setup(app)?;
 
             // ── Initialize terminal state store ──
             {

--- a/src-tauri/src/window/menu.rs
+++ b/src-tauri/src/window/menu.rs
@@ -1,0 +1,97 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) VS Codeee Contributors. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+//! Application menu setup for macOS.
+//!
+//! Creates a native menu bar that replaces Tauri's default with a custom
+//! "About" item that triggers the VS Code About dialog instead of the
+//! system's minimal version-only dialog.
+
+use tauri::{
+    menu::{MenuBuilder, MenuItem, SubmenuBuilder},
+    AppHandle, Emitter,
+};
+
+/// Menu item ID for the custom About entry.
+const ABOUT_MENU_ID: &str = "about-vscode-dialog";
+
+/// Build and install the application menu.
+///
+/// On macOS the first submenu becomes the "application menu" (app name in
+/// the menu bar). We keep the standard items (Services, Hide, Quit) but
+/// replace the default About with a custom entry that emits a Tauri event
+/// so the WebView can show the VS Code About dialog.
+pub fn setup(app: &tauri::App) -> tauri::Result<()> {
+    let app_submenu = SubmenuBuilder::new(app, "VS Codeee")
+        .item(&MenuItem::with_id(
+            app,
+            ABOUT_MENU_ID,
+            "About VS Codeee",
+            true,
+            None::<&str>,
+        )?)
+        .separator()
+        .services()
+        .separator()
+        .hide()
+        .hide_others()
+        .show_all()
+        .separator()
+        .quit()
+        .build()?;
+
+    let edit_submenu = SubmenuBuilder::new(app, "Edit")
+        .undo()
+        .redo()
+        .separator()
+        .cut()
+        .copy()
+        .paste()
+        .select_all()
+        .build()?;
+
+    let view_submenu = SubmenuBuilder::new(app, "View")
+        .text("toggle-devtools", "Toggle Developer Tools")
+        .build()?;
+
+    let window_submenu = SubmenuBuilder::new(app, "Window")
+        .minimize()
+        .separator()
+        .close_window()
+        .build()?;
+
+    let help_submenu = SubmenuBuilder::new(app, "Help")
+        .text("documentation", "Documentation")
+        .build()?;
+
+    let menu = MenuBuilder::new(app)
+        .item(&app_submenu)
+        .item(&edit_submenu)
+        .item(&view_submenu)
+        .item(&window_submenu)
+        .item(&help_submenu)
+        .build()?;
+
+    app.set_menu(menu)?;
+
+    Ok(())
+}
+
+/// Handle menu item click events.
+///
+/// For the custom About entry, emits `show-about-dialog` to all WebView
+/// windows so the TypeScript side can open the VS Code About dialog.
+pub fn on_menu_event(app: &AppHandle, event: tauri::menu::MenuEvent) {
+    match event.id().as_ref() {
+        ABOUT_MENU_ID => {
+            if let Err(e) = app.emit("show-about-dialog", ()) {
+                log::warn!(target: "vscodeee::menu", "Failed to emit show-about-dialog: {e}");
+            }
+        }
+        id => {
+            log::trace!(target: "vscodeee::menu", "Unhandled menu event: {id}");
+        }
+    }
+}

--- a/src-tauri/src/window/mod.rs
+++ b/src-tauri/src/window/mod.rs
@@ -20,10 +20,12 @@
 //! - [`session`] — Session persistence to `sessions.json`.
 //! - [`settings`] — User window settings (restore mode, fullscreen behavior).
 //! - [`state`] — Shared types for window state (`WindowInfo`, `OpenWindowOptions`, etc.).
+//! - [`menu`] — Native application menu with custom About handling.
 
 pub mod chrome;
 pub mod events;
 pub mod manager;
+pub mod menu;
 pub mod quit_state;
 pub mod restore;
 pub mod restore_geometry;

--- a/src/vs/platform/product/common/productService.ts
+++ b/src/vs/platform/product/common/productService.ts
@@ -18,6 +18,8 @@ export interface IProductService extends Readonly<IProductConfiguration> {
 	readonly _serviceBrand: undefined;
 	/** Human-readable label for the extension host runtime (e.g. `"Bun 1.2.0"`). */
 	extensionHostRuntime?: string;
+	/** Tauri application version from tauri.conf.json (e.g. `"0.13.0"`). */
+	tauriAppVersion?: string;
 
 }
 

--- a/src/vs/workbench/browser/parts/dialogs/dialog.ts
+++ b/src/vs/workbench/browser/parts/dialogs/dialog.ts
@@ -6,7 +6,6 @@
 import { EventHelper } from '../../../../base/browser/dom.js';
 import { StandardKeyboardEvent } from '../../../../base/browser/keyboardEvent.js';
 import { IDialogOptions } from '../../../../base/browser/ui/dialog/dialog.js';
-import { fromNow } from '../../../../base/common/date.js';
 import { localize } from '../../../../nls.js';
 import { IHostService } from '../../../services/host/browser/host.js';
 import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
@@ -64,32 +63,27 @@ export function createWorkbenchDialogOptions(options: Partial<IDialogOptions>, k
  * Build the content for the workbench About dialog.
  *
  * Composes a title (long product name) and a details string containing the
- * version, commit hash, build date (with relative time), extension host runtime,
- * and browser user agent. Two variants of the details string are returned:
- * one with relative timestamps for display, and one without for clipboard copy.
+ * version, commit hash, extension host runtime, and browser user agent.
  *
- * @param productService - Provides product metadata (name, version, commit, date, runtime).
+ * @param productService - Provides product metadata (name, version, commit, runtime).
  * @returns An object with `title`, `details` (display string), and `detailsToCopy` (plain copy string).
  */
 export function createBrowserAboutDialogDetails(productService: IProductService): { title: string; details: string; detailsToCopy: string } {
-	const detailString = (useAgo: boolean): string => {
-		return localize('aboutDetail',
-			"Version: {0}\nCommit: {1}\nDate: {2}\nRuntime: {3}\nBrowser: {4}",
-			productService.version || 'Unknown',
-			productService.commit || 'Unknown',
-			productService.date ? `${productService.date}${useAgo ? ' (' + fromNow(new Date(productService.date), true) + ')' : ''}` : 'Unknown',
-			productService.extensionHostRuntime || 'Unknown',
-			navigator.userAgent
-		);
-	};
-
-	const details = detailString(true);
-	const detailsToCopy = detailString(false);
+	const version = productService.tauriAppVersion
+		? `v${productService.tauriAppVersion} (${productService.version || 'Unknown'})`
+		: productService.version || 'Unknown';
+	const detailString = localize('aboutDetail',
+		"Version: {0}\nCommit: {1}\nRuntime: {2}\nBrowser: {3}",
+		version,
+		productService.commit || 'Unknown',
+		productService.extensionHostRuntime || 'Unknown',
+		navigator.userAgent
+	);
 
 	return {
 		title: productService.nameLong,
-		details: details,
-		detailsToCopy: detailsToCopy
+		details: detailString,
+		detailsToCopy: detailString
 	};
 }
 

--- a/src/vs/workbench/tauri-browser/desktop.tauri.main.ts
+++ b/src/vs/workbench/tauri-browser/desktop.tauri.main.ts
@@ -61,6 +61,7 @@ import { BrowserRequestService } from '../services/request/browser/requestServic
 import { mainWindow } from '../../base/browser/window.js';
 import { IWorkbenchLayoutService } from '../services/layout/browser/layoutService.js';
 import { IOpenerService } from '../../platform/opener/common/opener.js';
+import { ICommandService } from '../../platform/commands/common/commands.js';
 
 import { TauriIPCMainProcessService } from '../../platform/ipc/tauri-browser/mainProcessService.js';
 import { TauriNativeHostService } from '../../platform/native/tauri-browser/nativeHostService.js';
@@ -178,6 +179,12 @@ export class TauriDesktopMain extends Disposable {
       // and manages the status bar indicator.
       const windowZoomService = accessor.get(IWindowZoomService);
       windowZoomService.restoreZoom(); // fire and forget — zoom applies asynchronously
+
+      // macOS menu bar About → VS Code About dialog.
+      const commandService = accessor.get(ICommandService);
+      listen<void>('show-about-dialog', () => {
+        commandService.executeCommand('workbench.action.showAboutDialog');
+      }).then(unlisten => this._register({ dispose: unlisten }));
     });
   }
 


### PR DESCRIPTION
## Summary

Improve the About dialog to properly show fork version information and fix the macOS native menu bar About entry.

- The Date field in the About dialog was showing "Unknown" because the Tauri runtime path did not inject the build date — removed it
- The macOS menu bar About only showed "Version 0.13.0 (0.13.0)" — replaced with a custom menu that triggers the VS Code About dialog
- Version display now shows fork version alongside upstream VS Code version in `v0.13.0 (1.115.0)` format via a new `tauriAppVersion` property

## Related Issue

Closes #434

## Changes

- Remove Date field from About dialog (was showing "Unknown")
- Add custom macOS menu bar with About item that emits `show-about-dialog` event to WebView
- Add `tauriAppVersion` property to `IProductService` (injected from `tauri.conf.json`)
- Display version as `v{tauriAppVersion} ({upstreamVersion})` in About dialog
- Remove unused `fromNow` import

## How to Test

1. `cargo tauri dev`
2. Open command palette → "About" → verify Date field is gone, version shows `v0.13.0 (1.115.0)`
3. Click "VS Codeee" → "About VS Codeee" in menu bar → same dialog appears
4. Verify built-in extensions load without compatibility errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)