### PR TITLE
chore: remove AppImage from required release assets

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -643,7 +643,6 @@ jobs:
             const renames = [
               { match: `_${version}_aarch64.dmg`, fixedName: 'VSCodeee_macOS_arm64.dmg' },
               { match: `_${version}_x64.dmg`, fixedName: 'VSCodeee_macOS_x64.dmg' },
-              { match: `_${version}_amd64.AppImage`, fixedName: 'VSCodeee_Linux_x64.AppImage' },
               { match: `_${version}_amd64.deb`, fixedName: 'VSCodeee_Linux_x64.deb' },
               { match: `_${version}_x64-setup.exe`, fixedName: 'VSCodeee_Windows_x64-setup.exe' },
             ];
@@ -716,11 +715,11 @@ jobs:
 
             const assetNames = release.assets.map(a => a.name);
 
-            // Expected Tauri desktop assets (4 platforms)
+            // Expected Tauri desktop assets (3 platforms, Linux ships deb only)
             const expectedTauri = [
               `_${version}_aarch64.dmg`,
               `_${version}_x64.dmg`,
-              `_${version}_amd64.AppImage`,
+              `_${version}_amd64.deb`,
               `_${version}_x64-setup.exe`,
             ];
             // Expected REH server assets (5 targets)


### PR DESCRIPTION
## Summary

Remove AppImage from the required release asset checks in the publish
workflow so the v0.14.0 release can complete successfully.

## Changes

- Remove AppImage from `renames` mapping (upload-stable-assets job)
- Replace AppImage with deb in `expectedTauri` required assets list

## How to Test

1. Merge this PR
2. Delete the existing v0.14.0 draft release and tag
3. Re-run the publish workflow — it should publish successfully