### PR TITLE
chore: release v0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.0] - 2026-05-06
+
+### Added
+
+- Hide Chat UI while keeping non-chat Copilot features functional (#468)
+  - Add `product.chatHidden` flag to hide Chat View and Activity Bar tab
+  - Auto-install copilot-chat extension from gallery on startup
+  - Preserve inline completions, NES, and SCM commit message generation
+
 ## [0.18.0] - 2026-05-06
 
 ### Added

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-utils/schema.json",
   "productName": "VS Codeee",
   "mainBinaryName": "codeee",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "identifier": "com.vscodeee.app",
   "build": {
     "frontendDist": "../out",


### PR DESCRIPTION
## Summary

Release v0.19.0

### Changes since v0.18.0

- feat: hide Chat UI while keeping non-chat Copilot features functional (#468)
  - Add `product.chatHidden` flag to hide Chat View and Activity Bar tab
  - Auto-install copilot-chat extension from gallery on startup
  - Preserve inline completions, NES, and SCM commit message generation

### Version Updates

- `src-tauri/tauri.conf.json`: 0.18.0 → 0.19.0
- `CHANGELOG.md`: Added v0.19.0 section