### PR TITLE
feat: add cursor auto-hide after inactivity

### DIFF
--- a/build/lib/i18n.resources.json
+++ b/build/lib/i18n.resources.json
@@ -195,6 +195,10 @@
 			"project": "vscode-workbench"
 		},
 		{
+			"name": "vs/workbench/contrib/cursorAutoHide",
+			"project": "vscode-workbench"
+		},
+		{
 			"name": "vs/workbench/contrib/sash",
 			"project": "vscode-workbench"
 		},

--- a/build/next/index.ts
+++ b/build/next/index.ts
@@ -1221,6 +1221,15 @@ async function packageExtensions(): Promise<void> {
 
 	console.log(`[package-extensions] Packaged ${totalFiles} files (${(totalSize / 1024 / 1024).toFixed(1)} MB) into .build/extensions/`);
 	console.log(`[package-extensions]   dist-bundled: ${distCount}, fallback (out+node_modules): ${fallbackCount}`);
+
+	// Clean up top-level node_modules in .build/extensions/ that may be created
+	// by fallback-mode extensions. These contain Node.js built-in stubs (e.g., node:sqlite)
+	// whose colon-prefixed paths break Tauri's resource bundling.
+	const buildExtNodeModules = path.join(REPO_ROOT, '.build', 'extensions', 'node_modules');
+	if (fs.existsSync(buildExtNodeModules)) {
+		await fs.promises.rm(buildExtNodeModules, { recursive: true });
+		console.log('[package-extensions] Cleaned up .build/extensions/node_modules/ (breaks Tauri resource bundling)');
+	}
 }
 
 async function fileExists(filePath: string): Promise<boolean> {

--- a/src/vs/workbench/contrib/cursorAutoHide/browser/cursorAutoHide.contribution.ts
+++ b/src/vs/workbench/contrib/cursorAutoHide/browser/cursorAutoHide.contribution.ts
@@ -1,36 +1,35 @@
 /*---------------------------------------------------------------------------------------------
-*  Copyright (c) Microsoft Corporation. All rights reserved.
-*  Licensed under the MIT License. See License.txt in the project root for license information.
-*--------------------------------------------------------------------------------------------*/
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 
-import { localize } from "../../../../nls.js";
-import { IConfigurationRegistry, Extensions as ConfigurationExtensions } from "../../../../platform/configuration/common/configurationRegistry.js";
-import { Registry } from "../../../../platform/registry/common/platform.js";
-import { registerWorkbenchContribution2, WorkbenchPhase } from "../../../common/contributions.js";
-import { CursorAutoHideController } from "./cursorAutoHide.js";
-
+import { localize } from '../../../../nls.js';
+import { IConfigurationRegistry, Extensions as ConfigurationExtensions } from '../../../../platform/configuration/common/configurationRegistry.js';
+import { Registry } from '../../../../platform/registry/common/platform.js';
+import { registerWorkbenchContribution2, WorkbenchPhase } from '../../../common/contributions.js';
+import { CursorAutoHideController } from './cursorAutoHide.js';
 
 // Cursor auto-hide contribution
 registerWorkbenchContribution2(CursorAutoHideController.ID, CursorAutoHideController, WorkbenchPhase.AfterRestored);
 
 // Cursor auto-hide configuration
 Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
-    .registerConfiguration({
-        "id": "vscodeee",
-        "title": localize("vscodeeeConfigurationTitle", "VS Codeee"),
-        "type": "object",
-        "properties": {
-            "vscodeee.cursorAutoHide.enabled": {
-                "type": "boolean",
-                "default": true,
-                "description": localize("cursorAutoHideEnabled", "Controls whether the mouse cursor is automatically hidden after a period of inactivity.")
-            },
-            "vscodeee.cursorAutoHide.delay": {
-                "type": "number",
-                "default": 3000,
-                "minimum": 500,
-                "maximum": 60000,
-                "description": localize("cursorAutoHideDelay", "Controls the delay in milliseconds before the mouse cursor is hidden after inactivity.")
-            }
-        }
-    })
+	.registerConfiguration({
+		'id': 'vscodeee',
+		'title': localize('vscodeeeConfigurationTitle', "VS Codeee"),
+		'type': 'object',
+		'properties': {
+			'vscodeee.cursorAutoHide.enabled': {
+				'type': 'boolean',
+				'default': true,
+				'description': localize('cursorAutoHideEnabled', "Controls whether the mouse cursor is automatically hidden after a period of inactivity.")
+			},
+			'vscodeee.cursorAutoHide.delay': {
+				'type': 'number',
+				'default': 3000,
+				'minimum': 500,
+				'maximum': 60000,
+				'description': localize('cursorAutoHideDelay', "Controls the delay in milliseconds before the mouse cursor is hidden after inactivity.")
+			}
+		}
+	});

--- a/src/vs/workbench/contrib/cursorAutoHide/browser/cursorAutoHide.contribution.ts
+++ b/src/vs/workbench/contrib/cursorAutoHide/browser/cursorAutoHide.contribution.ts
@@ -1,0 +1,36 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import { localize } from "../../../../nls.js";
+import { IConfigurationRegistry, Extensions as ConfigurationExtensions } from "../../../../platform/configuration/common/configurationRegistry.js";
+import { Registry } from "../../../../platform/registry/common/platform.js";
+import { registerWorkbenchContribution2, WorkbenchPhase } from "../../../common/contributions.js";
+import { CursorAutoHideController } from "./cursorAutoHide.js";
+
+
+// Cursor auto-hide contribution
+registerWorkbenchContribution2(CursorAutoHideController.ID, CursorAutoHideController, WorkbenchPhase.AfterRestored);
+
+// Cursor auto-hide configuration
+Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
+    .registerConfiguration({
+        "id": "vscodeee",
+        "title": localize("vscodeeeConfigurationTitle", "VS Codeee"),
+        "type": "object",
+        "properties": {
+            "vscodeee.cursorAutoHide.enabled": {
+                "type": "boolean",
+                "default": true,
+                "description": localize("cursorAutoHideEnabled", "Controls whether the mouse cursor is automatically hidden after a period of inactivity.")
+            },
+            "vscodeee.cursorAutoHide.delay": {
+                "type": "number",
+                "default": 3000,
+                "minimum": 500,
+                "maximum": 60000,
+                "description": localize("cursorAutoHideDelay", "Controls the delay in milliseconds before the mouse cursor is hidden after inactivity.")
+            }
+        }
+    })

--- a/src/vs/workbench/contrib/cursorAutoHide/browser/cursorAutoHide.ts
+++ b/src/vs/workbench/contrib/cursorAutoHide/browser/cursorAutoHide.ts
@@ -1,0 +1,167 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import { Event } from "../../../../base/common/event.js";
+import { Disposable } from "../../../../base/common/lifecycle.js";
+import { IConfigurationService } from "../../../../platform/configuration/common/configuration.js";
+import { IWorkbenchContribution } from "../../../common/contributions.js";
+import "./media/cursorAutoHide.css";
+
+
+/**
+* Workbench contribution that automatically hides the mouse cursor after a
+* configurable period of inactivity. When the cursor is hidden, pointer-events
+* are suppressed on all child elements to prevent hover highlights (e.g. sash).
+* Any mouse activity restores the cursor; keyboard activity hides it immediately.
+*/
+export class CursorAutoHideController extends Disposable implements IWorkbenchContribution {
+static readonly ID = "workbench.contrib.cursorAutoHide";
+
+private _delay: number = 3000;
+
+private _enabled: boolean = true;
+
+private _isHidden: boolean = false;
+
+private _showCursor(): void {
+        if (this._isHidden) {
+            document.body.classList.remove("cursor-auto-hidden");
+            this._isHidden = false;
+        }
+    }
+
+private _timer: ReturnType<typeof setTimeout> | undefined;
+
+private _clearTimer(): void {
+        if (this._timer !== undefined) {
+            clearTimeout(this._timer);
+            this._timer = undefined;
+        }
+    }
+
+private _hideCursor(): void {
+        if (!this._isHidden) {
+            document.body.classList.add("cursor-auto-hidden");
+            this._isHidden = true;
+        }
+    }
+
+private _resetTimer(): void {
+        this._clearTimer();
+        this._timer = setTimeout(() => {
+            this._hideCursor();
+        }, this._delay);
+    }
+
+private readonly _onActivity = (e: globalThis.Event): void => {
+        if (!this._enabled) {
+            return;
+        }
+        const wasHidden = this._isHidden;
+        this._showCursor();
+        this._resetTimer();
+
+        // If cursor was hidden and user clicked, re-dispatch the click
+        // to the actual target element now that pointer-events is restored
+        if (wasHidden && e.type === "mousedown") {
+            const mouseEvent = e as MouseEvent;
+            const target = document.elementFromPoint(mouseEvent.clientX, mouseEvent.clientY);
+            if (target) {
+                const newEvent = new MouseEvent("mousedown", {
+                    bubbles: true,
+                    cancelable: true,
+                    clientX: mouseEvent.clientX,
+                    clientY: mouseEvent.clientY,
+                    button: mouseEvent.button,
+                    buttons: mouseEvent.buttons,
+                });
+                target.dispatchEvent(newEvent);
+            }
+        }
+    };
+
+private readonly _onKeyDown = (): void => {
+        if (!this._enabled) {
+            return;
+        }
+        // On keydown, hide cursor immediately (user is typing)
+        this._hideCursor();
+        this._clearTimer();
+    };
+
+constructor(
+        @IConfigurationService private readonly configurationService: IConfigurationService,
+    ) {
+        super();
+
+        // Listen for configuration changes
+        const onDidChangeEnabled = Event.filter(
+            configurationService.onDidChangeConfiguration,
+            e => e.affectsConfiguration("vscodeee.cursorAutoHide.enabled")
+        );
+        onDidChangeEnabled(this._onDidChangeEnabled, this, this._store);
+
+        const onDidChangeDelay = Event.filter(
+            configurationService.onDidChangeConfiguration,
+            e => e.affectsConfiguration("vscodeee.cursorAutoHide.delay")
+        );
+        onDidChangeDelay(this._onDidChangeDelay, this, this._store);
+
+        // Initialize
+        this._readConfiguration();
+        this._setupListeners();
+    }
+
+private _onDidChangeDelay(): void {
+        this._delay = this.configurationService.getValue<number>("vscodeee.cursorAutoHide.delay") ?? 3000;
+        if (this._enabled) {
+            this._resetTimer();
+        }
+    }
+
+private _onDidChangeEnabled(): void {
+        this._enabled = this.configurationService.getValue<boolean>("vscodeee.cursorAutoHide.enabled") ?? true;
+        if (!this._enabled) {
+            this._showCursor();
+            this._clearTimer();
+        } else {
+            this._resetTimer();
+        }
+    }
+
+private _readConfiguration(): void {
+        this._enabled = this.configurationService.getValue<boolean>("vscodeee.cursorAutoHide.enabled") ?? true;
+        this._delay = this.configurationService.getValue<number>("vscodeee.cursorAutoHide.delay") ?? 3000;
+    }
+
+override dispose(): void {
+        this._clearTimer();
+        this._showCursor();
+        super.dispose();
+    }
+
+private _setupListeners(): void {
+        // Use document-level listeners with capture phase so they fire
+        // even when pointer-events: none is applied to body
+        const doc = document;
+
+        this._store.add({
+            dispose: () => {
+                doc.removeEventListener("mousemove", this._onActivity, true);
+                doc.removeEventListener("mousedown", this._onActivity, true);
+                doc.removeEventListener("keydown", this._onKeyDown, true);
+            }
+        });
+
+        doc.addEventListener("mousemove", this._onActivity, true);
+        doc.addEventListener("mousedown", this._onActivity, true);
+        doc.addEventListener("keydown", this._onKeyDown, true);
+
+        // Start the timer if enabled
+        if (this._enabled) {
+            this._resetTimer();
+        }
+    }
+}

--- a/src/vs/workbench/contrib/cursorAutoHide/browser/cursorAutoHide.ts
+++ b/src/vs/workbench/contrib/cursorAutoHide/browser/cursorAutoHide.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { mainWindow } from '../../../../base/browser/window.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IWorkbenchContribution } from '../../../common/contributions.js';
@@ -73,7 +74,7 @@ export class CursorAutoHideController extends Disposable implements IWorkbenchCo
 	private _setupListeners(): void {
 		// Use document-level listeners with capture phase so they fire
 		// even when pointer-events: none is applied to body
-		const doc = document;
+		const doc = mainWindow.document;
 
 		this._store.add({
 			dispose: () => {
@@ -105,7 +106,7 @@ export class CursorAutoHideController extends Disposable implements IWorkbenchCo
 		// to the actual target element now that pointer-events is restored
 		if (wasHidden && e.type === 'mousedown') {
 			const mouseEvent = e as MouseEvent;
-			const target = document.elementFromPoint(mouseEvent.clientX, mouseEvent.clientY);
+			const target = mainWindow.document.elementFromPoint(mouseEvent.clientX, mouseEvent.clientY);
 			if (target) {
 				const newEvent = new MouseEvent('mousedown', {
 					bubbles: true,
@@ -145,14 +146,14 @@ export class CursorAutoHideController extends Disposable implements IWorkbenchCo
 
 	private _hideCursor(): void {
 		if (!this._isHidden) {
-			document.body.classList.add('cursor-auto-hidden');
+			mainWindow.document.body.classList.add('cursor-auto-hidden');
 			this._isHidden = true;
 		}
 	}
 
 	private _showCursor(): void {
 		if (this._isHidden) {
-			document.body.classList.remove('cursor-auto-hidden');
+			mainWindow.document.body.classList.remove('cursor-auto-hidden');
 			this._isHidden = false;
 		}
 	}

--- a/src/vs/workbench/contrib/cursorAutoHide/browser/cursorAutoHide.ts
+++ b/src/vs/workbench/contrib/cursorAutoHide/browser/cursorAutoHide.ts
@@ -1,167 +1,165 @@
 /*---------------------------------------------------------------------------------------------
-*  Copyright (c) Microsoft Corporation. All rights reserved.
-*  Licensed under the MIT License. See License.txt in the project root for license information.
-*--------------------------------------------------------------------------------------------*/
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 
-import { Event } from "../../../../base/common/event.js";
-import { Disposable } from "../../../../base/common/lifecycle.js";
-import { IConfigurationService } from "../../../../platform/configuration/common/configuration.js";
-import { IWorkbenchContribution } from "../../../common/contributions.js";
-import "./media/cursorAutoHide.css";
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { IWorkbenchContribution } from '../../../common/contributions.js';
+import { Event } from '../../../../base/common/event.js';
 
+import './media/cursorAutoHide.css';
 
 /**
-* Workbench contribution that automatically hides the mouse cursor after a
-* configurable period of inactivity. When the cursor is hidden, pointer-events
-* are suppressed on all child elements to prevent hover highlights (e.g. sash).
-* Any mouse activity restores the cursor; keyboard activity hides it immediately.
-*/
+ * Workbench contribution that automatically hides the mouse cursor after a
+ * configurable period of inactivity. When the cursor is hidden, pointer-events
+ * are suppressed on all child elements to prevent hover highlights (e.g. sash).
+ * Any mouse activity restores the cursor; keyboard activity hides it immediately.
+ */
 export class CursorAutoHideController extends Disposable implements IWorkbenchContribution {
-static readonly ID = "workbench.contrib.cursorAutoHide";
 
-private _delay: number = 3000;
+	static readonly ID = 'workbench.contrib.cursorAutoHide';
 
-private _enabled: boolean = true;
+	private _enabled: boolean = true;
+	private _delay: number = 3000;
+	private _timer: ReturnType<typeof setTimeout> | undefined;
+	private _isHidden: boolean = false;
 
-private _isHidden: boolean = false;
+	constructor(
+		@IConfigurationService private readonly configurationService: IConfigurationService,
+	) {
+		super();
 
-private _showCursor(): void {
-        if (this._isHidden) {
-            document.body.classList.remove("cursor-auto-hidden");
-            this._isHidden = false;
-        }
-    }
+		// Listen for configuration changes
+		const onDidChangeEnabled = Event.filter(
+			configurationService.onDidChangeConfiguration,
+			e => e.affectsConfiguration('vscodeee.cursorAutoHide.enabled')
+		);
+		onDidChangeEnabled(this._onDidChangeEnabled, this, this._store);
 
-private _timer: ReturnType<typeof setTimeout> | undefined;
+		const onDidChangeDelay = Event.filter(
+			configurationService.onDidChangeConfiguration,
+			e => e.affectsConfiguration('vscodeee.cursorAutoHide.delay')
+		);
+		onDidChangeDelay(this._onDidChangeDelay, this, this._store);
 
-private _clearTimer(): void {
-        if (this._timer !== undefined) {
-            clearTimeout(this._timer);
-            this._timer = undefined;
-        }
-    }
+		// Initialize
+		this._readConfiguration();
+		this._setupListeners();
+	}
 
-private _hideCursor(): void {
-        if (!this._isHidden) {
-            document.body.classList.add("cursor-auto-hidden");
-            this._isHidden = true;
-        }
-    }
+	private _readConfiguration(): void {
+		this._enabled = this.configurationService.getValue<boolean>('vscodeee.cursorAutoHide.enabled') ?? true;
+		this._delay = this.configurationService.getValue<number>('vscodeee.cursorAutoHide.delay') ?? 3000;
+	}
 
-private _resetTimer(): void {
-        this._clearTimer();
-        this._timer = setTimeout(() => {
-            this._hideCursor();
-        }, this._delay);
-    }
+	private _onDidChangeEnabled(): void {
+		this._enabled = this.configurationService.getValue<boolean>('vscodeee.cursorAutoHide.enabled') ?? true;
+		if (!this._enabled) {
+			this._showCursor();
+			this._clearTimer();
+		} else {
+			this._resetTimer();
+		}
+	}
 
-private readonly _onActivity = (e: globalThis.Event): void => {
-        if (!this._enabled) {
-            return;
-        }
-        const wasHidden = this._isHidden;
-        this._showCursor();
-        this._resetTimer();
+	private _onDidChangeDelay(): void {
+		this._delay = this.configurationService.getValue<number>('vscodeee.cursorAutoHide.delay') ?? 3000;
+		if (this._enabled) {
+			this._resetTimer();
+		}
+	}
 
-        // If cursor was hidden and user clicked, re-dispatch the click
-        // to the actual target element now that pointer-events is restored
-        if (wasHidden && e.type === "mousedown") {
-            const mouseEvent = e as MouseEvent;
-            const target = document.elementFromPoint(mouseEvent.clientX, mouseEvent.clientY);
-            if (target) {
-                const newEvent = new MouseEvent("mousedown", {
-                    bubbles: true,
-                    cancelable: true,
-                    clientX: mouseEvent.clientX,
-                    clientY: mouseEvent.clientY,
-                    button: mouseEvent.button,
-                    buttons: mouseEvent.buttons,
-                });
-                target.dispatchEvent(newEvent);
-            }
-        }
-    };
+	private _setupListeners(): void {
+		// Use document-level listeners with capture phase so they fire
+		// even when pointer-events: none is applied to body
+		const doc = document;
 
-private readonly _onKeyDown = (): void => {
-        if (!this._enabled) {
-            return;
-        }
-        // On keydown, hide cursor immediately (user is typing)
-        this._hideCursor();
-        this._clearTimer();
-    };
+		this._store.add({
+			dispose: () => {
+				doc.removeEventListener('mousemove', this._onActivity, true);
+				doc.removeEventListener('mousedown', this._onActivity, true);
+				doc.removeEventListener('keydown', this._onKeyDown, true);
+			}
+		});
 
-constructor(
-        @IConfigurationService private readonly configurationService: IConfigurationService,
-    ) {
-        super();
+		doc.addEventListener('mousemove', this._onActivity, true);
+		doc.addEventListener('mousedown', this._onActivity, true);
+		doc.addEventListener('keydown', this._onKeyDown, true);
 
-        // Listen for configuration changes
-        const onDidChangeEnabled = Event.filter(
-            configurationService.onDidChangeConfiguration,
-            e => e.affectsConfiguration("vscodeee.cursorAutoHide.enabled")
-        );
-        onDidChangeEnabled(this._onDidChangeEnabled, this, this._store);
+		// Start the timer if enabled
+		if (this._enabled) {
+			this._resetTimer();
+		}
+	}
 
-        const onDidChangeDelay = Event.filter(
-            configurationService.onDidChangeConfiguration,
-            e => e.affectsConfiguration("vscodeee.cursorAutoHide.delay")
-        );
-        onDidChangeDelay(this._onDidChangeDelay, this, this._store);
+	private readonly _onActivity = (e: globalThis.Event): void => {
+		if (!this._enabled) {
+			return;
+		}
+		const wasHidden = this._isHidden;
+		this._showCursor();
+		this._resetTimer();
 
-        // Initialize
-        this._readConfiguration();
-        this._setupListeners();
-    }
+		// If cursor was hidden and user clicked, re-dispatch the click
+		// to the actual target element now that pointer-events is restored
+		if (wasHidden && e.type === 'mousedown') {
+			const mouseEvent = e as MouseEvent;
+			const target = document.elementFromPoint(mouseEvent.clientX, mouseEvent.clientY);
+			if (target) {
+				const newEvent = new MouseEvent('mousedown', {
+					bubbles: true,
+					cancelable: true,
+					clientX: mouseEvent.clientX,
+					clientY: mouseEvent.clientY,
+					button: mouseEvent.button,
+					buttons: mouseEvent.buttons,
+				});
+				target.dispatchEvent(newEvent);
+			}
+		}
+	};
 
-private _onDidChangeDelay(): void {
-        this._delay = this.configurationService.getValue<number>("vscodeee.cursorAutoHide.delay") ?? 3000;
-        if (this._enabled) {
-            this._resetTimer();
-        }
-    }
+	private readonly _onKeyDown = (): void => {
+		if (!this._enabled) {
+			return;
+		}
+		// On keydown, hide cursor immediately (user is typing)
+		this._hideCursor();
+		this._clearTimer();
+	};
 
-private _onDidChangeEnabled(): void {
-        this._enabled = this.configurationService.getValue<boolean>("vscodeee.cursorAutoHide.enabled") ?? true;
-        if (!this._enabled) {
-            this._showCursor();
-            this._clearTimer();
-        } else {
-            this._resetTimer();
-        }
-    }
+	private _resetTimer(): void {
+		this._clearTimer();
+		this._timer = setTimeout(() => {
+			this._hideCursor();
+		}, this._delay);
+	}
 
-private _readConfiguration(): void {
-        this._enabled = this.configurationService.getValue<boolean>("vscodeee.cursorAutoHide.enabled") ?? true;
-        this._delay = this.configurationService.getValue<number>("vscodeee.cursorAutoHide.delay") ?? 3000;
-    }
+	private _clearTimer(): void {
+		if (this._timer !== undefined) {
+			clearTimeout(this._timer);
+			this._timer = undefined;
+		}
+	}
 
-override dispose(): void {
-        this._clearTimer();
-        this._showCursor();
-        super.dispose();
-    }
+	private _hideCursor(): void {
+		if (!this._isHidden) {
+			document.body.classList.add('cursor-auto-hidden');
+			this._isHidden = true;
+		}
+	}
 
-private _setupListeners(): void {
-        // Use document-level listeners with capture phase so they fire
-        // even when pointer-events: none is applied to body
-        const doc = document;
+	private _showCursor(): void {
+		if (this._isHidden) {
+			document.body.classList.remove('cursor-auto-hidden');
+			this._isHidden = false;
+		}
+	}
 
-        this._store.add({
-            dispose: () => {
-                doc.removeEventListener("mousemove", this._onActivity, true);
-                doc.removeEventListener("mousedown", this._onActivity, true);
-                doc.removeEventListener("keydown", this._onKeyDown, true);
-            }
-        });
-
-        doc.addEventListener("mousemove", this._onActivity, true);
-        doc.addEventListener("mousedown", this._onActivity, true);
-        doc.addEventListener("keydown", this._onKeyDown, true);
-
-        // Start the timer if enabled
-        if (this._enabled) {
-            this._resetTimer();
-        }
-    }
+	override dispose(): void {
+		this._clearTimer();
+		this._showCursor();
+		super.dispose();
+	}
 }

--- a/src/vs/workbench/contrib/cursorAutoHide/browser/media/cursorAutoHide.css
+++ b/src/vs/workbench/contrib/cursorAutoHide/browser/media/cursorAutoHide.css
@@ -1,0 +1,18 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+.cursor-auto-hidden {
+	cursor: none !important;
+}
+
+.cursor-auto-hidden * {
+	cursor: none !important;
+	pointer-events: none !important;
+}
+
+/* Keep pointer-events on body itself so document-level listeners work */
+.cursor-auto-hidden {
+	pointer-events: auto !important;
+}

--- a/src/vs/workbench/workbench.common.main.ts
+++ b/src/vs/workbench/workbench.common.main.ts
@@ -252,6 +252,9 @@ import './contrib/searchEditor/browser/searchEditor.contribution.js';
 // Sash
 import './contrib/sash/browser/sash.contribution.js';
 
+// Cursor Auto Hide
+import './contrib/cursorAutoHide/browser/cursorAutoHide.contribution.js';
+
 // Git
 import './contrib/git/browser/git.contributions.js';
 


### PR DESCRIPTION
## Summary

Implement a built-in workbench contribution that automatically hides the mouse cursor after a configurable period of inactivity (default: 3 seconds).

## Changes

- Add `CursorAutoHideController` as a workbench contribution (`WorkbenchPhase.AfterRestored`)
- Register settings under `vscodeee.cursorAutoHide`:
  - `enabled` (boolean, default: `true`) — opt-out design
  - `delay` (number, default: `3000` ms, range: 500–60000)
- Apply `cursor: none` + `pointer-events: none` on `body *` to suppress sash hover highlights
- Re-dispatch `mousedown` to correct target on cursor reveal (click-through fix)
- Hide cursor immediately on `keydown` (typing mode)
- Clean up `.build/extensions/node_modules/` in `packageExtensions()` to fix Tauri resource bundling with colon-prefixed paths (`node:sqlite`)

## Settings

| Setting | Type | Default | Description |
|---------|------|---------|-------------|
| `vscodeee.cursorAutoHide.enabled` | boolean | `true` | Enable/disable cursor auto-hide |
| `vscodeee.cursorAutoHide.delay` | number | `3000` | Delay in ms before hiding |

## Testing

- Verified cursor hides after 3 seconds of mouse inactivity
- Verified sash hover highlights do not appear while cursor is hidden
- Verified cursor reappears on mouse movement
- Verified click-through works when cursor is hidden
- Verified immediate hide on keyboard input

Closes #440