### PR TITLE
feat: change vscodeee editor defaults to opt-out model

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editor.ts
+++ b/src/vs/workbench/browser/parts/editor/editor.ts
@@ -24,12 +24,18 @@ import { coalesce } from '../../../../base/common/arrays.js';
 /**
  * Configuration shape for VSCodeEE-specific editor settings.
  * Nested under `vscodeee.workbench.editor` in settings.json.
+ *
+ * These settings allow users to override VSCodeEE's opt-out defaults
+ * for editor part behavior. When defined, they take precedence over
+ * the corresponding properties in `DEFAULT_EDITOR_PART_OPTIONS`.
  */
 interface IVSCodeEEEditorConfiguration {
 	vscodeee?: {
 		workbench?: {
 			editor?: {
+				/** When `true`, editor groups automatically expand/unmaximize on focus (default: `false`). */
 				autoMaximizeOnFocus?: boolean;
+				/** When `true`, displays the group index prefix on the active tab (default: `true`). */
 				editorGroupIndexInTab?: boolean;
 			};
 		};
@@ -58,6 +64,11 @@ export const DEFAULT_EDITOR_MAX_DIMENSIONS = new Dimension(Number.POSITIVE_INFIN
  * Default editor part options. These values are used as fallbacks
  * when no user configuration is provided. Properties that are objects
  * are defined as getters to prevent consumers from mutating the defaults.
+ *
+ * Note: Several defaults differ from upstream VS Code to align with
+ * VSCodeEE's opt-out philosophy:
+ * - `editorGroupIndexInTab` defaults to `true` (upstream: `false`)
+ * - `autoMaximizeOnFocus` defaults to `false` (upstream: `true`)
  */
 export const DEFAULT_EDITOR_PART_OPTIONS: IEditorPartOptions = {
 	showTabs: 'multiple',
@@ -66,7 +77,7 @@ export const DEFAULT_EDITOR_PART_OPTIONS: IEditorPartOptions = {
 	tabActionCloseVisibility: true,
 	tabActionUnpinVisibility: true,
 	showTabIndex: false,
-	editorGroupIndexInTab: false,
+	editorGroupIndexInTab: true,
 	alwaysShowEditorActions: false,
 	tabSizing: 'fit',
 	tabSizingFixedMinWidth: 50,
@@ -91,7 +102,7 @@ export const DEFAULT_EDITOR_PART_OPTIONS: IEditorPartOptions = {
 	dragToOpenWindow: true,
 	centeredLayoutFixedWidth: false,
 	doubleClickTabToToggleEditorGroupSizes: 'expand',
-	autoMaximizeOnFocus: true,
+	autoMaximizeOnFocus: false,
 	editorActionsLocation: 'default',
 	wrapTabs: false,
 	enablePreviewFromQuickOpen: false,
@@ -130,6 +141,12 @@ export function impactsEditorPartOptions(event: IConfigurationChangeEvent): bool
  * with the default options. Handles special cases like `autoLockGroups` object
  * conversion, `window.density.editorTabHeight` override, and the
  * `vscodeee.workbench.editor` settings.
+ *
+ * The merge order is: `DEFAULT_EDITOR_PART_OPTIONS` -> `workbench.editor` (user)
+ * -> `window.density.editorTabHeight` -> `vscodeee.workbench.editor` (user).
+ * The `vscodeee` settings act as a final override layer, allowing users to
+ * fine-tune VSCodeEE-specific defaults independently of the standard
+ * `workbench.editor` configuration.
  *
  * @param configurationService - The configuration service to read settings from.
  * @param themeService - The theme service to determine icon availability.

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -1106,6 +1106,14 @@ Registry.as<IConfigurationMigrationRegistry>(Extensions.ConfigurationMigration)
  * These settings extend the standard VS Code configuration with behaviors
  * specific to the Tauri-based VSCodeEE fork. Settings are scoped under the
  * `vscodeee` prefix to distinguish them from upstream VS Code settings.
+ *
+ * The registered defaults here are kept in sync with `DEFAULT_EDITOR_PART_OPTIONS`
+ * in `editor.ts`. They follow VSCodeEE's opt-out philosophy, which differs from
+ * upstream VS Code for certain settings (e.g., `editorGroupIndexInTab` defaults to
+ * `true`, `autoMaximizeOnFocus` defaults to `false`).
+ *
+ * Users can override these via `vscodeee.workbench.editor.*` in settings.json,
+ * which takes final precedence in {@link getEditorPartOptions}.
  */
 // VSCodeEE: Workbench editor settings
 registry.registerConfiguration({
@@ -1116,12 +1124,12 @@ registry.registerConfiguration({
 	'properties': {
 		'vscodeee.workbench.editor.autoMaximizeOnFocus': {
 			'type': 'boolean',
-			'default': true,
+			'default': false,
 			'description': localize('autoMaximizeOnFocus', "Controls whether editor groups are automatically expanded or unmaximized when receiving focus. When disabled, minimized editor groups stay minimized and other groups stay maximized when focus moves between them.")
 		},
 		'vscodeee.workbench.editor.editorGroupIndexInTab': {
 			'type': 'boolean',
-			'default': false,
+			'default': true,
 			'description': localize('editorGroupIndexInTab', "When enabled, shows the editor group index prefix (e.g., [1]) on the active tab of each editor group. Only appears when 2 or more editor groups are open.")
 		}
 	}


### PR DESCRIPTION
## Summary
- Change `vscodeee.workbench.editor.editorGroupIndexInTab` default from `false` to `true` — displays group index prefix (e.g., `[1]`) on tabs by default for tmux-like navigation
- Change `vscodeee.workbench.editor.autoMaximizeOnFocus` default from `true` to `false` — editor groups no longer auto-maximize on focus, providing tmux-like pane behavior
- Add JSDoc documentation for `IVSCodeEEEditorConfiguration`, `DEFAULT_EDITOR_PART_OPTIONS`, and `getEditorPartOptions` clarifying the opt-out philosophy and override precedence

Closes #446

## Test plan
- [ ] Verify editor group index `[1]`, `[2]` appears on tabs when 2+ editor groups are open with no user config
- [ ] Verify editor groups do NOT auto-maximize when switching focus between groups with no user config
- [ ] Verify both settings can still be overridden via `settings.json`
- [ ] Verify `DEFAULT_EDITOR_PART_OPTIONS` and configuration registry defaults are consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)