### PR TITLE
chore: release v0.21.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.1] - 2026-05-08
+
+### Fixed
+
+- Patch open-remote-ssh for Bun runtime compatibility (#483)
+
 ## [0.21.0] - 2026-05-07
 
 ### Added

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-utils/schema.json",
   "productName": "VS Codeee",
   "mainBinaryName": "codeee",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "identifier": "com.vscodeee.app",
   "build": {
     "frontendDist": "../out",


### PR DESCRIPTION
## Summary

Patch release v0.21.1 to fix open-remote-ssh compatibility with Bun runtime.

## Changes

- Bump version from `0.21.0` to `0.21.1` in `src-tauri/tauri.conf.json`
- Update CHANGELOG.md with release notes

## How to Test

1. Verify version bump in `src-tauri/tauri.conf.json`
2. Verify CHANGELOG.md entry for v0.21.1
3. CI/CD pipeline should create GitHub Release and tag automatically on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)