### PR TITLE
chore: skip AppImage bundling on Linux CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -266,7 +266,7 @@ jobs:
           - platform: 'macos-latest'
             args: '--target x86_64-apple-darwin'
           - platform: 'ubuntu-22.04'
-            args: ''
+            args: '--bundles deb,rpm'
           - platform: 'windows-latest'
             args: '--bundles nsis'
 


### PR DESCRIPTION
<!-- NOTE: Please resolve all Copilot review issues before requesting human review. -->

## Summary

Skip AppImage bundling on Linux CI to fix publish workflow failures.
The `linuxdeploy` tool fails consistently on ubuntu-22.04 runners.
deb and rpm bundles build successfully and cover the major distributions.

## Changes

- Change Linux matrix args from `''` to `'--bundles deb,rpm'` in publish.yml

## How to Test

1. Merge this PR
2. The Release workflow will be triggered by the merge commit
3. Verify that the `publish-tauri (ubuntu-22.04)` job completes successfully
4. Verify that deb and rpm artifacts are uploaded to the draft release