### PR TITLE
fix: resolve extension module paths in production build

### DIFF
--- a/src-tauri/src/exthost/sidecar.rs
+++ b/src-tauri/src/exthost/sidecar.rs
@@ -95,10 +95,12 @@ fn resolve_runtime_binary() -> String {
 /// `.build/extensions/*/out/` where no `node_modules` exist. Bun walks up
 /// from the extension's location and never finds the source tree's packages.
 ///
+/// User-installed extensions at `~/.vscodeee/extensions/*/` may also ship their
+/// own `node_modules/` (e.g., Prettier bundles its own `prettier` package).
+///
 /// This function constructs a colon/semicolon-separated list of paths that includes
-/// both the production resource path and, when an `extensions/` directory is detected
-/// in `app_root`, all extension `node_modules/` directories so `require('byline')` etc.
-/// resolve.
+/// the production resource path, built-in extension `node_modules/`, and
+/// user extension `node_modules/` directories so `require('byline')` etc. resolve.
 ///
 /// The paths are set as both `NODE_PATH` and `VSCODEEE_EXT_NODE_MODULES_PATHS`:
 /// - `NODE_PATH`: Bun adds these to `Module.globalPaths` at process startup.
@@ -128,19 +130,16 @@ fn build_ext_node_modules_paths(app_root: &Path, resource_dir: &Path) -> String 
         }
 
         // Each extension's own node_modules
-        if let Ok(entries) = std::fs::read_dir(&extensions_dir) {
-            let mut ext_paths: Vec<String> = entries
-                .filter_map(|e| {
-                    let nm = e.ok()?.path().join("node_modules");
-                    if nm.is_dir() {
-                        Some(nm.to_string_lossy().into_owned())
-                    } else {
-                        None
-                    }
-                })
-                .collect();
-            ext_paths.sort();
-            paths.append(&mut ext_paths);
+        paths.append(&mut collect_child_node_modules(&extensions_dir));
+    }
+
+    // User-installed extensions: ~/.vscodeee/extensions/*/node_modules
+    // Extensions like Prettier bundle their own npm dependencies (e.g., prettier)
+    // which must be resolvable via CJS require() in the extension host process.
+    if let Some(home_dir) = dirs::home_dir() {
+        let user_ext_dir = home_dir.join(".vscodeee").join("extensions");
+        if user_ext_dir.is_dir() {
+            paths.append(&mut collect_child_node_modules(&user_ext_dir));
         }
     }
 
@@ -151,6 +150,28 @@ fn build_ext_node_modules_paths(app_root: &Path, resource_dir: &Path) -> String 
         paths.len()
     );
     paths_str
+}
+
+/// Collect `node_modules` paths from immediate subdirectories of `dir`.
+///
+/// Reads the entries of `dir`, looks for `<entry>/node_modules/` directories,
+/// sorts them alphabetically, and returns them as a list of paths.
+fn collect_child_node_modules(dir: &Path) -> Vec<String> {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    let mut paths: Vec<String> = entries
+        .filter_map(|e| {
+            let nm = e.ok()?.path().join("node_modules");
+            if nm.is_dir() {
+                Some(nm.to_string_lossy().into_owned())
+            } else {
+                None
+            }
+        })
+        .collect();
+    paths.sort();
+    paths
 }
 
 /// Build an enriched PATH for the Extension Host child process.
@@ -346,31 +367,31 @@ fn augment_product_json(app_root: &Path) -> Option<(std::path::PathBuf, String)>
     }
 
     // Write augmented product.json (pretty-printed to preserve readability)
-    match serde_json::to_string_pretty(&product) {
-        Ok(augmented) => {
-            // Add trailing newline to match typical JSON formatting
-            let augmented = augmented + "\n";
-            if let Err(e) = std::fs::write(&product_path, &augmented) {
-                log::warn!(
-                    target: "vscodeee::exthost::sidecar",
-                    "Failed to write augmented product.json: {e}"
-                );
-                return None;
-            }
-            log::info!(
-                target: "vscodeee::exthost::sidecar",
-                "Wrote augmented product.json with commit and version"
-            );
-            Some((product_path, original))
-        }
+    let augmented = match serde_json::to_string_pretty(&product) {
+        Ok(s) => s,
         Err(e) => {
             log::warn!(
                 target: "vscodeee::exthost::sidecar",
                 "Failed to serialize augmented product.json: {e}"
             );
-            None
+            return None;
         }
+    };
+
+    // Add trailing newline to match typical JSON formatting
+    let augmented = augmented + "\n";
+    if let Err(e) = std::fs::write(&product_path, &augmented) {
+        log::warn!(
+            target: "vscodeee::exthost::sidecar",
+            "Failed to write augmented product.json: {e}"
+        );
+        return None;
     }
+    log::info!(
+        target: "vscodeee::exthost::sidecar",
+        "Wrote augmented product.json with commit and version"
+    );
+    Some((product_path, original))
 }
 
 /// Spawn the Extension Host as a Bun sidecar, returning the connected stream.

--- a/src/vs/workbench/api/node/extHostExtensionService.ts
+++ b/src/vs/workbench/api/node/extHostExtensionService.ts
@@ -83,6 +83,7 @@ class NodeModuleRequireInterceptor extends RequireInterceptor {
 	private _installBunInterceptor(node_module: Record<string, unknown>): void {
 		const that = this;
 		const originalResolveFilename = node_module._resolveFilename as ResolveFilenameFn;
+		const g = globalThis as Record<string, unknown>;
 
 		// Global keys for Bun shim communication
 		const parentKey = '__VSCODEEE_BUN_PARENT__';
@@ -91,10 +92,10 @@ class NodeModuleRequireInterceptor extends RequireInterceptor {
 		// Expose a loader function globally. The shim files call this with
 		// the module name and receive the factory result. This keeps URI and
 		// factory references inside the closure — no need to import them in shims.
-		(globalThis as Record<string, unknown>)[parentKey] = '';
-		(globalThis as Record<string, unknown>)[loaderKey] = (moduleName: string, shimRequire: (id: string) => unknown): unknown => {
+		g[parentKey] = '';
+		g[loaderKey] = (moduleName: string, shimRequire: (id: string) => unknown): unknown => {
 			const factory = that._factories.get(moduleName);
-			const parentFilename = (globalThis as Record<string, unknown>)[parentKey] as string || 'unknown';
+			const parentFilename = g[parentKey] as string || 'unknown';
 			if (factory) {
 				return factory.load(
 					moduleName,
@@ -115,7 +116,7 @@ class NodeModuleRequireInterceptor extends RequireInterceptor {
 			if (that._factories.has(request)) {
 				// Store caller context for the shim to read synchronously
 				const parentFilename = (parent as { filename?: string })?.filename || 'unknown';
-				(globalThis as Record<string, unknown>)[parentKey] = parentFilename;
+				g[parentKey] = parentFilename;
 
 				// Get or create the shim file for this module
 				const shimPath = that._getBunShimPath(shimDir, request, loaderKey);
@@ -253,6 +254,7 @@ class NodeModuleESMInterceptor extends RequireInterceptor {
 	 * so the package re-evaluates with the new API.
 	 */
 	private _installBunESMInterceptor(): void {
+		const g = globalThis as Record<string, unknown>;
 		// Create node_modules/vscode/ in the same shim directory as the CJS interceptor
 		const tmpDir = os.tmpdir();
 		const shimDir = path.join(tmpDir, `vscodeee-bun-shims-${process.pid}`);
@@ -283,14 +285,14 @@ module.exports = globalThis.__VSCODEEE_ESM_API__ || {};
 
 		// Register a global function that _doLoadModule calls before each ESM import.
 		// It looks up the per-extension API, sets the global, and busts the CJS cache.
-		(globalThis as Record<string, unknown>).__VSCODEEE_PREPARE_ESM__ = (moduleUri: string) => {
+		g.__VSCODEEE_PREPARE_ESM__ = (moduleUri: string) => {
 			const factory = this._factories.get('vscode');
 			if (!factory) {
 				return;
 			}
 			const uri = URI.parse(moduleUri);
 			const apiInstance = factory.load('_not_used', uri, () => { throw new Error('Cannot load module from here.'); });
-			(globalThis as Record<string, unknown>).__VSCODEEE_ESM_API__ = apiInstance;
+			g.__VSCODEEE_ESM_API__ = apiInstance;
 
 			// Clear CJS cache so the vscode module re-evaluates with the new API.
 			// Use the known path directly since require.resolve('vscode') may fail
@@ -317,6 +319,7 @@ module.exports = globalThis.__VSCODEEE_ESM_API__ || {};
 		if (!factory) {
 			return;
 		}
+		const g = globalThis as Record<string, unknown>;
 
 		const moduleDir = path.join(shimDir, 'node_modules', moduleName);
 		fs.mkdirSync(moduleDir, { recursive: true });
@@ -328,7 +331,7 @@ module.exports = globalThis.__VSCODEEE_ESM_API__ || {};
 		}));
 
 		const loadedModule = factory.load(moduleName, URI.parse(`file:///${moduleName}`), () => { throw new Error('Cannot load module from here.'); });
-		(globalThis as Record<string, unknown>)[globalKey] = loadedModule;
+		g[globalKey] = loadedModule;
 
 		fs.writeFileSync(path.join(moduleDir, 'index.js'), `'use strict';
 	module.exports = globalThis.${globalKey} || {};
@@ -338,11 +341,13 @@ module.exports = globalThis.__VSCODEEE_ESM_API__ || {};
 	}
 
 	/**
-	 * Create symlinks to the vscode package at locations Bun's ESM resolver searches.
+	 * Create symlinks to the module at locations Bun's ESM resolver searches.
 	 *
-	 * Bun walks up the directory tree looking for node_modules/vscode/.
-	 * Built-in extensions live under extensions/ and user extensions under
-	 * ~/.vscodeee/extensions/, so we symlink at both roots.
+	 * Bun walks up the directory tree looking for node_modules/<name>/.
+	 * In development, built-in extensions live under cwd/extensions/.
+	 * In production, they are at cwd/.build/extensions/ (Tauri maps ../
+	 * resources to _up_/ inside the .app bundle). User extensions are under
+	 * ~/.vscodeee/extensions/. We symlink at all three roots.
 	 */
 	private _createBunESMSymlink(moduleName: string, packageDir: string): void {
 		const createSymlink = (targetDir: string) => {
@@ -356,10 +361,16 @@ module.exports = globalThis.__VSCODEEE_ESM_API__ || {};
 			} catch { /* best-effort: may fail due to permissions */ }
 		};
 
-		// Built-in extensions: extensions/node_modules/vscode
+		// Built-in extensions: extensions/node_modules/<module> (development)
 		createSymlink(path.join(process.cwd(), 'extensions'));
 
-		// User-installed extensions: ~/.vscodeee/extensions/node_modules/vscode
+		// Built-in extensions: .build/extensions/node_modules/<module> (production)
+		const buildExtDir = path.join(process.cwd(), '.build', 'extensions');
+		if (fs.existsSync(buildExtDir)) {
+			createSymlink(buildExtDir);
+		}
+
+		// User-installed extensions: ~/.vscodeee/extensions/node_modules/<module>
 		const homeExtDir = path.join(os.homedir(), '.vscodeee', 'extensions');
 		if (fs.existsSync(homeExtDir)) {
 			createSymlink(homeExtDir);


### PR DESCRIPTION
## Summary

Extension host module resolution failed in production (`cargo tauri build`) but worked in development. Two root causes identified and fixed.

## Changes

- **ESM symlink path fix**: `_createBunESMSymlink()` created symlinks only at `cwd/extensions/node_modules/`, but in production the actual path is `cwd/.build/extensions/node_modules/` due to Tauri's `_up_` resource mapping. Added symlink at the correct path with existence guard.
- **User extension NODE_PATH**: `build_ext_node_modules_paths()` only scanned built-in extension `node_modules`. Added `~/.vscodeee/extensions/*/node_modules` scan so user-installed extensions (e.g., Prettier) can resolve their bundled npm dependencies via CJS `require()`.
- **Refactoring**: Extracted `collect_child_node_modules` helper in Rust to deduplicate directory scanning logic. Reduced `globalThis` casting repetition in TypeScript.

## How to Test

1. `cargo tauri build` and launch the built .app
2. Verify built-in extensions (e.g., vscode.github) activate without "Cannot find package 'vscode'" error
3. Verify user extensions (e.g., Prettier) activate without "Cannot find package 'prettier'" error
4. `cargo tauri dev` — verify existing extension loading still works