### PR TITLE
feat: block Remote-SSH and Remote-Tunnels extensions via unsupportedExtensions

### DIFF
--- a/product.json
+++ b/product.json
@@ -211,6 +211,14 @@
     {
       "id": "GitHub.copilot-chat",
       "reason": "This extension is not compatible with VS Codeee's Bun runtime."
+    },
+    {
+      "id": "ms-vscode-remote.remote-ssh",
+      "reason": "Remote-SSH is not compatible with VS Codeee's Tauri architecture. Electron-based remote extensions are not supported."
+    },
+    {
+      "id": "ms-vscode.remote-server",
+      "reason": "Remote-Tunnels is not compatible with VS Codeee's Tauri architecture. Electron-based remote extensions are not supported."
     }
   ],
   "win32ShellNameShort": "V&S Codeee",


### PR DESCRIPTION
## Summary

Block `ms-vscode-remote.remote-ssh` (Remote-SSH) and `ms-vscode.remote-server` (Remote-Tunnels) extensions via the existing `unsupportedExtensions` mechanism in `product.json`.

These extensions are architecturally incompatible with VS Codeee's Tauri runtime (they require Electron-based remote infrastructure).

## Changes

- Added 2 entries to `unsupportedExtensions` in `product.json`
- Leverages existing infrastructure from #454 (no code changes needed)

## Behavior

1. Extensions are excluded from marketplace search/install
2. Already-installed instances are auto-uninstalled on startup
3. Deprecation warning message displayed in extension details

Closes #227