### PR TITLE
feat: exclude terminal editors from Quick Open results

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -115,6 +115,8 @@ VSCodeee は Electron アーキテクチャを2つのレイヤーで置き換え
   - `"vscodeee.activePaneBorder.width": 1` (px, 1〜5)
   - ターミナルの水平パディング
   - `"vscodeee.terminal.horizontalPadding": 20` (px, 0〜100)
+- Quick Openからターミナルエディタを除外する
+  - `"vscodeee.quickOpen.excludeTerminals": true`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ VSCodeee replaces the Electron architecture at two layers, achieving significant
   - `"vscodeee.activePaneBorder.width": 1` (px, 1–5)
   - Terminal horizontal padding
   - `"vscodeee.terminal.horizontalPadding": 20` (px, 0–100)
+- Exclude terminal editors from Quick Open
+  - `"vscodeee.quickOpen.excludeTerminals": true`
 
 ---
 

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -1131,6 +1131,12 @@ registry.registerConfiguration({
 			'type': 'boolean',
 			'default': true,
 			'description': localize('editorGroupIndexInTab', "When enabled, shows the editor group index prefix (e.g., [1]) on the active tab of each editor group. Only appears when 2 or more editor groups are open.")
+		},
+		/** Controls whether terminal editor tabs are hidden from Quick Open (Cmd/Ctrl+P) results. */
+		'vscodeee.quickOpen.excludeTerminals': {
+			'type': 'boolean',
+			'default': true,
+			'description': localize('quickOpenExcludeTerminals', "When enabled, terminal editors are excluded from Quick Open (Cmd+P) results.")
 		}
 	}
 });

--- a/src/vs/workbench/contrib/search/browser/anythingQuickAccess.ts
+++ b/src/vs/workbench/contrib/search/browser/anythingQuickAccess.ts
@@ -104,6 +104,9 @@ export class AnythingQuickAccessProvider extends PickerQuickAccessProvider<IAnyt
 
 	private static readonly MAX_RESULTS = 512;
 
+	/** Type identifier for {@link TerminalEditorInput}, used to detect terminal editors in Quick Open results. */
+	private static readonly TERMINAL_EDITOR_TYPE_ID = 'workbench.editors.terminal';
+
 	private static readonly TYPING_SEARCH_DELAY = 200; // this delay accommodates for the user typing a word and then stops typing to start searching
 
 	private static SYMBOL_PICKS_MERGE_DELAY = 200; // allow some time to merge fast and slow picks to reduce flickering
@@ -205,6 +208,14 @@ export class AnythingQuickAccessProvider extends PickerQuickAccessProvider<IAnyt
 		this.editorSymbolsQuickAccess = this.instantiationService.createInstance(GotoSymbolQuickAccessProvider);
 	}
 
+	/**
+	 * Resolves the merged Quick Open configuration from editor, search,
+	 * quickOpen, and VSCodeEE-specific settings. Cached per access; each
+	 * property is re-read from {@link IConfigurationService} on every call.
+	 *
+	 * @returns An object containing Quick Open behavior flags and the
+	 *          {@link excludeTerminals} toggle from `vscodeee.quickOpen.excludeTerminals`.
+	 */
 	private get configuration() {
 		const editorConfig = this.configurationService.getValue<IWorkbenchEditorConfiguration>().workbench?.editor;
 		const searchConfig = this.configurationService.getValue<IWorkbenchSearchConfiguration>().search;
@@ -216,7 +227,8 @@ export class AnythingQuickAccessProvider extends PickerQuickAccessProvider<IAnyt
 			includeSymbols: searchConfig?.quickOpen.includeSymbols,
 			includeHistory: searchConfig?.quickOpen.includeHistory,
 			historyFilterSortOrder: searchConfig?.quickOpen.history.filterSortOrder,
-			preserveInput: quickAccessConfig.preserveInput
+			preserveInput: quickAccessConfig.preserveInput,
+			excludeTerminals: this.configurationService.getValue<boolean>('vscodeee.quickOpen.excludeTerminals') ?? true
 		};
 	}
 
@@ -504,7 +516,9 @@ export class AnythingQuickAccessProvider extends PickerQuickAccessProvider<IAnyt
 
 		// Just return all history entries if not searching
 		if (!query.normalized) {
-			return this.historyService.getHistory().map(editor => this.createAnythingPick(editor, configuration));
+			return this.historyService.getHistory()
+				.filter(editor => !this.isTerminalEditor(editor, configuration))
+				.map(editor => this.createAnythingPick(editor, configuration));
 		}
 
 		if (!this.configuration.includeHistory) {
@@ -517,6 +531,10 @@ export class AnythingQuickAccessProvider extends PickerQuickAccessProvider<IAnyt
 		for (const editor of this.historyService.getHistory()) {
 			const resource = editor.resource;
 			if (!resource) {
+				continue;
+			}
+
+			if (this.isTerminalEditor(editor, configuration)) {
 				continue;
 			}
 
@@ -542,6 +560,26 @@ export class AnythingQuickAccessProvider extends PickerQuickAccessProvider<IAnyt
 
 		// Perform sorting
 		return editorHistoryPicks.sort((editorA, editorB) => compareItemsByFuzzyScore(editorA, editorB, query, false, editorHistoryScorerAccessor, this.pickState.scorerCache));
+	}
+
+	/**
+	 * Determines whether the given editor represents a terminal editor tab
+	 * and should therefore be excluded from Quick Open results.
+	 *
+	 * When the {@link configuration.excludeTerminals} flag is `false`, this
+	 * method always returns `false` regardless of the editor type.
+	 *
+	 * @param editor - The editor input or resource editor input to check.
+	 * @param configuration - The current Quick Open configuration containing
+	 *                        the `excludeTerminals` toggle.
+	 * @returns `true` if the editor is a terminal editor and terminal exclusion
+	 *          is enabled; `false` otherwise.
+	 */
+	private isTerminalEditor(editor: EditorInput | IResourceEditorInput, configuration: { excludeTerminals: boolean }): boolean {
+		if (!configuration.excludeTerminals) {
+			return false;
+		}
+		return isEditorInput(editor) && editor.typeId === AnythingQuickAccessProvider.TERMINAL_EDITOR_TYPE_ID;
 	}
 
 	//#endregion


### PR DESCRIPTION
## Summary
- Add `vscodeee.quickOpen.excludeTerminals` setting (default: `true`) to exclude terminal editor tabs from Quick Open (Cmd+P) results
- Terminal editors remain visible in the Editor Picker (Ctrl+Tab) — only the Go to File quick access is affected

## Details

When terminal instances are opened as editor tabs, they appear in the Quick Open (Cmd+P) history results alongside file editors. This change adds a configurable filter to exclude terminal editors from Quick Open, keeping the results focused on file navigation.

The filtering is applied at display time in `AnythingQuickAccessProvider.getEditorHistoryPicks()` by checking `editor.typeId` against `TerminalEditorInput.ID`. No new cross-contribution dependencies are introduced — the terminal type ID is referenced as a documented string literal.

## Test plan
- [ ] Open a terminal as an editor tab (Terminal: Move Terminal into Editor Area)
- [ ] Cmd+P → terminal editor should NOT appear in results (default: `excludeTerminals: true`)
- [ ] Ctrl+Tab → terminal editor SHOULD still appear in Editor Picker
- [ ] Set `vscodeee.quickOpen.excludeTerminals: false` → terminal SHOULD appear in Cmd+P
- [ ] Verify setting description appears in Settings editor under "VSCodeEE"

🤖 Generated with [Claude Code](https://claude.com/claude-code)