### PR TITLE
🚀 Release v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-05-05
+
+### Added
+
+- Migrate Extension Host runtime from Node.js to Bun ([#436](https://github.com/j4rviscmd/vscodeee/pull/436))
+- Add node:sqlite polyfill shim for Bun compatibility
+- Add node:sea polyfill shim for Bun compatibility ([#443](https://github.com/j4rviscmd/vscodeee/pull/443))
+
+### Fixed
+
+- Improve About dialog with custom menu and fork version display ([#438](https://github.com/j4rviscmd/vscodeee/pull/438))
+- Resolve ESLint warnings in node-sqlite shim
+- Add type definitions for bun:sqlite API
+
 ## [0.13.0] - 2026-05-04
 
 ### Added

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-utils/schema.json",
   "productName": "VS Codeee",
   "mainBinaryName": "codeee",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "identifier": "com.vscodeee.app",
   "build": {
     "frontendDist": "../out",


### PR DESCRIPTION
<!-- NOTE: Please resolve all Copilot review issues before requesting human review. -->

## Summary

Release v0.14.0 with Extension Host Bun migration and polyfill shims.

## Changes

- Bump version from 0.13.0 to 0.14.0
- Update CHANGELOG.md with release notes

### Included changes since v0.13.0

**Added**
- Migrate Extension Host runtime from Node.js to Bun (#436)
- Add node:sqlite polyfill shim for Bun compatibility
- Add node:sea polyfill shim for Bun compatibility (#443)

**Fixed**
- Improve About dialog with custom menu and fork version display (#438)
- Resolve ESLint warnings in node-sqlite shim
- Add type definitions for bun:sqlite API

## How to Test

1. Checkout this branch
2. Run `cargo build` to verify the build succeeds
3. Launch the app and verify the version is displayed as 0.14.0
4. Test extension host functionality to confirm Bun runtime works