### PR TITLE
fix(windows): vscode-file:// protocol and frontendDist path handling

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -152,7 +152,19 @@ pub async fn get_window_configuration(
                 .ok()
                 .map(|rd| rd.join("out"))
         })
-        .map(|p| p.to_string_lossy().to_string())
+        .map(|p| {
+            let s = p.to_string_lossy().to_string();
+            // Strip Windows extended-length path prefix (\\?\) which causes
+            // TypeScript's URI.file() to misparse the path as UNC.
+            #[cfg(target_os = "windows")]
+            {
+                s.trim_start_matches(r"\\?\").to_string()
+            }
+            #[cfg(not(target_os = "windows"))]
+            {
+                s
+            }
+        })
         .unwrap_or_default();
 
     // Application data directory for user settings/state.

--- a/src-tauri/src/commands/window.rs
+++ b/src-tauri/src/commands/window.rs
@@ -81,7 +81,19 @@ pub async fn get_extended_window_configuration(
                 .ok()
                 .map(|rd| rd.join("out"))
         })
-        .map(|p| p.to_string_lossy().to_string())
+        .map(|p| {
+            let s = p.to_string_lossy().to_string();
+            // Strip Windows extended-length path prefix (\\?\) which causes
+            // TypeScript's URI.file() to misparse the path as UNC.
+            #[cfg(target_os = "windows")]
+            {
+                s.trim_start_matches(r"\\?\").to_string()
+            }
+            #[cfg(not(target_os = "windows"))]
+            {
+                s
+            }
+        })
         .unwrap_or_default();
 
     let fullscreen = window.is_fullscreen().unwrap_or(false);

--- a/src-tauri/src/protocol/mod.rs
+++ b/src-tauri/src/protocol/mod.rs
@@ -246,12 +246,18 @@ fn serve_file(
 ///   `/Users/foo/work/vscodeee/out/vs/code/foo.js` → `"vs/code/foo.js"`
 ///   `/Applications/VS Codeee.app/Contents/Resources/out/vs/base/worker/...` → `"vs/base/worker/..."`
 ///
-/// Returns `None` if the path does not contain `/out/`.
+/// Returns `None` if the path does not contain `/out/` or `\out\`.
 fn extract_asset_key(decoded_path: &str) -> Option<&str> {
-    // Find the last occurrence of "/out/" to handle paths like
-    // `/foo/checkout/out/vs/...` or `/app/Resources/out/vs/...`
+    // Find the last occurrence of "/out/" (forward slash: URI paths, macOS/Linux)
     if let Some(idx) = decoded_path.rfind("/out/") {
         let key = &decoded_path[idx + 5..]; // skip "/out/"
+        if !key.is_empty() {
+            return Some(key);
+        }
+    }
+    // Try backslash (Windows filesystem paths from parse_vscode_file_uri_raw)
+    if let Some(idx) = decoded_path.rfind("\\out\\") {
+        let key = &decoded_path[idx + 5..]; // skip "\out\"
         if !key.is_empty() {
             return Some(key);
         }

--- a/src-tauri/src/protocol/uri.rs
+++ b/src-tauri/src/protocol/uri.rs
@@ -74,6 +74,23 @@ pub fn parse_vscode_file_uri(raw_uri: &str) -> Result<PathBuf, ProtocolError> {
     // symlinks and verify the final path exists, and roots validation follows.
     let normalized = normalize_dot_segments(&decoded);
 
+    // On Windows, URI paths from TypeScript's URI.file() come as /E:/work/...
+    // (forward slashes with leading / before the drive letter). Convert to a
+    // native Windows path (E:\work\...) so canonicalize() can resolve it.
+    #[cfg(target_os = "windows")]
+    let normalized = {
+        let s = normalized.to_string_lossy();
+        if let Some(stripped) = s.strip_prefix('/') {
+            if stripped.len() >= 2 && stripped.as_bytes()[1] == b':' {
+                PathBuf::from(stripped.replace('/', r"\"))
+            } else {
+                normalized
+            }
+        } else {
+            normalized
+        }
+    };
+
     // Canonicalize to resolve symlinks and verify the path exists.
     let canonical = std::fs::canonicalize(&normalized).map_err(|e| match e.kind() {
         std::io::ErrorKind::NotFound => {

--- a/src/vs/platform/extensionResourceLoader/browser/extensionResourceLoaderService.ts
+++ b/src/vs/platform/extensionResourceLoader/browser/extensionResourceLoaderService.ts
@@ -14,6 +14,7 @@ import { ILogService } from '../../log/common/log.js';
 import { IConfigurationService } from '../../configuration/common/configuration.js';
 import { AbstractExtensionResourceLoaderService, IExtensionResourceLoaderService } from '../common/extensionResourceLoader.js';
 import { IExtensionGalleryManifestService } from '../../extensionManagement/common/extensionGalleryManifest.js';
+import * as platform from '../../../base/common/platform.js';
 
 class ExtensionResourceLoaderService extends AbstractExtensionResourceLoaderService {
 
@@ -34,11 +35,15 @@ class ExtensionResourceLoaderService extends AbstractExtensionResourceLoaderServ
 	async readExtensionResource(uri: URI): Promise<string> {
 		uri = FileAccess.uriToBrowserUri(uri);
 
-		// In Tauri, file:// URIs are rewritten to vscode-file:// by uriToBrowserUri.
-		// The vscode-file:// scheme is served by Tauri's custom protocol handler, not
-		// by an IFileService provider, so we must use fetch() to load these resources.
-		// For http/https/data schemes, we also use fetch() (with optional gallery headers).
-		if (uri.scheme !== Schemas.http && uri.scheme !== Schemas.https && uri.scheme !== Schemas.data && uri.scheme !== Schemas.vscodeFileResource) {
+		// In Tauri, convert vscode-file:// back to file:// and route through
+		// _fileService.readFile() which uses TauriDiskFileSystemProvider (IPC).
+		// This bypasses fetch() which depends on browser custom-scheme support
+		// that may behave differently across WebView runtimes (WKWebView vs WebView2).
+		if (platform.isTauri && uri.scheme === Schemas.vscodeFileResource) {
+			uri = FileAccess.uriToFileUri(uri);
+		}
+
+		if (uri.scheme !== Schemas.http && uri.scheme !== Schemas.https && uri.scheme !== Schemas.data) {
 			const result = await this._fileService.readFile(uri);
 			return result.value.toString();
 		}


### PR DESCRIPTION
## Summary

- Strip `\?\` extended-length path prefix from `frontendDist` on Windows, preventing TypeScript `URI.file()` from misparsing the path as UNC (authority `?` → `%3F` in URIs)
- Convert URI drive-letter paths (`/E:/work/...`) to native Windows paths (`E:\work\...`) in `parse_vscode_file_uri()` so `canonicalize()` can resolve them
- Handle backslash paths (`\out\`) in `extract_asset_key()` for Windows embedded asset lookup
- Route `vscode-file://` extension resource reads through `_fileService.readFile()` → `TauriDiskFileSystemProvider` (IPC) instead of `fetch()`, bypassing WebView2 custom-scheme limitations

## Root Cause

Windows `std::fs::canonicalize()` returns paths with the `\?\` prefix. This flowed to TypeScript as `frontendDist`, where `URI.file()` interpreted `\?\E:\...` (normalized to `//?/E:/...`) as a UNC path with authority `?`. The resulting `vscode-file://%3F/...` URIs could not be parsed by the Rust protocol handler, causing **all** resource loading to fail (404).

## Test Plan

- [ ] Build and run on Windows 11 — verify workbench loads without errors
- [ ] Build and run on macOS — verify no regression
- [ ] Open a workspace with extensions — verify extension resources load
- [ ] Check DevTools network tab for `vscode-file://` request success rates
- [ ] Verify AMD module loading (`<script src="vscode-file://...">`) works on WebView2

🤖 Generated with [Claude Code](https://claude.com/claude-code)