### PR TITLE
🚀 Release v0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.0] - 2026-05-07
+
+### Added
+
+- Add tmux-like active border to sidebar, panel, and auxiliary bar (#477)
+  - Visually highlight the currently focused panel container with a colored border
+- Use dynamic terminal tab title from OSC sequence (#478)
+  - Terminal tabs now display the title set by shell escape sequences (OSC 0/2)
+
 ## [0.19.1] - 2026-05-07
 
 ### Fixed

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-utils/schema.json",
   "productName": "VS Codeee",
   "mainBinaryName": "codeee",
-  "version": "0.19.1",
+  "version": "0.20.0",
   "identifier": "com.vscodeee.app",
   "build": {
     "frontendDist": "../out",


### PR DESCRIPTION
## Summary

Release v0.20.0 — bumps version from v0.19.1 with 2 new features.

## Changes

- **Add tmux-like active border to sidebar, panel, and auxiliary bar** (#477)
  - Visually highlight the currently focused panel container with a colored border using existing `vscodeee.activePaneBorder.*` settings
- **Use dynamic terminal tab title from OSC sequence** (#478)
  - Terminal tabs now display the title set by shell escape sequences (OSC 0/2)

## How to Test

1. Launch the app and verify version is `0.20.0`
2. Click between sidebar, panel, and auxiliary bar — confirm active border highlights the focused part
3. Open a terminal and run a command that sets the tab title via OSC sequence — confirm the tab title updates dynamically

🤖 Generated with [Claude Code](https://claude.com/claude-code)