### PR TITLE
feat: use dynamic terminal tab title from OSC sequence

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -1912,7 +1912,6 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 			this._setTitle(title, TitleEventSource.Sequence);
 		}
 	}
-
 	private async _trust(): Promise<boolean> {
 		if (this._configurationService.getValue(TerminalSettingId.AllowInUntrustedWorkspace)) {
 			this._logService.info(`Workspace trust check bypassed due to ${TerminalSettingId.AllowInUntrustedWorkspace}`);
@@ -2091,6 +2090,9 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 
 	private _updateTitleProperties(title: string | undefined, eventSource: TitleEventSource): string {
 		if (!title) {
+			if (eventSource === TitleEventSource.Sequence) {
+				this._sequence = undefined;
+			}
 			return this._processName;
 		}
 		switch (eventSource) {
@@ -2368,7 +2370,6 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 		if ((this._shellLaunchConfig?.type === 'Task' || this._titleSource === TitleEventSource.Api) && eventSource === TitleEventSource.Process) {
 			return;
 		}
-
 		const reset = !title;
 		title = this._updateTitleProperties(title, eventSource);
 		const titleChanged = title !== this._title;
@@ -2838,8 +2839,6 @@ export function parseExitResult(
 
 	return { code, message };
 }
-
-
 export class TerminalInstanceColorProvider implements IXtermColorProvider {
 	constructor(
 		private readonly _target: IReference<TerminalLocation | undefined>,

--- a/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
@@ -342,7 +342,7 @@ const terminalConfiguration: IStringDictionary<IConfigurationPropertySchema> = {
 	},
 	[TerminalSettingId.TerminalTitle]: {
 		'type': 'string',
-		'default': '${process}',
+		'default': '${sequence}',
 		'markdownDescription': terminalTitle
 	},
 	[TerminalSettingId.TerminalDescription]: {


### PR DESCRIPTION
## Summary
- Change default `terminal.integrated.tabs.title` from `${process}` to `${sequence}` to enable wezterm-like dynamic tab titles
- Fix a bug where empty OSC sequences did not clear the stored sequence title, causing stale titles to persist after program exit

## Details

When a shell or program sends an OSC 0/2 escape sequence, the terminal tab title now updates automatically (e.g., Claude CLI shows "Claude Code", vim shows "vim"). When the program sends an empty OSC sequence, the stored sequence is cleared and the title falls back to the process name (e.g., "zsh").

Closes #472

🤖 Generated with [Claude Code](https://claude.com/claude-code)