### PR TITLE
🚀 Release v0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.0] - 2026-05-07
+
+### Added
+
+- Exclude terminal editors (vim, nano, etc.) from Quick Open results (#481)
+
 ## [0.20.0] - 2026-05-07
 
 ### Added

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-utils/schema.json",
   "productName": "VS Codeee",
   "mainBinaryName": "codeee",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "identifier": "com.vscodeee.app",
   "build": {
     "frontendDist": "../out",


### PR DESCRIPTION
## Summary
- Bump version from v0.20.0 to v0.21.0
- Add changelog entry for Quick Open terminal editor exclusion

## Related Issue

Related to #481

## Changes
- Update version in `src-tauri/tauri.conf.json` from 0.20.0 to 0.21.0
- Add changelog entry for excluding terminal editors from Quick Open results

## How to Test
1. Verify version number is correctly set to 0.21.0 in `src-tauri/tauri.conf.json`
2. Verify CHANGELOG.md entry is correct
3. Verify Quick Open excludes terminal editors as expected