### PR TITLE
feat: add node:sea polyfill shim for Bun compatibility

### DIFF
--- a/src/vs/workbench/api/node/extHostExtensionService.ts
+++ b/src/vs/workbench/api/node/extHostExtensionService.ts
@@ -22,6 +22,7 @@ import nodeModule from 'node:module';
 import { DisposableStore } from '../../../base/common/lifecycle.js';
 import { ExtHostChildProcessInterceptor } from './extHostChildProcessInterceptor.js';
 import { NodeSqliteModuleFactory } from './nodeSqliteModuleFactory.js';
+import { NodeSeaModuleFactory } from './nodeSeaModuleFactory.js';
 
 const nodeRequire = nodeModule.createRequire(import.meta.url);
 const fs = nodeRequire('fs');
@@ -30,6 +31,19 @@ const os = nodeRequire('os');
 
 /** Type signature for Node.js Module._resolveFilename, used by both the stored original and the replacement. */
 type ResolveFilenameFn = (request: string, parent: { filename?: string } | unknown, isMain: boolean, options?: { paths?: string[] }) => string;
+
+/**
+ * Register best-effort cleanup of a directory on process exit signals.
+ * Shared by both CJS and ESM interceptors.
+ */
+function registerProcessCleanup(dir: string): void {
+	const cleanup = () => {
+		try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* best-effort */ }
+	};
+	process.on('exit', cleanup);
+	process.on('SIGTERM', cleanup);
+	process.on('SIGINT', cleanup);
+}
 
 /**
  * Node.js/Bun-specific require() interceptor for the extension host.
@@ -132,13 +146,7 @@ class NodeModuleRequireInterceptor extends RequireInterceptor {
 		const shimDir = path.join(tmpDir, `vscodeee-bun-shims-${process.pid}`);
 		fs.mkdirSync(shimDir, { recursive: true });
 
-		// Register cleanup on process exit
-		const cleanup = () => {
-			try { fs.rmSync(shimDir, { recursive: true, force: true }); } catch { /* best-effort */ }
-		};
-		process.on('exit', cleanup);
-		process.on('SIGTERM', cleanup);
-		process.on('SIGINT', cleanup);
+		registerProcessCleanup(shimDir);
 
 		// Remove stale shim directories from dead processes (best-effort)
 		try {
@@ -268,29 +276,10 @@ module.exports = globalThis.__VSCODEEE_ESM_API__ || {};
 		// Place symlinks at locations Bun's ESM resolver will find.
 		this._createBunESMSymlink('vscode', vscodeDir);
 
-		// Create node_modules/node:sqlite/ for ESM import resolution.
-		// Unlike vscode, node:sqlite is not per-extension — the global is set once.
-		const sqliteFactory = this._factories.get('node:sqlite');
-		if (sqliteFactory) {
-			const sqliteDir = path.join(shimDir, 'node_modules', 'node:sqlite');
-			fs.mkdirSync(sqliteDir, { recursive: true });
-
-			fs.writeFileSync(path.join(sqliteDir, 'package.json'), JSON.stringify({
-				name: 'node:sqlite',
-				version: '0.0.0',
-				main: 'index.js'
-			}));
-
-			// Set the global once during initialization (no per-extension swap needed)
-			const sqliteModule = sqliteFactory.load('node:sqlite', URI.parse('file:///node:sqlite'), () => { throw new Error('Cannot load module from here.'); });
-			(globalThis as Record<string, unknown>).__VSCODEEE_NODE_SQLITE_MODULE__ = sqliteModule;
-
-			fs.writeFileSync(path.join(sqliteDir, 'index.js'), `'use strict';
-module.exports = globalThis.__VSCODEEE_NODE_SQLITE_MODULE__ || {};
-`);
-
-			this._createBunESMSymlink('node:sqlite', sqliteDir);
-		}
+		// Register singleton modules (node:sqlite, node:sea) for ESM import resolution.
+		// These are not per-extension — the global is set once during initialization.
+		this._installBunESMSingletonModule(shimDir, 'node:sqlite', '__VSCODEEE_NODE_SQLITE_MODULE__');
+		this._installBunESMSingletonModule(shimDir, 'node:sea', '__VSCODEEE_NODE_SEA_MODULE__');
 
 		// Register a global function that _doLoadModule calls before each ESM import.
 		// It looks up the per-extension API, sets the global, and busts the CJS cache.
@@ -313,13 +302,39 @@ module.exports = globalThis.__VSCODEEE_NODE_SQLITE_MODULE__ || {};
 			}
 		};
 
-		// Register cleanup
-		const cleanup = () => {
-			try { fs.rmSync(shimDir, { recursive: true, force: true }); } catch { /* best-effort */ }
-		};
-		process.on('exit', cleanup);
-		process.on('SIGTERM', cleanup);
-		process.on('SIGINT', cleanup);
+		registerProcessCleanup(shimDir);
+	}
+
+	/**
+	 * Create a singleton ESM module package for a factory-registered module.
+	 *
+	 * Creates node_modules/<moduleName>/ with a package.json and index.js that
+	 * reads from a global variable, loads the module from the factory once,
+	 * and places symlinks for Bun's ESM resolver.
+	 */
+	private _installBunESMSingletonModule(shimDir: string, moduleName: string, globalKey: string): void {
+		const factory = this._factories.get(moduleName);
+		if (!factory) {
+			return;
+		}
+
+		const moduleDir = path.join(shimDir, 'node_modules', moduleName);
+		fs.mkdirSync(moduleDir, { recursive: true });
+
+		fs.writeFileSync(path.join(moduleDir, 'package.json'), JSON.stringify({
+			name: moduleName,
+			version: '0.0.0',
+			main: 'index.js'
+		}));
+
+		const loadedModule = factory.load(moduleName, URI.parse(`file:///${moduleName}`), () => { throw new Error('Cannot load module from here.'); });
+		(globalThis as Record<string, unknown>)[globalKey] = loadedModule;
+
+		fs.writeFileSync(path.join(moduleDir, 'index.js'), `'use strict';
+	module.exports = globalThis.${globalKey} || {};
+`);
+
+		this._createBunESMSymlink(moduleName, moduleDir);
 	}
 
 	/**
@@ -391,15 +406,18 @@ export class ExtHostExtensionService extends AbstractExtHostExtensionService {
 		// Register local file system shortcut
 		this._instaService.createInstance(ExtHostDiskFileSystemProvider);
 
-		// Module loading tricks
+		// Module loading tricks — register built-in Node.js module polyfills
 		const sqliteFactory = new NodeSqliteModuleFactory();
+		const seaFactory = new NodeSeaModuleFactory();
 		const requireInterceptor = this._instaService.createInstance(NodeModuleRequireInterceptor, extensionApiFactory, { mine: this._myRegistry, all: this._globalRegistry });
 		requireInterceptor.register(sqliteFactory);
+		requireInterceptor.register(seaFactory);
 		await requireInterceptor.install();
 
 		// ESM loading tricks
 		const esmInterceptor = this._store.add(this._instaService.createInstance(NodeModuleESMInterceptor, extensionApiFactory, { mine: this._myRegistry, all: this._globalRegistry }));
 		esmInterceptor.register(sqliteFactory);
+		esmInterceptor.register(seaFactory);
 		await esmInterceptor.install();
 
 		// Child process interceptor — injects --no-experimental-require-module

--- a/src/vs/workbench/api/node/nodeSeaModuleFactory.ts
+++ b/src/vs/workbench/api/node/nodeSeaModuleFactory.ts
@@ -1,43 +1,42 @@
 /*---------------------------------------------------------------------------------------------
-*  Copyright (c) Microsoft Corporation. All rights reserved.
-*  Licensed under the MIT License. See License.txt in the project root for license information.
-*--------------------------------------------------------------------------------------------*/
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 
-import { INodeModuleFactory } from "../common/extHostRequireInterceptor.js";
-import * as nodeSeaShim from "./nodeSeaShim.js";
-
+import { INodeModuleFactory } from '../common/extHostRequireInterceptor.js';
+import * as nodeSeaShim from './nodeSeaShim.js';
 
 /**
-* Factory that provides the `node:sea` stub module to extensions.
-*
-* Bun does not support `node:sea`. This factory returns a singleton stub where
-* `isSea()` is always `false` and asset methods throw, matching Node.js
-* behavior outside of a Single Executable Application.
-*/
+ * Factory that provides the `node:sea` stub module to extensions.
+ *
+ * Bun does not support `node:sea`. This factory returns a singleton stub where
+ * `isSea()` is always `false` and asset methods throw, matching Node.js
+ * behavior outside of a Single Executable Application.
+ */
 export class NodeSeaModuleFactory implements INodeModuleFactory {
-/** Singleton module object exposing the `node:sea` stub API. */
-    private readonly _module: object = {
-        isSea: nodeSeaShim.isSea,
-        getAsset: nodeSeaShim.getAsset,
-        getAssetAsBlob: nodeSeaShim.getAssetAsBlob,
-        getRawAsset: nodeSeaShim.getRawAsset,
-    };
+	public readonly nodeModuleName = 'node:sea';
 
-public readonly nodeModuleName = "node:sea";
+	/** Singleton module object exposing the `node:sea` stub API. */
+	private readonly _module: object = {
+		isSea: nodeSeaShim.isSea,
+		getAsset: nodeSeaShim.getAsset,
+		getAssetAsBlob: nodeSeaShim.getAssetAsBlob,
+		getRawAsset: nodeSeaShim.getRawAsset,
+	};
 
-/**
-    * Loads the `node:sea` stub module.
-    *
-    * Returns a singleton module object that exposes `isSea`, `getAsset`,
-    * `getAssetAsBlob`, and `getRawAsset` from the shim. The same instance
-    * is reused across all extension loads since the stub has no per-extension state.
-    *
-    * @param _request - The module identifier being requested (unused).
-    * @param _parent - The parent module requesting the import (unused).
-    * @param _original - The original Node.js require function (unused).
-    * @returns The `node:sea` stub module object.
-    */
-    load(_request: string, _parent: unknown, _original: (id: string) => unknown): object {
-        return this._module;
-    }
+	/**
+	 * Loads the `node:sea` stub module.
+	 *
+	 * Returns a singleton module object that exposes `isSea`, `getAsset`,
+	 * `getAssetAsBlob`, and `getRawAsset` from the shim. The same instance
+	 * is reused across all extension loads since the stub has no per-extension state.
+	 *
+	 * @param _request - The module identifier being requested (unused).
+	 * @param _parent - The parent module requesting the import (unused).
+	 * @param _original - The original Node.js require function (unused).
+	 * @returns The `node:sea` stub module object.
+	 */
+	load(_request: string, _parent: unknown, _original: (id: string) => unknown): object {
+		return this._module;
+	}
 }

--- a/src/vs/workbench/api/node/nodeSeaModuleFactory.ts
+++ b/src/vs/workbench/api/node/nodeSeaModuleFactory.ts
@@ -1,0 +1,43 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import { INodeModuleFactory } from "../common/extHostRequireInterceptor.js";
+import * as nodeSeaShim from "./nodeSeaShim.js";
+
+
+/**
+* Factory that provides the `node:sea` stub module to extensions.
+*
+* Bun does not support `node:sea`. This factory returns a singleton stub where
+* `isSea()` is always `false` and asset methods throw, matching Node.js
+* behavior outside of a Single Executable Application.
+*/
+export class NodeSeaModuleFactory implements INodeModuleFactory {
+/** Singleton module object exposing the `node:sea` stub API. */
+    private readonly _module: object = {
+        isSea: nodeSeaShim.isSea,
+        getAsset: nodeSeaShim.getAsset,
+        getAssetAsBlob: nodeSeaShim.getAssetAsBlob,
+        getRawAsset: nodeSeaShim.getRawAsset,
+    };
+
+public readonly nodeModuleName = "node:sea";
+
+/**
+    * Loads the `node:sea` stub module.
+    *
+    * Returns a singleton module object that exposes `isSea`, `getAsset`,
+    * `getAssetAsBlob`, and `getRawAsset` from the shim. The same instance
+    * is reused across all extension loads since the stub has no per-extension state.
+    *
+    * @param _request - The module identifier being requested (unused).
+    * @param _parent - The parent module requesting the import (unused).
+    * @param _original - The original Node.js require function (unused).
+    * @returns The `node:sea` stub module object.
+    */
+    load(_request: string, _parent: unknown, _original: (id: string) => unknown): object {
+        return this._module;
+    }
+}

--- a/src/vs/workbench/api/node/nodeSeaShim.ts
+++ b/src/vs/workbench/api/node/nodeSeaShim.ts
@@ -1,0 +1,51 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Stub shim for the `node:sea` (Single Executable Applications) module.
+ *
+ * Bun does not support `node:sea`. Since the extension host always runs as
+ * a regular process (never as a SEA), `isSea()` returns `false` and all
+ * asset-retrieval methods throw — matching Node.js behavior when not running
+ * inside a single executable.
+ */
+
+/**
+ * Whether the Node.js application is running from a Single Executable Application.
+ * Always `false` in the extension host because it runs as a standard Bun process.
+ */
+export function isSea(): false {
+	return false;
+}
+
+/**
+ * Throws because the process is not a Single Executable Application.
+ *
+ * @param _key - The asset key (unused — always throws).
+ * @throws {Error} Always throws.
+ */
+export function getAsset(_key: string): never {
+	throw new Error('[node:sea shim] getAsset() is not available because this process is not a Single Executable Application');
+}
+
+/**
+ * Throws because the process is not a Single Executable Application.
+ *
+ * @param _key - The asset key (unused — always throws).
+ * @throws {Error} Always throws.
+ */
+export function getAssetAsBlob(_key: string, _options?: { type?: string }): never {
+	throw new Error('[node:sea shim] getAssetAsBlob() is not available because this process is not a Single Executable Application');
+}
+
+/**
+ * Throws because the process is not a Single Executable Application.
+ *
+ * @param _key - The asset key (unused — always throws).
+ * @throws {Error} Always throws.
+ */
+export function getRawAsset(_key: string): never {
+	throw new Error('[node:sea shim] getRawAsset() is not available because this process is not a Single Executable Application');
+}


### PR DESCRIPTION
## Summary

- Add `node:sea` stub shim for Bun compatibility, resolving #437 (copilot-chat CLI error: "No such built-in module: node:sea")
- `isSea()` returns `false`, asset methods throw descriptive errors — matching Node.js behavior outside Single Executable Applications
- Registered in both CJS and ESM module interceptors, following the same pattern as `node:sqlite` (#433)
- Refactored `extHostExtensionService.ts` to extract shared `registerProcessCleanup()` and `_installBunESMSingletonModule()` helpers, eliminating duplication between node:sqlite and node:sea ESM setup

## Test plan

- [ ] Verify copilot-chat extension loads without "No such built-in module: node:sea" error
- [ ] Verify `isSea()` returns `false` when called from extension context
- [ ] Verify CJS `require('node:sea')` and ESM `import from 'node:sea'` both resolve correctly
- [ ] Verify `getAsset()`, `getAssetAsBlob()`, `getRawAsset()` throw descriptive errors
- [ ] Verify existing node:sqlite shim continues to work correctly (no regression)

Closes #437

🤖 Generated with [Claude Code](https://claude.com/claude-code)