### PR TITLE
feat: add configurable terminal horizontal padding setting

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -113,6 +113,8 @@ VSCodeee は Electron アーキテクチャを2つのレイヤーで置き換え
   - `"vscodeee.activePaneBorder.enabled": true`
   - `"vscodeee.activePaneBorder.color": ""` (空文字 = テーマのfocusBorder色)
   - `"vscodeee.activePaneBorder.width": 1` (px, 1〜5)
+  - ターミナルの水平パディング
+  - `"vscodeee.terminal.horizontalPadding": 20` (px, 0〜100)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ VSCodeee replaces the Electron architecture at two layers, achieving significant
   - `"vscodeee.activePaneBorder.enabled": true`
   - `"vscodeee.activePaneBorder.color": ""` (empty = theme focusBorder)
   - `"vscodeee.activePaneBorder.width": 1` (px, 1–5)
+  - Terminal horizontal padding
+  - `"vscodeee.terminal.horizontalPadding": 20` (px, 0–100)
 
 ---
 

--- a/build/lib/stylelint/vscode-known-variables.json
+++ b/build/lib/stylelint/vscode-known-variables.json
@@ -1055,6 +1055,7 @@
 		"--vscode-cornerRadius-small",
 		"--vscode-cornerRadius-xLarge",
 		"--vscode-cornerRadius-xSmall",
-		"--vscode-strokeThickness"
+		"--vscode-strokeThickness",
+		"--vscodeee-terminal-hpadding"
 	]
 }

--- a/src/vs/workbench/contrib/cursorAutoHide/browser/cursorAutoHide.contribution.ts
+++ b/src/vs/workbench/contrib/cursorAutoHide/browser/cursorAutoHide.contribution.ts
@@ -3,6 +3,20 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+/**
+ * Cursor auto-hide and VSCodeee-specific configuration contribution.
+ *
+ * Registers the {@link CursorAutoHideController} as a workbench contribution and
+ * declares all `vscodeee.*` configuration properties, including:
+ *
+ * - `vscodeee.cursorAutoHide.enabled` / `vscodeee.cursorAutoHide.delay` -
+ *   automatic mouse cursor hiding after a period of inactivity
+ * - `vscodeee.activePaneBorder.enabled` / `.color` / `.width` -
+ *   tmux-like active editor pane border highlighting
+ * - `vscodeee.terminal.horizontalPadding` -
+ *   configurable horizontal padding for the integrated terminal
+ */
+
 import { localize } from '../../../../nls.js';
 import { IConfigurationRegistry, Extensions as ConfigurationExtensions } from '../../../../platform/configuration/common/configurationRegistry.js';
 import { Registry } from '../../../../platform/registry/common/platform.js';
@@ -47,6 +61,13 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
 				'minimum': 1,
 				'maximum': 5,
 				'description': localize('activePaneBorderWidth', "Controls the width in pixels of the active pane border.")
+			},
+			'vscodeee.terminal.horizontalPadding': {
+				'type': 'number',
+				'default': 20,
+				'minimum': 0,
+				'maximum': 100,
+				'description': localize('terminalHorizontalPadding', "Controls the horizontal padding (in pixels) applied to both left and right sides of the integrated terminal.")
 			}
 		}
 	});

--- a/src/vs/workbench/contrib/terminal/browser/media/terminal.css
+++ b/src/vs/workbench/contrib/terminal/browser/media/terminal.css
@@ -72,17 +72,21 @@
 	box-sizing: border-box;
 }
 
+.monaco-workbench .terminal-wrapper {
+	--vscodeee-terminal-hpadding: 20px;
+}
+
 .monaco-workbench .xterm {
-	/* All terminals have at least 20px left padding for the gutter */
-	padding-left: 20px;
+	padding-left: var(--vscodeee-terminal-hpadding);
+	padding-right: max(0px, calc(var(--vscodeee-terminal-hpadding) - 14px));
 }
 
 .monaco-workbench .xterm .xterm-scrollable-element {
 	/* Offset the scrollable element such that:
 	 * - The terminal grid will be positioned to the right of the gutter
 	 * - Elements are not hidden in the gutter */
-	margin-left: -20px;
-	padding-left: 20px;
+	margin-left: calc(-1 * var(--vscodeee-terminal-hpadding));
+	padding-left: var(--vscodeee-terminal-hpadding);
 }
 
 .monaco-workbench .terminal-editor .xterm,

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -399,6 +399,7 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 
 		this._wrapperElement = document.createElement('div');
 		this._wrapperElement.classList.add('terminal-wrapper');
+		this._applyTerminalHorizontalPadding();
 
 		this._widgetManager = this._register(instantiationService.createInstance(TerminalWidgetManager));
 
@@ -588,9 +589,13 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 				TerminalSettingId.FontWeightBold,
 				TerminalSettingId.LetterSpacing,
 				TerminalSettingId.LineHeight,
-				'editor.fontFamily'
+				'editor.fontFamily',
+				'vscodeee.terminal.horizontalPadding'
 			];
 			if (layoutSettings.some(id => e.affectsConfiguration(id))) {
+				if (e.affectsConfiguration('vscodeee.terminal.horizontalPadding')) {
+					this._applyTerminalHorizontalPadding();
+				}
 				this._layoutSettingsChanged = true;
 				await this._resize();
 			}
@@ -747,6 +752,32 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 		this._onMaximumDimensionsChanged.fire();
 	}
 
+	/**
+	 * Applies the user-configured horizontal padding to the terminal wrapper element.
+	 *
+	 * Reads the `vscodeee.terminal.horizontalPadding` setting and sets it as the
+	 * `--vscodeee-terminal-hpadding` CSS custom property on the terminal wrapper
+	 * DOM element. This value is consumed by `terminal.css` to control the left and
+	 * right padding of the xterm.js canvas.
+	 */
+	private _applyTerminalHorizontalPadding(): void {
+		const padding = this._configurationService.getValue<number>('vscodeee.terminal.horizontalPadding') ?? 20;
+		this._wrapperElement.style.setProperty('--vscodeee-terminal-hpadding', `${padding}px`);
+	}
+
+	/**
+	 * Calculates the available canvas dimensions for the terminal, accounting for
+	 * CSS padding (including the configurable horizontal padding) and scrollbar space.
+	 *
+	 * The computed CSS padding values are read from the xterm.js element so that any
+	 * dynamically applied padding (e.g. `vscodeee.terminal.horizontalPadding`) is
+	 * automatically reflected in the grid size calculation.
+	 *
+	 * @param width - The total available width in pixels (container width)
+	 * @param height - The total available height in pixels (container height)
+	 * @returns The canvas dimensions clamped to `MaxCanvasWidth`, or `undefined` if
+	 *          the font has not been initialized or the xterm element is not available
+	 */
 	private _getDimension(width: number, height: number): ICanvasDimensions | undefined {
 		// The font needs to have been initialized
 		const font = this.xterm ? this.xterm.getFont() : this._terminalConfigurationService.getFont(dom.getWindow(this.domElement));


### PR DESCRIPTION
## Summary
- Add `vscodeee.terminal.horizontalPadding` setting (0-100px, default 20) to control left and right padding of the integrated terminal
- Replace hardcoded 20px gutter padding with CSS custom property `--vscodeee-terminal-hpadding` on `.terminal-wrapper`
- Right-side padding automatically accounts for the 14px scrollbar offset to keep visual balance
- Padding changes are applied in real-time via the existing layout settings configuration listener

## Test plan
- [ ] Open terminal and verify default 20px padding on both sides (right visually matches left after scrollbar offset)
- [ ] Set `"vscodeee.terminal.horizontalPadding": 0` in settings.json and verify padding is removed
- [ ] Set `"vscodeee.terminal.horizontalPadding": 40` and verify wider padding on both sides
- [ ] Verify terminal column count recalculates automatically when setting changes
- [ ] Verify shell integration decorations still render correctly with default 20px

🤖 Generated with [Claude Code](https://claude.com/claude-code)