### PR TITLE
feat: add tmux-like active pane border highlighting

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -106,6 +106,13 @@ VSCodeee は Electron アーキテクチャを2つのレイヤーで置き換え
 - 最小Paneにフォーカスすると自動的に対象Paneが最大化されることを抑制する
   - `"vscodeee.workbench.editor.autoMaximizeOnFocus": false`
   - 本家VSCodeの[issue#85309](https://github.com/microsoft/vscode/issues/85309)
+- 一定時間操作がないとマウスカーソルを自動非表示
+  - `"vscodeee.cursorAutoHide.enabled": true`
+  - `"vscodeee.cursorAutoHide.delay": 3000` (ミリ秒)
+- アクティブペインのボーダーハイライト（tmuxライク）
+  - `"vscodeee.activePaneBorder.enabled": true`
+  - `"vscodeee.activePaneBorder.color": ""` (空文字 = テーマのfocusBorder色)
+  - `"vscodeee.activePaneBorder.width": 1` (px, 1〜5)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,13 @@ VSCodeee replaces the Electron architecture at two layers, achieving significant
 - Suppress auto-maximize when focusing the smallest pane
   - `"vscodeee.workbench.editor.autoMaximizeOnFocus": false`
   - Upstream VSCode [issue#85309](https://github.com/microsoft/vscode/issues/85309)
+- Cursor auto-hide after inactivity
+  - `"vscodeee.cursorAutoHide.enabled": true`
+  - `"vscodeee.cursorAutoHide.delay": 3000` (ms)
+- Active pane border highlight (tmux-like)
+  - `"vscodeee.activePaneBorder.enabled": true`
+  - `"vscodeee.activePaneBorder.color": ""` (empty = theme focusBorder)
+  - `"vscodeee.activePaneBorder.width": 1` (px, 1–5)
 
 ---
 

--- a/build/lib/stylelint/vscode-known-variables.json
+++ b/build/lib/stylelint/vscode-known-variables.json
@@ -916,6 +916,8 @@
 		"--vscode-window-inactiveBorder"
 	],
 	"others": [
+		"--active-pane-border-color",
+		"--active-pane-border-width",
 		"--activity-bar-action-height",
 		"--activity-bar-icon-size",
 		"--activity-bar-width",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
 		"symlink-local-component-explorer": "npm install ../vscode-packages/js-component-explorer/packages/explorer ../vscode-packages/js-component-explorer/packages/cli --no-save && cd build/rspack && npm install ../../../vscode-packages/js-component-explorer/packages/webpack-plugin ../../../vscode-packages/js-component-explorer/packages/explorer --no-save && cd ../vite && npm install ../../../vscode-packages/js-component-explorer/packages/vite-plugin ../../../vscode-packages/js-component-explorer/packages/explorer --no-save",
 		"install-latest-component-explorer": "npm install @vscode/component-explorer@next @vscode/component-explorer-cli@next && cd build/rspack && npm install @vscode/component-explorer-webpack-plugin@next @vscode/component-explorer@next && cd ../vite && npm install @vscode/component-explorer-vite-plugin@next @vscode/component-explorer@next",
 		"tauri": "tauri",
-		"tauri:dev": "npm install --silent || npm install && bash scripts/check-csp-hash.sh && node scripts/download-bun.mjs && node scripts/bundle-node-modules.mjs && node build/next/index.ts transpile && node build/next/index.ts transpile-extensions && node build/next/index.ts package-extensions && node scripts/generate-css-modules.mjs && tauri dev",
+		"tauri:dev": "npm install --silent || npm install && bash scripts/check-csp-hash.sh && node scripts/download-bun.mjs && node scripts/bundle-node-modules.mjs && node build/next/index.ts transpile && node build/next/index.ts transpile-extensions && node build/next/index.ts package-extensions && rm -rf .build/extensions/node_modules && node scripts/generate-css-modules.mjs && tauri dev",
 		"tauri:build": "npm install && bash scripts/check-csp-hash.sh && tauri build"
 	},
 	"dependencies": {

--- a/src/vs/workbench/browser/parts/editor/editor.ts
+++ b/src/vs/workbench/browser/parts/editor/editor.ts
@@ -367,6 +367,11 @@ export interface IEditorGroupView extends IDisposable, ISerializableView, IEdito
 	 */
 	updateEditorGroupIndex(): void;
 
+	/**
+	 * Updates the visual styles of this editor group (e.g. active pane border).
+	 */
+	updateStyles(): void;
+
 	openEditor(editor: EditorInput, options?: IEditorOptions, internalOptions?: IInternalEditorOpenOptions): Promise<IEditorPane | undefined>;
 
 	relayout(): void;

--- a/src/vs/workbench/browser/parts/editor/editorGroupView.ts
+++ b/src/vs/workbench/browser/parts/editor/editorGroupView.ts
@@ -17,7 +17,7 @@ import { IContextKeyService } from '../../../../platform/contextkey/common/conte
 import { ProgressBar } from '../../../../base/browser/ui/progressbar/progressbar.js';
 import { IThemeService, Themable } from '../../../../platform/theme/common/themeService.js';
 import { editorBackground, contrastBorder } from '../../../../platform/theme/common/colorRegistry.js';
-import { EDITOR_GROUP_HEADER_TABS_BACKGROUND, EDITOR_GROUP_HEADER_NO_TABS_BACKGROUND, EDITOR_GROUP_EMPTY_BACKGROUND, EDITOR_GROUP_HEADER_BORDER } from '../../../common/theme.js';
+import { EDITOR_GROUP_HEADER_TABS_BACKGROUND, EDITOR_GROUP_HEADER_NO_TABS_BACKGROUND, EDITOR_GROUP_EMPTY_BACKGROUND, EDITOR_GROUP_HEADER_BORDER, EDITOR_GROUP_ACTIVE_BORDER } from '../../../common/theme.js';
 import { ICloseEditorsFilter, GroupsOrder, ICloseEditorOptions, ICloseAllEditorsOptions, IEditorReplacement, IActiveEditorActions } from '../../../services/editor/common/editorGroupsService.js';
 import { EditorPanes } from './editorPanes.js';
 import { IEditorProgressService } from '../../../../platform/progress/common/progress.js';
@@ -44,6 +44,7 @@ import { Schemas } from '../../../../base/common/network.js';
 import { EditorActivation, IEditorOptions } from '../../../../platform/editor/common/editor.js';
 import { IFileDialogService, ConfirmResult, IDialogService } from '../../../../platform/dialogs/common/dialogs.js';
 import { IFilesConfigurationService, AutoSaveMode } from '../../../services/filesConfiguration/common/filesConfigurationService.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { URI } from '../../../../base/common/uri.js';
 import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uriIdentity.js';
 import { isLinux, isMacintosh, isNative, isWindows } from '../../../../base/common/platform.js';
@@ -156,6 +157,7 @@ export class EditorGroupView extends Themable implements IEditorGroupView {
 		@IFileDialogService private readonly fileDialogService: IFileDialogService,
 		@IEditorService private readonly editorService: EditorServiceImpl,
 		@IFilesConfigurationService private readonly filesConfigurationService: IFilesConfigurationService,
+		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@IUriIdentityService private readonly uriIdentityService: IUriIdentityService,
 		@ILogService private readonly logService: ILogService,
 		@IEditorResolverService private readonly editorResolverService: IEditorResolverService,
@@ -594,6 +596,10 @@ export class EditorGroupView extends Themable implements IEditorGroupView {
 
 		// Focus
 		this._register(this.onDidFocus(() => this.onDidGainFocus()));
+
+		// Active pane border configuration changes
+		const onDidChangeActivePaneBorder = Event.filter(this.configurationService.onDidChangeConfiguration, e => e.affectsConfiguration('vscodeee.activePaneBorder'));
+		this._register(onDidChangeActivePaneBorder(() => this.updateStyles()));
 	}
 
 	private onDidGroupModelChange(e: IGroupModelChangeEvent): void {
@@ -2157,6 +2163,28 @@ export class EditorGroupView extends Themable implements IEditorGroupView {
 
 		// Editor container
 		this.editorContainer.style.backgroundColor = this.getColor(editorBackground) || '';
+
+		// Active pane border (tmux-like): only show when multiple groups exist
+		const activePaneBorderEnabled = this.configurationService.getValue<boolean>('vscodeee.activePaneBorder.enabled') ?? true;
+		const hasMultipleGroups = this.groupsView.groups.length > 1;
+		if (activePaneBorderEnabled && hasMultipleGroups && this.active) {
+			const colorOverride = this.configurationService.getValue<string>('vscodeee.activePaneBorder.color');
+			const activeBorderColor = colorOverride || this.getColor(EDITOR_GROUP_ACTIVE_BORDER);
+			if (activeBorderColor) {
+				this.element.classList.add('active-pane-border');
+				this.element.style.setProperty('--active-pane-border-color', activeBorderColor);
+				const widthValue = this.configurationService.getValue<number>('vscodeee.activePaneBorder.width') ?? 1;
+				this.element.style.setProperty('--active-pane-border-width', `${widthValue}px`);
+			} else {
+				this.element.classList.remove('active-pane-border');
+				this.element.style.removeProperty('--active-pane-border-color');
+				this.element.style.removeProperty('--active-pane-border-width');
+			}
+		} else {
+			this.element.classList.remove('active-pane-border');
+			this.element.style.removeProperty('--active-pane-border-color');
+			this.element.style.removeProperty('--active-pane-border-width');
+		}
 	}
 
 	//#endregion

--- a/src/vs/workbench/browser/parts/editor/editorPart.ts
+++ b/src/vs/workbench/browser/parts/editor/editorPart.ts
@@ -216,6 +216,10 @@ export class EditorPart extends Part<IEditorPartMemento> implements IEditorPart,
 		// Update editor group index indicator when groups are added/removed
 		this._register(this.onDidAddGroup(() => this.updateAllGroupIndexIndicators()));
 		this._register(this.onDidRemoveGroup(() => this.updateAllGroupIndexIndicators()));
+
+		// Update active pane border styles when group count changes
+		this._register(this.onDidAddGroup(() => this.updateAllGroupStyles()));
+		this._register(this.onDidRemoveGroup(() => this.updateAllGroupStyles()));
 	}
 
 	private onConfigurationUpdated(event: IConfigurationChangeEvent): void {
@@ -250,6 +254,12 @@ export class EditorPart extends Part<IEditorPartMemento> implements IEditorPart,
 	private updateAllGroupIndexIndicators(): void {
 		for (const groupView of this.groupViews.values()) {
 			groupView.updateEditorGroupIndex();
+		}
+	}
+
+	private updateAllGroupStyles(): void {
+		for (const groupView of this.groupViews.values()) {
+			groupView.updateStyles();
 		}
 	}
 

--- a/src/vs/workbench/browser/parts/editor/media/editorgroupview.css
+++ b/src/vs/workbench/browser/parts/editor/media/editorgroupview.css
@@ -58,6 +58,17 @@
 
 .monaco-workbench .part.editor > .content .editor-group-container {
 	height: 100%;
+	position: relative;
+}
+
+/* Active pane border (tmux-like) */
+.monaco-workbench .part.editor > .content .editor-group-container.active-pane-border::after {
+	content: '';
+	position: absolute;
+	inset: 0;
+	border: var(--active-pane-border-width, 1px) solid var(--active-pane-border-color, transparent);
+	pointer-events: none;
+	z-index: 100;
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container.empty  {

--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -235,6 +235,13 @@ export const EDITOR_GROUP_BORDER = registerColor('editorGroup.border', {
 	hcLight: contrastBorder
 }, localize('editorGroupBorder', "Color to separate multiple editor groups from each other. Editor groups are the containers of editors."));
 
+export const EDITOR_GROUP_ACTIVE_BORDER = registerColor('editorGroup.activeBorder', {
+	dark: focusBorder,
+	light: focusBorder,
+	hcDark: contrastBorder,
+	hcLight: contrastBorder
+}, localize('editorGroupActiveBorder', "Border color of the active editor group when multiple editor groups are open. Similar to tmux active pane border. Defaults to the theme's focus border color."));
+
 export const EDITOR_DRAG_AND_DROP_BACKGROUND = registerColor('editorGroup.dropBackground', {
 	dark: Color.fromHex('#53595D').transparent(0.5),
 	light: Color.fromHex('#2677CB').transparent(0.18),

--- a/src/vs/workbench/contrib/cursorAutoHide/browser/cursorAutoHide.contribution.ts
+++ b/src/vs/workbench/contrib/cursorAutoHide/browser/cursorAutoHide.contribution.ts
@@ -12,7 +12,7 @@ import { CursorAutoHideController } from './cursorAutoHide.js';
 // Cursor auto-hide contribution
 registerWorkbenchContribution2(CursorAutoHideController.ID, CursorAutoHideController, WorkbenchPhase.AfterRestored);
 
-// Cursor auto-hide configuration
+// VS Codeee configuration
 Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
 	.registerConfiguration({
 		'id': 'vscodeee',
@@ -30,6 +30,23 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
 				'minimum': 500,
 				'maximum': 60000,
 				'description': localize('cursorAutoHideDelay', "Controls the delay in milliseconds before the mouse cursor is hidden after inactivity.")
+			},
+			'vscodeee.activePaneBorder.enabled': {
+				'type': 'boolean',
+				'default': true,
+				'description': localize('activePaneBorderEnabled', "Controls whether the active editor pane displays a border highlight when multiple panes are open (tmux-like).")
+			},
+			'vscodeee.activePaneBorder.color': {
+				'type': 'string',
+				'default': '',
+				'description': localize('activePaneBorderColor', "Override color for the active pane border (e.g. '#00FF00'). When empty, the theme's focus border color is used.")
+			},
+			'vscodeee.activePaneBorder.width': {
+				'type': 'number',
+				'default': 1,
+				'minimum': 1,
+				'maximum': 5,
+				'description': localize('activePaneBorderWidth', "Controls the width in pixels of the active pane border.")
 			}
 		}
 	});

--- a/src/vs/workbench/test/browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/workbenchTestServices.ts
@@ -1019,6 +1019,7 @@ export class TestEditorGroupView implements IEditorGroupView {
 	relayout() { }
 	createEditorActions(_menuDisposable: IDisposable): { actions: IToolbarActions; onDidChange: Event<IMenuChangeEvent> } { throw new Error('not implemented'); }
 	updateEditorGroupIndex(): void { }
+	updateStyles(): void { }
 }
 
 export class TestEditorGroupAccessor implements IEditorGroupsView {


### PR DESCRIPTION
## Summary

Implement configurable active pane border that highlights the focused editor group when multiple panes are open, similar to tmux's active pane indicator.

## Changes

- New color token `editorGroup.activeBorder` (defaults to theme `focusBorder`)
- CSS `::after` pseudo-element with `z-index: 100` for border rendering
- Settings: `vscodeee.activePaneBorder.enabled`, `.color`, `.width`
- Border only shows when 2+ editor groups exist
- Group count change triggers style update for all groups
- Fix `npm run tauri:dev` startup failure (stale `.build/extensions/node_modules/` cleanup)
- Document new settings in README.md and README.ja.md

## Settings

| Setting | Default | Description |
|---------|---------|-------------|
| `vscodeee.activePaneBorder.enabled` | `true` | Enable/disable active pane border |
| `vscodeee.activePaneBorder.color` | `""` | Override color (empty = theme focusBorder) |
| `vscodeee.activePaneBorder.width` | `1` | Border width in px (1–5) |

Closes #449