### PR TITLE
feat: hide Chat UI while keeping non-chat Copilot features functional

### DIFF
--- a/product.json
+++ b/product.json
@@ -207,11 +207,8 @@
   "win32MutexName": "vscodeee",
   "win32NameVersion": "VS Codeee",
   "win32RegValueName": "VSCodeee",
+  "chatHidden": true,
   "unsupportedExtensions": [
-    {
-      "id": "GitHub.copilot-chat",
-      "reason": "This extension is not compatible with VS Codeee's Bun runtime."
-    },
     {
       "id": "ms-vscode-remote.remote-ssh",
       "reason": "Remote-SSH is not compatible with VS Codeee's Tauri architecture. Electron-based remote extensions are not supported."

--- a/src/vs/base/common/product.ts
+++ b/src/vs/base/common/product.ts
@@ -230,6 +230,8 @@ export interface IProductConfiguration {
 	readonly chatSessionRecommendations?: IChatSessionRecommendation[];
 	readonly emergencyAlertUrl?: string;
 
+	readonly chatHidden?: boolean;
+
 	readonly unsupportedExtensions?: ReadonlyArray<{
 		readonly id: string;
 		readonly reason?: string;

--- a/src/vs/workbench/contrib/chat/browser/chatParticipant.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatParticipant.contribution.ts
@@ -37,7 +37,8 @@ import product from '../../../../platform/product/common/product.js';
 // --- Chat Container &  View Registration
 
 // Skip chat view registration entirely if the default chat agent extension is unsupported
-const isChatExtensionUnsupported = product.unsupportedExtensions?.some(
+// or if chat is explicitly hidden at the product level
+const isChatExtensionUnsupported = product.chatHidden || product.unsupportedExtensions?.some(
 	ext => ext.id.toLowerCase() === product.defaultChatAgent?.chatExtensionId?.toLowerCase()
 );
 

--- a/src/vs/workbench/contrib/chat/browser/chatStatus/chatStatusEntry.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatStatus/chatStatusEntry.ts
@@ -54,7 +54,10 @@ export class ChatStatusBarEntry extends Disposable implements IWorkbenchContribu
 
 	private update(): void {
 		const sentiment = this.chatEntitlementService.sentiment;
-		if (!sentiment.hidden) {
+		// When chat is hidden at the product level (product.chatHidden), we still show
+		// the status bar entry to display auth state and inline completions status.
+		// Only hide when the extension is truly unsupported (no shim available).
+		if (!sentiment.hidden || product.chatHidden) {
 			const props = this.getEntryProps();
 			if (this.entry) {
 				this.entry.update(props);

--- a/src/vs/workbench/contrib/extensions/browser/unsupportedExtensionsMigrationContribution.ts
+++ b/src/vs/workbench/contrib/extensions/browser/unsupportedExtensionsMigrationContribution.ts
@@ -3,10 +3,14 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IExtensionGalleryService, IGlobalExtensionEnablementService } from '../../../../platform/extensionManagement/common/extensionManagement.js';
+import { CancellationToken } from '../../../../base/common/cancellation.js';
+import { IExtensionGalleryService, IExtensionManagementService, IGlobalExtensionEnablementService } from '../../../../platform/extensionManagement/common/extensionManagement.js';
+import { areSameExtensions } from '../../../../platform/extensionManagement/common/extensionManagementUtil.js';
 import { IExtensionStorageService } from '../../../../platform/extensionManagement/common/extensionStorage.js';
 import { migrateUnsupportedExtensions, uninstallUnsupportedExtensions } from '../../../../platform/extensionManagement/common/unsupportedExtensionsMigration.js';
+import { ExtensionType } from '../../../../platform/extensions/common/extensions.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
+import { IProductService } from '../../../../platform/product/common/productService.js';
 import { IWorkbenchContribution } from '../../../common/contributions.js';
 import { IExtensionManagementServerService } from '../../../services/extensionManagement/common/extensionManagement.js';
 
@@ -17,6 +21,7 @@ export class UnsupportedExtensionsMigrationContrib implements IWorkbenchContribu
 		@IExtensionGalleryService extensionGalleryService: IExtensionGalleryService,
 		@IExtensionStorageService extensionStorageService: IExtensionStorageService,
 		@IGlobalExtensionEnablementService extensionEnablementService: IGlobalExtensionEnablementService,
+		@IProductService productService: IProductService,
 		@ILogService logService: ILogService,
 	) {
 		// Unsupported extensions are not migrated for local extension management server, because it is done in shared process
@@ -29,6 +34,47 @@ export class UnsupportedExtensionsMigrationContrib implements IWorkbenchContribu
 		// Tauri: no shared process, so uninstall unsupported extensions for local server directly
 		if (extensionManagementServerService.localExtensionManagementServer) {
 			uninstallUnsupportedExtensions(undefined, extensionManagementServerService.localExtensionManagementServer.extensionManagementService, logService);
+		}
+
+		// Auto-install the default chat agent extension when chat UI is hidden but
+		// non-chat Copilot features (inline completions, NES, SCM) are desired.
+		if (productService.chatHidden && productService.defaultChatAgent?.chatExtensionId) {
+			const extensionManagementService = extensionManagementServerService.localExtensionManagementServer?.extensionManagementService;
+			if (extensionManagementService) {
+				this.ensureChatExtensionInstalled(
+					productService.defaultChatAgent.chatExtensionId,
+					extensionManagementService,
+					extensionGalleryService,
+					logService
+				);
+			}
+		}
+	}
+
+	private async ensureChatExtensionInstalled(
+		chatExtensionId: string,
+		extensionManagementService: IExtensionManagementService,
+		galleryService: IExtensionGalleryService,
+		logService: ILogService
+	): Promise<void> {
+		try {
+			const installed = await extensionManagementService.getInstalled(ExtensionType.User);
+			const isInstalled = installed.some(ext => areSameExtensions(ext.identifier, { id: chatExtensionId }));
+			if (isInstalled) {
+				return;
+			}
+
+			logService.info(`[chatHidden] Default chat agent extension '${chatExtensionId}' is not installed. Installing from gallery...`);
+			const [gallery] = await galleryService.getExtensions([{ id: chatExtensionId }], CancellationToken.None);
+			if (!gallery) {
+				logService.warn(`[chatHidden] Could not find extension '${chatExtensionId}' in the gallery.`);
+				return;
+			}
+
+			await extensionManagementService.installFromGallery(gallery, { isMachineScoped: false });
+			logService.info(`[chatHidden] Successfully installed '${chatExtensionId}' extension.`);
+		} catch (error) {
+			logService.error(`[chatHidden] Failed to auto-install '${chatExtensionId}':`, error);
 		}
 	}
 

--- a/src/vs/workbench/services/chat/common/chatEntitlementService.ts
+++ b/src/vs/workbench/services/chat/common/chatEntitlementService.ts
@@ -347,6 +347,15 @@ export class ChatEntitlementService extends Disposable implements IChatEntitleme
 			return;
 		}
 
+		// Hide Chat UI at the product level (e.g., chat is disabled but other Copilot features like
+		// inline completions, NES, SCM commit messages remain functional).
+		// Unlike the unsupported extension check above, we do NOT return early here so that
+		// the entitlement service continues to initialize — this keeps the status bar entry
+		// and authentication flow working.
+		if (productService.chatHidden) {
+			ChatEntitlementContextKeys.Setup.hidden.bindTo(this.contextKeyService).set(true);
+		}
+
 		const context = this.context = new Lazy(() => this._register(instantiationService.createInstance(ChatEntitlementContext)));
 		this.requests = new Lazy(() => this._register(instantiationService.createInstance(ChatEntitlementRequests, context.value, {
 			clearQuotas: () => this.clearQuotas(),


### PR DESCRIPTION
## Summary

Closes #466

Hide the Chat View and Activity Bar tab while preserving all non-chat Copilot features (inline completions, NES, SCM commit message generation).

## Changes

- Add `product.chatHidden` flag to `product.json` and `IProductConfiguration` interface
- Gate Chat View Container registration on `product.chatHidden` in `chatParticipant.contribution.ts`
- Keep `ChatEntitlementService` fully initialized (no early return) so Status Bar and auth continue to work
- Override Status Bar visibility to always show when `chatHidden` is true
- Auto-install `GitHub.copilot-chat` extension from gallery on startup when missing (previously auto-uninstalled)
- Remove `GitHub.copilot-chat` from `unsupportedExtensions` list

## Architecture

| Component | Behavior with `chatHidden: true` |
|-----------|----------------------------------|
| Chat View Container | Not registered (hidden) |
| Activity Bar Copilot tab | Not visible |
| Status Bar Copilot icon | Visible (auth + completions state) |
| Inline completions | Functional |
| SCM commit messages | Functional |
| NES (Next Edit Suggestions) | Functional |
| Extension auto-install | Installs from gallery if missing |

## Testing

- Verified Chat View and Activity Bar tab are hidden
- Verified Status Bar Copilot icon is visible
- Verified inline completions work
- Verified SCM commit message generation works
- TypeScript compile check passes