### PR TITLE
feat: block GitHub.copilot-chat extension via product.json unsupportedExtensions

### DIFF
--- a/product.json
+++ b/product.json
@@ -207,6 +207,12 @@
   "win32MutexName": "vscodeee",
   "win32NameVersion": "VS Codeee",
   "win32RegValueName": "VSCodeee",
+  "unsupportedExtensions": [
+    {
+      "id": "GitHub.copilot-chat",
+      "reason": "This extension is not compatible with VS Codeee's Bun runtime."
+    }
+  ],
   "win32ShellNameShort": "V&S Codeee",
   "win32TunnelMutex": "vscodeee-tunnel",
   "win32TunnelServiceMutex": "vscodeee-tunnelservice",

--- a/src/vs/base/common/product.ts
+++ b/src/vs/base/common/product.ts
@@ -230,6 +230,11 @@ export interface IProductConfiguration {
 	readonly chatSessionRecommendations?: IChatSessionRecommendation[];
 	readonly emergencyAlertUrl?: string;
 
+	readonly unsupportedExtensions?: ReadonlyArray<{
+		readonly id: string;
+		readonly reason?: string;
+	}>;
+
 	readonly remoteDefaultExtensionsIfInstalledLocally?: string[];
 
 	readonly extensionConfigurationPolicy?: IStringDictionary<IPolicy>;

--- a/src/vs/platform/extensionManagement/common/extensionGalleryService.ts
+++ b/src/vs/platform/extensionManagement/common/extensionGalleryService.ts
@@ -1934,12 +1934,17 @@ export abstract class AbstractExtensionGalleryService implements IExtensionGalle
 	async getExtensionsControlManifest(): Promise<IExtensionsControlManifest> {
 		const manifest = await this.extensionGalleryManifestService.getExtensionGalleryManifest();
 		if (!manifest) {
-			throw new Error('No extension gallery service configured.');
+			// No gallery service configured — still return unsupported extensions from product.json
+			const deprecated: IStringDictionary<IDeprecationInfo> = {};
+			this.addUnsupportedExtensions(deprecated);
+			return { malicious: [], deprecated, search: [], autoUpdate: {} };
 		}
 
 
 		if (!this.extensionsControlUrl) {
-			return { malicious: [], deprecated: {}, search: [], autoUpdate: {} };
+			const deprecated: IStringDictionary<IDeprecationInfo> = {};
+			this.addUnsupportedExtensions(deprecated);
+			return { malicious: [], deprecated, search: [], autoUpdate: {} };
 		}
 
 		const context = await this.requestService.request({
@@ -2005,7 +2010,21 @@ export abstract class AbstractExtensionGalleryService implements IExtensionGalle
 			}
 		};
 
+		this.addUnsupportedExtensions(deprecated);
+
 		return { malicious, deprecated, search, autoUpdate };
+	}
+
+	private addUnsupportedExtensions(deprecated: IStringDictionary<IDeprecationInfo>): void {
+		const unsupported = this.productService.unsupportedExtensions;
+		if (unsupported) {
+			for (const ext of unsupported) {
+				deprecated[ext.id.toLowerCase()] = {
+					disallowInstall: true,
+					additionalInfo: ext.reason
+				};
+			}
+		}
 	}
 
 	private getRequestTimeout(): number {

--- a/src/vs/platform/extensionManagement/common/unsupportedExtensionsMigration.ts
+++ b/src/vs/platform/extensionManagement/common/unsupportedExtensionsMigration.ts
@@ -98,3 +98,40 @@ export async function migrateUnsupportedExtensions(profile: IUserDataProfile | u
 		logService.error(error);
 	}
 }
+
+/**
+ * Uninstalls extensions that are marked as unsupported (deprecated with disallowInstall and no replacement).
+ * This handles extensions that are incompatible with the runtime (e.g., Bun) and should be removed.
+ */
+export async function uninstallUnsupportedExtensions(
+	profile: IUserDataProfile | undefined,
+	extensionManagementService: IExtensionManagementService,
+	logService: ILogService
+): Promise<void> {
+	try {
+		const extensionsControlManifest = await extensionManagementService.getExtensionsControlManifest();
+		if (!extensionsControlManifest.deprecated) {
+			return;
+		}
+		const installed = await extensionManagementService.getInstalled(ExtensionType.User, profile?.extensionsResource);
+		for (const [unsupportedExtensionId, deprecated] of Object.entries(extensionsControlManifest.deprecated)) {
+			// Only handle extensions that disallow install and have NO replacement (pure unsupported)
+			if (!deprecated?.disallowInstall || deprecated.extension) {
+				continue;
+			}
+			const unsupportedExtension = installed.find(i => areSameExtensions(i.identifier, { id: unsupportedExtensionId }));
+			if (!unsupportedExtension) {
+				continue;
+			}
+			try {
+				logService.info(`Uninstalling unsupported extension '${unsupportedExtension.identifier.id}'...`);
+				await extensionManagementService.uninstall(unsupportedExtension, { profileLocation: profile?.extensionsResource });
+				logService.info(`Uninstalled unsupported extension '${unsupportedExtension.identifier.id}'.`);
+			} catch (error) {
+				logService.error(error);
+			}
+		}
+	} catch (error) {
+		logService.error(error);
+	}
+}

--- a/src/vs/workbench/contrib/chat/browser/chatParticipant.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatParticipant.contribution.ts
@@ -32,52 +32,62 @@ import { IRawChatParticipantContribution } from '../common/participants/chatPart
 import { ChatAgentLocation, ChatModeKind } from '../common/constants.js';
 import { ChatViewId, ChatViewContainerId } from './chat.js';
 import { ChatViewPane } from './widgetHosts/viewPane/chatViewPane.js';
+import product from '../../../../platform/product/common/product.js';
 
 // --- Chat Container &  View Registration
 
+// Skip chat view registration entirely if the default chat agent extension is unsupported
+const isChatExtensionUnsupported = product.unsupportedExtensions?.some(
+	ext => ext.id.toLowerCase() === product.defaultChatAgent?.chatExtensionId?.toLowerCase()
+);
+
 const chatViewIcon = registerIcon('chat-view-icon', Codicon.chatSparkle, localize('chatViewIcon', 'View icon of the chat view.'));
 
-const chatViewContainer: ViewContainer = Registry.as<IViewContainersRegistry>(ViewExtensions.ViewContainersRegistry).registerViewContainer({
-	id: ChatViewContainerId,
-	title: localize2('chat.viewContainer.label', "Chat"),
-	icon: chatViewIcon,
-	ctorDescriptor: new SyncDescriptor(ViewPaneContainer, [ChatViewContainerId, { mergeViewWithContainerWhenSingleView: true }]),
-	storageId: ChatViewContainerId,
-	hideIfEmpty: true,
-	order: 1,
-}, ViewContainerLocation.AuxiliaryBar, { isDefault: true, doNotRegisterOpenCommand: true });
+let chatViewContainer: ViewContainer | undefined;
 
-const chatViewDescriptor: IViewDescriptor = {
-	id: ChatViewId,
-	containerIcon: chatViewContainer.icon,
-	containerTitle: chatViewContainer.title.value,
-	singleViewPaneContainerTitle: chatViewContainer.title.value,
-	name: localize2('chat.viewContainer.label', "Chat"),
-	canToggleVisibility: false,
-	canMoveView: true,
-	openCommandActionDescriptor: {
+if (!isChatExtensionUnsupported) {
+	chatViewContainer = Registry.as<IViewContainersRegistry>(ViewExtensions.ViewContainersRegistry).registerViewContainer({
 		id: ChatViewContainerId,
-		title: chatViewContainer.title,
-		mnemonicTitle: localize({ key: 'miToggleChat', comment: ['&& denotes a mnemonic'] }, "&&Chat"),
-		keybindings: {
-			primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.KeyI,
-			mac: {
-				primary: KeyMod.CtrlCmd | KeyMod.WinCtrl | KeyCode.KeyI
-			}
+		title: localize2('chat.viewContainer.label', "Chat"),
+		icon: chatViewIcon,
+		ctorDescriptor: new SyncDescriptor(ViewPaneContainer, [ChatViewContainerId, { mergeViewWithContainerWhenSingleView: true }]),
+		storageId: ChatViewContainerId,
+		hideIfEmpty: true,
+		order: 1,
+	}, ViewContainerLocation.AuxiliaryBar, { isDefault: true, doNotRegisterOpenCommand: true });
+
+	const chatViewDescriptor: IViewDescriptor = {
+		id: ChatViewId,
+		containerIcon: chatViewContainer.icon,
+		containerTitle: chatViewContainer.title.value,
+		singleViewPaneContainerTitle: chatViewContainer.title.value,
+		name: localize2('chat.viewContainer.label', "Chat"),
+		canToggleVisibility: false,
+		canMoveView: true,
+		openCommandActionDescriptor: {
+			id: ChatViewContainerId,
+			title: chatViewContainer.title,
+			mnemonicTitle: localize({ key: 'miToggleChat', comment: ['&& denotes a mnemonic'] }, "&&Chat"),
+			keybindings: {
+				primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.KeyI,
+				mac: {
+					primary: KeyMod.CtrlCmd | KeyMod.WinCtrl | KeyCode.KeyI
+				}
+			},
+			order: 1
 		},
-		order: 1
-	},
-	ctorDescriptor: new SyncDescriptor(ChatViewPane),
-	when: ContextKeyExpr.or(
-		ContextKeyExpr.or(
-			ChatContextKeys.Setup.hidden,
-			ChatContextKeys.Setup.disabled
-		)?.negate(),
-		ChatContextKeys.panelParticipantRegistered,
-		ChatContextKeys.extensionInvalid
-	)
-};
-Registry.as<IViewsRegistry>(ViewExtensions.ViewsRegistry).registerViews([chatViewDescriptor], chatViewContainer);
+		ctorDescriptor: new SyncDescriptor(ChatViewPane),
+		when: ContextKeyExpr.and(
+			ChatContextKeys.Setup.hidden.negate(),
+			ContextKeyExpr.or(
+				ChatContextKeys.Setup.disabled.negate(),
+				ChatContextKeys.panelParticipantRegistered,
+				ChatContextKeys.extensionInvalid
+			)
+		)
+	};
+	Registry.as<IViewsRegistry>(ViewExtensions.ViewsRegistry).registerViews([chatViewDescriptor], chatViewContainer);
+}
 
 const chatParticipantExtensionPoint = extensionsRegistry.ExtensionsRegistry.registerExtensionPoint<IRawChatParticipantContribution[]>({
 	extensionPoint: 'chatParticipants',

--- a/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
@@ -563,7 +563,7 @@ export class InstallAction extends ExtensionAction {
 					}
 				});
 			} else if (this.extension.deprecationInfo.additionalInfo) {
-				detail = new MarkdownString(`${detail} ${this.extension.deprecationInfo.additionalInfo}`);
+				detail = new MarkdownString(this.extension.deprecationInfo.additionalInfo);
 			}
 
 			const { result } = await this.dialogService.prompt({
@@ -2613,11 +2613,13 @@ export class ExtensionStatusAction extends ExtensionAction {
 				const link = `[${localize('settings', "settings")}](${createCommandUri('workbench.action.openSettings', this.extension.deprecationInfo.settings.map(setting => `@id:${setting}`).join(' '))}})`;
 				this.updateStatus({ icon: warningIcon, message: new MarkdownString(localize('deprecated with alternate settings tooltip', "This extension is deprecated as this functionality is now built-in to VS Code. Configure these {0} to use this functionality.", link)) }, true);
 			} else {
-				const message = new MarkdownString(localize('deprecated tooltip', "This extension is deprecated as it is no longer being maintained."));
 				if (this.extension.deprecationInfo.additionalInfo) {
-					message.appendMarkdown(` ${this.extension.deprecationInfo.additionalInfo}`);
+					const message = new MarkdownString(this.extension.deprecationInfo.additionalInfo);
+					this.updateStatus({ icon: warningIcon, message }, true);
+				} else {
+					const message = new MarkdownString(localize('deprecated tooltip', "This extension is deprecated as it is no longer being maintained."));
+					this.updateStatus({ icon: warningIcon, message }, true);
 				}
-				this.updateStatus({ icon: warningIcon, message }, true);
 			}
 			return;
 		}

--- a/src/vs/workbench/contrib/extensions/browser/unsupportedExtensionsMigrationContribution.ts
+++ b/src/vs/workbench/contrib/extensions/browser/unsupportedExtensionsMigrationContribution.ts
@@ -5,7 +5,7 @@
 
 import { IExtensionGalleryService, IGlobalExtensionEnablementService } from '../../../../platform/extensionManagement/common/extensionManagement.js';
 import { IExtensionStorageService } from '../../../../platform/extensionManagement/common/extensionStorage.js';
-import { migrateUnsupportedExtensions } from '../../../../platform/extensionManagement/common/unsupportedExtensionsMigration.js';
+import { migrateUnsupportedExtensions, uninstallUnsupportedExtensions } from '../../../../platform/extensionManagement/common/unsupportedExtensionsMigration.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { IWorkbenchContribution } from '../../../common/contributions.js';
 import { IExtensionManagementServerService } from '../../../services/extensionManagement/common/extensionManagement.js';
@@ -25,6 +25,10 @@ export class UnsupportedExtensionsMigrationContrib implements IWorkbenchContribu
 		}
 		if (extensionManagementServerService.webExtensionManagementServer) {
 			migrateUnsupportedExtensions(undefined, extensionManagementServerService.webExtensionManagementServer.extensionManagementService, extensionGalleryService, extensionStorageService, extensionEnablementService, logService);
+		}
+		// Tauri: no shared process, so uninstall unsupported extensions for local server directly
+		if (extensionManagementServerService.localExtensionManagementServer) {
+			uninstallUnsupportedExtensions(undefined, extensionManagementServerService.localExtensionManagementServer.extensionManagementService, logService);
 		}
 	}
 

--- a/src/vs/workbench/services/chat/common/chatEntitlementService.ts
+++ b/src/vs/workbench/services/chat/common/chatEntitlementService.ts
@@ -341,6 +341,12 @@ export class ChatEntitlementService extends Disposable implements IChatEntitleme
 			return; // we need a default chat agent configured going forward from here
 		}
 
+		// Hide Chat UI if the default chat agent extension is unsupported (e.g., incompatible with Bun runtime)
+		if (productService.unsupportedExtensions?.some(ext => ext.id.toLowerCase() === productService.defaultChatAgent.chatExtensionId.toLowerCase())) {
+			ChatEntitlementContextKeys.Setup.hidden.bindTo(this.contextKeyService).set(true);
+			return;
+		}
+
 		const context = this.context = new Lazy(() => this._register(instantiationService.createInstance(ChatEntitlementContext)));
 		this.requests = new Lazy(() => this._register(instantiationService.createInstance(ChatEntitlementRequests, context.value, {
 			clearQuotas: () => this.clearQuotas(),


### PR DESCRIPTION
## Summary

Block `GitHub.copilot-chat` extension from being installed or used in VS Codeee, as it is incompatible with the Bun runtime.

## Changes

- Add `unsupportedExtensions` configuration to `product.json` with runtime incompatibility reason
- Extend `IProductConfiguration` interface with `unsupportedExtensions` type
- Modify `getExtensionsControlManifest()` to include unsupported extensions in deprecated list even when gallery manifest or controlUrl is unavailable
- Add `uninstallUnsupportedExtensions()` for automatic removal on startup
- Skip chat view container registration entirely when chat extension is unsupported (prevents stale UI from stored state)
- Hide Chat UI via `ChatEntitlementService` `Setup.hidden` context key
- Show only `additionalInfo` as deprecation message in marketplace (not prepended with default "no longer maintained" text)

## Behavior

| Scenario | Result |
|----------|--------|
| Extension already installed | Auto-uninstalled on next launch |
| Try to install from marketplace | Blocked with compatibility warning |
| Chat panel in auxiliary bar | Not rendered (view container not registered) |
| `Open Chat` command (Cmd+Ctrl+I) | Disabled via precondition |
| Command palette "Open Chat" | Greyed out |

## Testing

- [x] Extension auto-uninstalls on startup
- [x] Marketplace shows "This extension is not compatible with VS Codeee's Bun runtime."
- [x] Chat panel completely hidden from auxiliary bar
- [x] TypeScript compiles cleanly
- [x] Rust builds pass

Closes #453