### PR TITLE
🚀 Release v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-05-06
+
+### Added
+
+- Block GitHub.copilot-chat extension via product.json unsupportedExtensions
+
+### Fixed
+
+- Resolve extension module paths in production build
+
+### Changed
+
+- Add retry logic and cleanup-on-failure to release workflow
+
 ## [0.14.0] - 2026-05-05
 
 ### Added

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-utils/schema.json",
   "productName": "VS Codeee",
   "mainBinaryName": "codeee",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "identifier": "com.vscodeee.app",
   "build": {
     "frontendDist": "../out",


### PR DESCRIPTION
## Summary

Release v0.15.0 — version bump and changelog update.

## Changes

- Bump version from 0.14.0 to 0.15.0
- Update CHANGELOG.md with release notes

## What's in this release

### Added
- Block GitHub.copilot-chat extension via product.json unsupportedExtensions

### Fixed
- Resolve extension module paths in production build

### Changed
- Add retry logic and cleanup-on-failure to release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)