### PR TITLE
🚀 Release v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.0] - 2026-05-06
+
+### Added
+
+- Add configurable terminal horizontal padding setting (#465)
+- Block Remote-SSH and Remote-Tunnels extensions via unsupportedExtensions (#463)
+
+### Changed
+
+- Remove unused native message box dialog code (#464)
+
 ## [0.17.0] - 2026-05-06
 
 ### Added

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-utils/schema.json",
   "productName": "VS Codeee",
   "mainBinaryName": "codeee",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "identifier": "com.vscodeee.app",
   "build": {
     "frontendDist": "../out",


### PR DESCRIPTION
## Summary

Release v0.18.0 — bump version from 0.17.0 to 0.18.0 and update CHANGELOG.

## Related Issue

N/A

## Changes

- Add configurable terminal horizontal padding setting (#465)
- Block Remote-SSH and Remote-Tunnels extensions via unsupportedExtensions (#463)
- Remove unused native message box dialog code (#464)
- Update `src-tauri/tauri.conf.json`: version `0.17.0` → `0.18.0`
- Update `CHANGELOG.md`: add [0.18.0] entry

## Screenshots / Recording

N/A (version bump only)

## How to Test

1. Verify `src-tauri/tauri.conf.json` version is `0.18.0`
2. Verify `CHANGELOG.md` has a `[0.18.0]` section