### PR TITLE
fix: add localhost HTTP file server for Windows WebView2 compatibility

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -73,6 +73,13 @@ pub struct WindowConfiguration {
     /// Cached theme foreground color from previous session (e.g. `"#CCCCCC"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub theme_foreground: Option<String>,
+    /// URL of the localhost file server (Windows only).
+    ///
+    /// WebView2 blocks `fetch()` and `import()` for custom URI schemes.
+    /// The TypeScript side uses this URL to construct HTTP resource URLs
+    /// instead of `vscode-file://` URIs. Empty string on non-Windows.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub file_server_url: String,
 }
 
 /// Retrieve native host environment information.
@@ -152,7 +159,19 @@ pub async fn get_window_configuration(
                 .ok()
                 .map(|rd| rd.join("out"))
         })
-        .map(|p| p.to_string_lossy().to_string())
+        .map(|p| {
+            let s = p.to_string_lossy().to_string();
+            // Strip Windows extended-length path prefix (\\?\) which causes
+            // TypeScript's URI.file() to misparse the path as UNC.
+            #[cfg(target_os = "windows")]
+            {
+                s.trim_start_matches(r"\\?\").to_string()
+            }
+            #[cfg(not(target_os = "windows"))]
+            {
+                s
+            }
+        })
         .unwrap_or_default();
 
     // Application data directory for user settings/state.
@@ -181,6 +200,15 @@ pub async fn get_window_configuration(
     // Read cached theme colors from previous session for splash screen.
     let (theme_background, theme_foreground) = read_theme_cache(&app_handle);
 
+    // Retrieve the file server URL (Windows only, empty string on other platforms).
+    #[cfg(target_os = "windows")]
+    let file_server_url = app_handle
+        .try_state::<std::sync::Arc<crate::FileServerState>>()
+        .map(|s| s.url.clone())
+        .unwrap_or_default();
+    #[cfg(not(target_os = "windows"))]
+    let file_server_url = String::new();
+
     Ok(WindowConfiguration {
         window_id,
         log_level: 1, // Info
@@ -192,6 +220,7 @@ pub async fn get_window_configuration(
         is_dev_build,
         theme_background,
         theme_foreground,
+        file_server_url,
     })
 }
 

--- a/src-tauri/src/commands/window.rs
+++ b/src-tauri/src/commands/window.rs
@@ -41,6 +41,9 @@ pub struct ExtendedWindowConfiguration {
     pub fullscreen: bool,
     /// Whether the window is currently maximized.
     pub maximized: bool,
+    /// URL of the localhost file server (Windows only, empty on other platforms).
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub file_server_url: String,
 }
 
 /// Retrieve extended window configuration including OS info.
@@ -81,11 +84,32 @@ pub async fn get_extended_window_configuration(
                 .ok()
                 .map(|rd| rd.join("out"))
         })
-        .map(|p| p.to_string_lossy().to_string())
+        .map(|p| {
+            let s = p.to_string_lossy().to_string();
+            // Strip Windows extended-length path prefix (\\?\) which causes
+            // TypeScript's URI.file() to misparse the path as UNC.
+            #[cfg(target_os = "windows")]
+            {
+                s.trim_start_matches(r"\\?\").to_string()
+            }
+            #[cfg(not(target_os = "windows"))]
+            {
+                s
+            }
+        })
         .unwrap_or_default();
 
     let fullscreen = window.is_fullscreen().unwrap_or(false);
     let maximized = window.is_maximized().unwrap_or(false);
+
+    // Retrieve the file server URL (Windows only).
+    #[cfg(target_os = "windows")]
+    let file_server_url = app_handle
+        .try_state::<std::sync::Arc<crate::FileServerState>>()
+        .map(|s| s.url.clone())
+        .unwrap_or_default();
+    #[cfg(not(target_os = "windows"))]
+    let file_server_url = String::new();
 
     Ok(ExtendedWindowConfiguration {
         window_id,
@@ -103,6 +127,7 @@ pub async fn get_extended_window_configuration(
             .unwrap_or_else(|_| "unknown".to_string()),
         fullscreen,
         maximized,
+        file_server_url,
     })
 }
 

--- a/src-tauri/src/file_server.rs
+++ b/src-tauri/src/file_server.rs
@@ -1,0 +1,268 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) VS Codeee Contributors. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+//! Lightweight HTTP file server for Windows WebView2 compatibility.
+//!
+//! WebView2 blocks `fetch()` and dynamic `import()` for custom URI schemes
+//! (`vscode-file://`). This module starts a localhost HTTP server that serves
+//! files from the same roots as the protocol handler, allowing the TypeScript
+//! side to use standard HTTP URLs for all resource loading.
+//!
+//! Only compiled on Windows. macOS/Linux WKWebView/WebKitGTK properly support
+//! custom schemes for all request types.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+use crate::protocol::ProtocolState;
+
+/// A localhost HTTP file server that serves files from registered roots.
+pub struct FileServer {
+    port: u16,
+}
+
+impl FileServer {
+    /// Start the file server on a random available port.
+    ///
+    /// The server listens on `127.0.0.1:<random_port>` and serves GET requests
+    /// by resolving the URL path to a file under one of the registered roots.
+    pub async fn start(state: Arc<ProtocolState>) -> Result<Self, String> {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .map_err(|e| format!("file server bind failed: {e}"))?;
+        let port = listener
+            .local_addr()
+            .map_err(|e| format!("file server local_addr failed: {e}"))?
+            .port();
+
+        log::info!(
+            target: "vscodeee::file_server",
+            "File server listening on http://127.0.0.1:{port}"
+        );
+
+        tokio::spawn(async move {
+            loop {
+                match listener.accept().await {
+                    Ok((mut stream, _addr)) => {
+                        let state = state.clone();
+                        tokio::spawn(async move {
+                            if let Err(e) = handle_connection(&mut stream, &state.roots).await {
+                                log::debug!(
+                                    target: "vscodeee::file_server",
+                                    "Connection error: {e}"
+                                );
+                            }
+                        });
+                    }
+                    Err(e) => {
+                        log::warn!(
+                            target: "vscodeee::file_server",
+                            "Accept error: {e}"
+                        );
+                    }
+                }
+            }
+        });
+
+        Ok(Self { port })
+    }
+
+    /// Returns the port number the server is listening on.
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+
+    /// Returns the base URL of the file server (e.g., `http://127.0.0.1:12345`).
+    pub fn base_url(&self) -> String {
+        format!("http://127.0.0.1:{}", self.port)
+    }
+}
+
+/// Handle a single HTTP connection.
+///
+/// Reads the raw request bytes, extracts the URL path, attempts to serve the
+/// corresponding file from the registered roots, and writes back a complete
+/// HTTP/1.1 response with appropriate status code, Content-Type, and CORS headers.
+async fn handle_connection(
+    stream: &mut tokio::net::TcpStream,
+    roots: &crate::protocol::roots::ValidRoots,
+) -> Result<(), String> {
+    let mut buf = vec![0u8; 8192];
+    let n = stream
+        .read(&mut buf)
+        .await
+        .map_err(|e| format!("read failed: {e}"))?;
+
+    if n == 0 {
+        return Ok(());
+    }
+
+    let request = String::from_utf8_lossy(&buf[..n]);
+    let path = extract_request_path(&request);
+
+    let (status, content_type, body) = match serve_file_from_roots(roots, &path) {
+        Ok((mime, content)) => (200, mime, content),
+        Err(FileServerError::NotFound) => (
+            404,
+            "text/plain; charset=utf-8".to_string(),
+            b"Not Found".to_vec(),
+        ),
+        Err(FileServerError::Forbidden(msg)) => (
+            403,
+            "text/plain; charset=utf-8".to_string(),
+            msg.into_bytes(),
+        ),
+        Err(FileServerError::Io(msg)) => {
+            log::warn!(target: "vscodeee::file_server", "IO error: {msg}");
+            (
+                500,
+                "text/plain; charset=utf-8".to_string(),
+                b"Internal Server Error".to_vec(),
+            )
+        }
+    };
+
+    let status_text = match status {
+        200 => "OK",
+        403 => "Forbidden",
+        404 => "Not Found",
+        _ => "Internal Server Error",
+    };
+
+    let header = format!(
+        "HTTP/1.1 {status} {status_text}\r\n\
+         Content-Type: {content_type}\r\n\
+         Content-Length: {}\r\n\
+         Access-Control-Allow-Origin: *\r\n\
+         Access-Control-Allow-Headers: *\r\n\
+         \r\n",
+        body.len()
+    );
+
+    let mut response = header.into_bytes();
+    response.extend_from_slice(&body);
+
+    stream
+        .write_all(&response)
+        .await
+        .map_err(|e| format!("write failed: {e}"))?;
+
+    Ok(())
+}
+
+/// Error variants for file server request handling.
+enum FileServerError {
+    NotFound,
+    Forbidden(String),
+    Io(String),
+}
+
+/// Resolve a URL path to a file on disk and read its contents.
+///
+/// Strips the leading `/`, percent-decodes the path, converts forward slashes
+/// to backslashes (Windows), canonicalizes to resolve symlinks, and validates
+/// the result against the registered roots. Returns the MIME type and file bytes
+/// on success.
+///
+/// # Errors
+///
+/// - [`FileServerError::NotFound`] if the path is empty or does not exist on disk.
+/// - [`FileServerError::Forbidden`] if the resolved path is not under any registered root.
+/// - [`FileServerError::Io`] if the file cannot be read.
+fn serve_file_from_roots(
+    roots: &crate::protocol::roots::ValidRoots,
+    url_path: &str,
+) -> Result<(String, Vec<u8>), FileServerError> {
+    // URL path is like "/E:/work/vscodeee/out/vs/foo.js"
+    // Strip leading "/" to get a filesystem path on Windows.
+    let fs_path_str = url_path.trim_start_matches('/');
+
+    if fs_path_str.is_empty() {
+        return Err(FileServerError::NotFound);
+    }
+
+    // Decode percent-encoded characters.
+    let decoded = percent_decode(fs_path_str);
+
+    // Convert forward slashes to backslashes for Windows.
+    let native_path = decoded.replace('/', r"\");
+
+    // Canonicalize to resolve symlinks and verify existence.
+    let canonical = PathBuf::from(&native_path)
+        .canonicalize()
+        .map_err(|_| FileServerError::NotFound)?;
+
+    // Security: validate against registered roots.
+    if !roots.is_path_allowed(&canonical) {
+        return Err(FileServerError::Forbidden(format!(
+            "path not under any valid root: {}",
+            canonical.display()
+        )));
+    }
+
+    let content = std::fs::read(&canonical).map_err(|e| FileServerError::Io(e.to_string()))?;
+
+    let mime = crate::protocol::mime::mime_from_path(&canonical);
+
+    Ok((mime.to_string(), content))
+}
+
+/// Extract the path from an HTTP request line.
+///
+/// Parses `GET /path HTTP/1.1\r\n...` and returns the path portion.
+/// Falls back to `"/"` if the request line cannot be parsed.
+fn extract_request_path(request: &str) -> &str {
+    let first_line = request.lines().next().unwrap_or("");
+    let mut parts = first_line.split_whitespace();
+    parts.next(); // Skip method (e.g. "GET")
+    parts.next().unwrap_or("/")
+}
+
+/// Percent-decode a URI path component.
+///
+/// Decodes `%XX` sequences where `XX` is a two-digit hex value.
+/// Non-encoded bytes and malformed sequences are passed through as-is.
+fn percent_decode(input: &str) -> String {
+    let bytes = input.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            if let Some(decoded) = decode_hex_pair(bytes[i + 1], bytes[i + 2]) {
+                out.push(decoded);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+/// Decode a pair of ASCII hex digits into a byte value.
+///
+/// Returns `None` if either digit is not a valid hexadecimal character.
+fn decode_hex_pair(hi: u8, lo: u8) -> Option<u8> {
+    let h = hex_val(hi)?;
+    let l = hex_val(lo)?;
+    Some(h << 4 | l)
+}
+
+/// Convert a single ASCII hex digit to its numeric value (0--15).
+///
+/// Returns `None` if the byte is not a valid hexadecimal digit.
+fn hex_val(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        b'A'..=b'F' => Some(b - b'A' + 10),
+        _ => None,
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -18,6 +18,24 @@ mod shutdown;
 /// root validation, CORS, COOP/COEP, and MIME type resolution.
 mod protocol;
 
+/// HTTP file server for Windows WebView2 compatibility.
+///
+/// WebView2 blocks `fetch()` and dynamic `import()` for custom URI schemes.
+/// This module provides a localhost HTTP server as an alternative, serving
+/// files from the same roots as the protocol handler.
+#[cfg(target_os = "windows")]
+mod file_server;
+
+/// Managed state for the localhost file server URL (Windows only).
+///
+/// Stored as Tauri managed state so commands can retrieve the URL
+/// without passing it through every function.
+#[cfg(target_os = "windows")]
+pub struct FileServerState {
+    /// Base URL of the running file server (e.g., `http://127.0.0.1:12345`).
+    pub url: String,
+}
+
 /// IPC infrastructure — channel routing and event bus for VS Code's binary IPC protocol.
 ///
 /// Replaces Electron's `ipcMain` / `ipcRenderer` with a Tauri-native
@@ -498,6 +516,30 @@ pub fn run(gui_args: Option<cli::dispatch::ParsedGuiArgs>) {
 
             // Initialize protocol state with app root directories.
             let state = protocol::init_protocol_state(app);
+
+            // Start the HTTP file server on Windows.
+            // WebView2 blocks fetch()/import() for custom URI schemes,
+            // so we provide a localhost HTTP server that serves the same files.
+            #[cfg(target_os = "windows")]
+            {
+                match tauri::async_runtime::block_on(file_server::FileServer::start(Arc::clone(&state))) {
+                    Ok(server) => {
+                        let url = server.base_url();
+                        log::info!(
+                            target: "vscodeee::file_server",
+                            "File server started at {url}"
+                        );
+                        app.manage(std::sync::Arc::new(FileServerState { url }));
+                    }
+                    Err(e) => {
+                        log::error!(
+                            target: "vscodeee::file_server",
+                            "Failed to start file server: {e}"
+                        );
+                    }
+                }
+            }
+
             let _ = protocol_state.set(state);
 
             // ── Deep-link handler ──

--- a/src-tauri/src/protocol/mod.rs
+++ b/src-tauri/src/protocol/mod.rs
@@ -246,17 +246,16 @@ fn serve_file(
 ///   `/Users/foo/work/vscodeee/out/vs/code/foo.js` → `"vs/code/foo.js"`
 ///   `/Applications/VS Codeee.app/Contents/Resources/out/vs/base/worker/...` → `"vs/base/worker/..."`
 ///
-/// Returns `None` if the path does not contain `/out/`.
+/// Returns `None` if the path does not contain `/out/` or `\out\`.
 fn extract_asset_key(decoded_path: &str) -> Option<&str> {
-    // Find the last occurrence of "/out/" to handle paths like
-    // `/foo/checkout/out/vs/...` or `/app/Resources/out/vs/...`
-    if let Some(idx) = decoded_path.rfind("/out/") {
-        let key = &decoded_path[idx + 5..]; // skip "/out/"
-        if !key.is_empty() {
-            return Some(key);
-        }
+    /// Find the asset key after the last occurrence of `sep`.
+    fn find_after<'a>(haystack: &'a str, sep: &str) -> Option<&'a str> {
+        let idx = haystack.rfind(sep)?;
+        let key = &haystack[idx + sep.len()..];
+        (!key.is_empty()).then_some(key)
     }
-    None
+
+    find_after(decoded_path, "/out/").or_else(|| find_after(decoded_path, "\\out\\"))
 }
 
 /// Serve a file from Tauri's embedded asset resolver.

--- a/src-tauri/src/protocol/uri.rs
+++ b/src-tauri/src/protocol/uri.rs
@@ -74,6 +74,23 @@ pub fn parse_vscode_file_uri(raw_uri: &str) -> Result<PathBuf, ProtocolError> {
     // symlinks and verify the final path exists, and roots validation follows.
     let normalized = normalize_dot_segments(&decoded);
 
+    // On Windows, URI paths from TypeScript's URI.file() come as /E:/work/...
+    // (forward slashes with leading / before the drive letter). Convert to a
+    // native Windows path (E:\work\...) so canonicalize() can resolve it.
+    #[cfg(target_os = "windows")]
+    let normalized = {
+        let s = normalized.to_string_lossy();
+        if let Some(stripped) = s.strip_prefix('/') {
+            if stripped.len() >= 2 && stripped.as_bytes()[1] == b':' {
+                PathBuf::from(stripped.replace('/', r"\"))
+            } else {
+                normalized
+            }
+        } else {
+            normalized
+        }
+    };
+
     // Canonicalize to resolve symlinks and verify the path exists.
     let canonical = std::fs::canonicalize(&normalized).map_err(|e| match e.kind() {
         std::io::ErrorKind::NotFound => {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -32,7 +32,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; img-src 'self' data: blob: https: vscode-file:; script-src 'self' 'unsafe-eval' 'unsafe-inline' blob: vscode-file:; style-src 'self' 'unsafe-inline' vscode-file:; connect-src 'self' https: ws: wss: tauri: ipc: vscode-file:; font-src 'self' https: vscode-file:; frame-src 'self' vscode-file:",
+      "csp": "default-src 'self'; img-src 'self' data: blob: https: vscode-file: http://127.0.0.1:*; script-src 'self' 'unsafe-eval' 'unsafe-inline' blob: vscode-file: http://127.0.0.1:*; style-src 'self' 'unsafe-inline' vscode-file: http://127.0.0.1:*; connect-src 'self' https: ws: wss: tauri: ipc: vscode-file: http://127.0.0.1:*; font-src 'self' https: vscode-file: http://127.0.0.1:*; frame-src 'self' vscode-file: http://127.0.0.1:*; worker-src 'self' blob: vscode-file: http://127.0.0.1:*",
       "dangerousDisableAssetCspModification": true
     }
   },

--- a/src/vs/amdX.ts
+++ b/src/vs/amdX.ts
@@ -16,6 +16,13 @@ declare const document: any;
 declare const self: any;
 declare const globalThis: any;
 
+/**
+ * Represents a single AMD `define()` call captured from a loaded script.
+ *
+ * Stores the module ID (if provided), the dependency list, and the factory
+ * callback. These are collected during script evaluation and consumed by
+ * `AMDModuleImporter.load()` to resolve exports.
+ */
 class DefineCall {
 	constructor(
 		public readonly id: string | null | undefined,
@@ -24,12 +31,26 @@ class DefineCall {
 	) { }
 }
 
+/** Tracks the initialization state of the AMD define shim. */
 enum AMDModuleImporterState {
 	Uninitialized = 1,
 	InitializedInternal,
 	InitializedExternal
 }
 
+/**
+ * AMD module loader that dynamically loads scripts and resolves their exports.
+ *
+ * Intercepts `globalThis.define()` calls from AMD-formatted scripts and
+ * resolves their exported values. Supports three runtime contexts:
+ *
+ * - **Renderer** (browser): loads scripts via `<script>` element injection.
+ * - **Web Worker**: loads scripts via dynamic `import()`.
+ * - **Node.js**: loads scripts via `fs` + `vm` module.
+ *
+ * When an external AMD loader (e.g., from a test harness) is already present,
+ * delegates to it instead of installing a custom shim.
+ */
 class AMDModuleImporter {
 	public static INSTANCE = new AMDModuleImporter();
 
@@ -42,6 +63,15 @@ class AMDModuleImporter {
 
 	constructor() { }
 
+	/**
+	 * Install the AMD `define()` shim if not already initialized.
+	 *
+	 * If an external AMD loader is detected (`globalThis.define` exists before
+	 * initialization), marks the state as `InitializedExternal` and defers all
+	 * `define()` calls to the existing loader. Otherwise installs a custom shim
+	 * that captures define calls into `_defineCalls`.
+	 * Also creates a Trusted Types policy for script URL validation in the renderer.
+	 */
 	private _initialize(): void {
 		if (this._state === AMDModuleImporterState.Uninitialized) {
 			if (globalThis.define) {
@@ -81,6 +111,10 @@ class AMDModuleImporter {
 					if (value.startsWith(`${Schemas.vscodeFileResource}://${VSCODE_AUTHORITY}`)) {
 						return value;
 					}
+					const fileServerUrl = (globalThis as Record<string, unknown>)._VSCODE_FILE_SERVER_URL;
+					if (typeof fileServerUrl === 'string' && fileServerUrl && value.startsWith(fileServerUrl)) {
+						return value;
+					}
 					throw new Error(`[trusted_script_src] Invalid script url: ${value}`);
 				}
 			});
@@ -93,6 +127,13 @@ class AMDModuleImporter {
 		}
 	}
 
+	/**
+	 * Load an AMD-formatted script and resolve its exported value.
+	 *
+	 * @param scriptSrc - The URL of the script to load.
+	 * @returns The value exported by the script's `define()` callback.
+	 * @throws If the script has unresolved dependencies or fails to load.
+	 */
 	public async load<T>(scriptSrc: string): Promise<T> {
 		this._initialize();
 
@@ -136,6 +177,14 @@ class AMDModuleImporter {
 		}
 	}
 
+	/**
+	 * Load a script in the renderer (browser) context by injecting a `<script>` element.
+	 *
+	 * Applies Trusted Types policy to the script URL if available.
+	 *
+	 * @param scriptSrc - The URL of the script to load.
+	 * @returns The `DefineCall` captured from the script, or `undefined` if none was emitted.
+	 */
 	private _rendererLoadScript(scriptSrc: string): Promise<DefineCall | undefined> {
 		return new Promise<DefineCall | undefined>((resolve, reject) => {
 			const scriptElement = document.createElement('script');
@@ -167,6 +216,14 @@ class AMDModuleImporter {
 		});
 	}
 
+	/**
+	 * Load a script in a Web Worker context via dynamic `import()`.
+	 *
+	 * Applies Trusted Types policy to the script URL if available.
+	 *
+	 * @param scriptSrc - The URL of the script to load.
+	 * @returns The `DefineCall` captured from the script, or `undefined` if none was emitted.
+	 */
 	private async _workerLoadScript(scriptSrc: string): Promise<DefineCall | undefined> {
 		if (this._amdPolicy) {
 			scriptSrc = this._amdPolicy.createScriptURL(scriptSrc) as unknown as string;
@@ -175,6 +232,15 @@ class AMDModuleImporter {
 		return this._defineCalls.pop();
 	}
 
+	/**
+	 * Load a script in a Node.js context by reading the file and evaluating it via `vm.Script`.
+	 *
+	 * Strips shebang lines (`#!...`) before evaluation.
+	 *
+	 * @param scriptSrc - The file URI of the script to load.
+	 * @returns The `DefineCall` captured from the script, or `undefined` if none was emitted.
+	 * @throws If the file cannot be read, parsed, or evaluated.
+	 */
 	private async _nodeJSLoadScript(scriptSrc: string): Promise<DefineCall | undefined> {
 		try {
 			const fs = (await import(/* webpackIgnore: true */ /* @vite-ignore */ `${'fs'}`)).default;
@@ -228,6 +294,16 @@ export async function importAMDNodeModule<T>(nodeModuleName: string, pathInsideN
 	return result;
 }
 
+/**
+ * Resolve the browser URL for an AMD node module without loading it.
+ *
+ * Computes the same URL that `importAMDNodeModule` would use for the given
+ * module, but returns it as a string instead of dynamically importing the module.
+ *
+ * @param nodeModuleName - The npm package name (e.g., `vscode-textmate`).
+ * @param pathInsideNodeModule - The path within the package (e.g., `release/main.js`).
+ * @returns The fully resolved browser URL as a string.
+ */
 export function resolveAmdNodeModulePath(nodeModuleName: string, pathInsideNodeModule: string): string {
 	const product = globalThis._VSCODE_PRODUCT_JSON as unknown as IProductConfiguration;
 	const isBuilt = Boolean((product ?? globalThis.vscode?.context?.configuration()?.product)?.commit);

--- a/src/vs/base/common/network.ts
+++ b/src/vs/base/common/network.ts
@@ -302,6 +302,16 @@ class FileAccessImpl {
 			return RemoteAuthorities.rewrite(uri);
 		}
 
+		// On Windows Tauri, WebView2 blocks fetch() and import() for
+		// custom URI schemes. Route through the localhost HTTP file server
+		// instead.
+		if (uri.scheme === Schemas.file && platform.isWindows && platform.isTauri) {
+			const fileServerUrl = (globalThis as Record<string, unknown>)._VSCODE_FILE_SERVER_URL;
+			if (typeof fileServerUrl === 'string' && fileServerUrl) {
+				return URI.parse(`${fileServerUrl}${uri.path}`);
+			}
+		}
+
 		// Convert to `vscode-file` resource..
 		if (
 			// ...only ever for `file` resources

--- a/src/vs/code/tauri-browser/workbench/workbench-tauri.html
+++ b/src/vs/code/tauri-browser/workbench/workbench-tauri.html
@@ -34,6 +34,7 @@
 			https://tauri.localhost
 			vscode-file:
 			vscode-remote-resource:
+			http://127.0.0.1:*
 		;
 		media-src
 			'self'
@@ -51,6 +52,7 @@
 			tauri:
 			https://tauri.localhost
 			vscode-file:
+			http://127.0.0.1:*
 		;
 		style-src
 			'self'
@@ -66,12 +68,20 @@
 			https://tauri.localhost
 			ipc:
 			vscode-file:
+			http://127.0.0.1:*
 		;
 		font-src
 			'self'
 			https:
 			vscode-file:
 			vscode-remote-resource:
+			http://127.0.0.1:*
+		;
+		worker-src
+			'self'
+			blob:
+			vscode-file:
+			http://127.0.0.1:*
 		;
 	"/>
 	<meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/src/vs/code/tauri-browser/workbench/workbench-tauri.ts
+++ b/src/vs/code/tauri-browser/workbench/workbench-tauri.ts
@@ -217,6 +217,13 @@
   const baseUrl = `${window.location.origin}/`;
   (globalThis as Record<string, unknown>)._VSCODE_FILE_ROOT = windowConfig.frontendDist;
 
+  // On Windows, WebView2 blocks fetch() and import() for custom URI schemes.
+  // The Rust backend starts a localhost HTTP file server as a workaround.
+  // Store its URL so uriToBrowserUri() can convert file:// → http:// URLs.
+  if (windowConfig.fileServerUrl) {
+    (globalThis as Record<string, unknown>)._VSCODE_FILE_SERVER_URL = windowConfig.fileServerUrl;
+  }
+
   //#endregion
 
   //#region CSS Import Maps

--- a/src/vs/code/tauri-browser/workbench/workbench-tauri.ts
+++ b/src/vs/code/tauri-browser/workbench/workbench-tauri.ts
@@ -140,6 +140,7 @@
     isDevBuild?: boolean;
     themeBackground?: string;
     themeForeground?: string;
+    fileServerUrl?: string;
   }
 
   /**

--- a/src/vs/platform/extensionResourceLoader/browser/extensionResourceLoaderService.ts
+++ b/src/vs/platform/extensionResourceLoader/browser/extensionResourceLoaderService.ts
@@ -14,6 +14,7 @@ import { ILogService } from '../../log/common/log.js';
 import { IConfigurationService } from '../../configuration/common/configuration.js';
 import { AbstractExtensionResourceLoaderService, IExtensionResourceLoaderService } from '../common/extensionResourceLoader.js';
 import { IExtensionGalleryManifestService } from '../../extensionManagement/common/extensionGalleryManifest.js';
+import * as platform from '../../../base/common/platform.js';
 
 class ExtensionResourceLoaderService extends AbstractExtensionResourceLoaderService {
 
@@ -34,11 +35,15 @@ class ExtensionResourceLoaderService extends AbstractExtensionResourceLoaderServ
 	async readExtensionResource(uri: URI): Promise<string> {
 		uri = FileAccess.uriToBrowserUri(uri);
 
-		// In Tauri, file:// URIs are rewritten to vscode-file:// by uriToBrowserUri.
-		// The vscode-file:// scheme is served by Tauri's custom protocol handler, not
-		// by an IFileService provider, so we must use fetch() to load these resources.
-		// For http/https/data schemes, we also use fetch() (with optional gallery headers).
-		if (uri.scheme !== Schemas.http && uri.scheme !== Schemas.https && uri.scheme !== Schemas.data && uri.scheme !== Schemas.vscodeFileResource) {
+		// In Tauri, convert vscode-file:// back to file:// and route through
+		// _fileService.readFile() which uses TauriDiskFileSystemProvider (IPC).
+		// This bypasses fetch() which depends on browser custom-scheme support
+		// that may behave differently across WebView runtimes (WKWebView vs WebView2).
+		if (platform.isTauri && uri.scheme === Schemas.vscodeFileResource) {
+			uri = FileAccess.uriToFileUri(uri);
+		}
+
+		if (uri.scheme !== Schemas.http && uri.scheme !== Schemas.https && uri.scheme !== Schemas.data) {
 			const result = await this._fileService.readFile(uri);
 			return result.value.toString();
 		}

--- a/src/vs/platform/webWorker/browser/webWorkerServiceImpl.ts
+++ b/src/vs/platform/webWorker/browser/webWorkerServiceImpl.ts
@@ -14,10 +14,29 @@ import { getNLSLanguage, getNLSMessages } from '../../../nls.js';
 import { WebWorkerDescriptor } from './webWorkerDescriptor.js';
 import { IWebWorkerService } from './webWorkerService.js';
 
+/**
+ * Default implementation of {@link IWebWorkerService} that creates Web Workers
+ * with NLS injection, Trusted Types policy, and Cross-Origin Isolation (COI) support.
+ *
+ * Each worker is bootstrapped via a `Blob` URL that injects `_VSCODE_NLS_MESSAGES`,
+ * `_VSCODE_NLS_LANGUAGE`, `_VSCODE_FILE_ROOT`, `_VSCODE_FILE_SERVER_URL`, and
+ * `__TAURI_INTERNALS__` globals before dynamically importing the actual worker script.
+ * This ensures workers have access to the same configuration as the main thread.
+ */
 export class WebWorkerService implements IWebWorkerService {
 	private static _workerIdPool: number = 0;
 	declare readonly _serviceBrand: undefined;
 
+	/**
+	 * Create a new web worker client wrapping the given worker descriptor.
+	 *
+	 * If the descriptor is already a `Worker` instance or a promise resolving to one,
+	 * it is used directly. Otherwise, a new worker is created via `_createWorker`.
+	 *
+	 * @typeParam T - The shape of the worker's public API.
+	 * @param workerDescriptor - A `WebWorkerDescriptor`, an existing `Worker`, or a promise of one.
+	 * @returns A `WebWorkerClient` that proxies calls to the worker.
+	 */
 	createWorkerClient<T extends object>(workerDescriptor: WebWorkerDescriptor | Worker | Promise<Worker>): IWebWorkerClient<T> {
 		let worker: Worker | Promise<Worker>;
 		const id = ++WebWorkerService._workerIdPool;
@@ -30,6 +49,16 @@ export class WebWorkerService implements IWebWorkerService {
 		return new WebWorkerClient<T>(new WebWorker(worker, id));
 	}
 
+	/**
+	 * Create a new Web Worker from a descriptor.
+	 *
+	 * Resolves the worker script URL, wraps it in a bootstrap `Blob` that injects
+	 * NLS and Tauri globals, and waits for the worker to signal readiness via
+	 * a `vscode-worker-ready` postMessage.
+	 *
+	 * @param descriptor - The descriptor containing the worker module location.
+	 * @returns A promise resolving to the created `Worker` once it is ready.
+	 */
 	protected _createWorker(descriptor: WebWorkerDescriptor): Promise<Worker> {
 		const workerRunnerUrl = this.getWorkerUrl(descriptor);
 
@@ -38,10 +67,23 @@ export class WebWorkerService implements IWebWorkerService {
 		return whenESMWorkerReady(worker);
 	}
 
+	/**
+	 * Returns an optional error message to display when a worker fails to load.
+	 *
+	 * Subclasses can override this to provide context-specific error messages.
+	 * The default implementation returns `undefined` (no custom message).
+	 */
 	protected _getWorkerLoadingFailedErrorMessage(_descriptor: WebWorkerDescriptor): string | undefined {
 		return undefined;
 	}
 
+	/**
+	 * Resolve the browser URL for a worker descriptor's ESM module location.
+	 *
+	 * @param descriptor - The descriptor containing the ESM module location (URL string, URI, or function).
+	 * @returns The fully resolved URL string for the worker module.
+	 * @throws If `esmModuleLocation` is not set on the descriptor.
+	 */
 	getWorkerUrl(descriptor: WebWorkerDescriptor): string {
 		if (!descriptor.esmModuleLocation) {
 			throw new Error('Missing esmModuleLocation in WebWorkerDescriptor');
@@ -68,6 +110,17 @@ const ttPolicy = ((): ReturnType<typeof createTrustedTypesPolicy> => {
 	}
 })();
 
+/**
+ * Create a Web Worker from a Blob URL.
+ *
+ * Validates that the URL is a `blob:` scheme and applies the Trusted Types
+ * policy if available.
+ *
+ * @param blobUrl - The Blob URL to load as a worker script.
+ * @param options - Optional `WorkerOptions` passed to the `Worker` constructor.
+ * @returns A new `Worker` instance.
+ * @throws {URIError} If the provided URL is not a Blob URL.
+ */
 export function createBlobWorker(blobUrl: string, options?: WorkerOptions): Worker {
 	if (!blobUrl.startsWith('blob:')) {
 		throw new URIError('Not a blob-url: ' + blobUrl);
@@ -75,6 +128,25 @@ export function createBlobWorker(blobUrl: string, options?: WorkerOptions): Work
 	return new Worker(ttPolicy ? ttPolicy.createScriptURL(blobUrl) as unknown as string : blobUrl, { ...options, type: 'module' });
 }
 
+/**
+ * Build a bootstrap Blob URL for a Web Worker.
+ *
+ * Creates a `Blob` script that:
+ * 1. Injects NLS messages and language into `globalThis`.
+ * 2. Sets `_VSCODE_FILE_ROOT` for `vscode-file://` URI resolution.
+ * 3. Propagates `__TAURI_INTERNALS__` for Tauri platform detection.
+ * 4. Propagates `_VSCODE_FILE_SERVER_URL` for Windows WebView2 compatibility.
+ * 5. Creates a Trusted Types policy for the worker context.
+ * 6. Dynamically imports the actual worker script.
+ * 7. Posts a `vscode-worker-ready` message to signal completion.
+ *
+ * Cross-origin worker scripts are loaded as-is without COI parameter injection.
+ *
+ * @param label - A descriptive label for the worker (used in comments and error messages).
+ * @param workerScriptUrl - The URL of the worker script to import.
+ * @param workerLoadingFailedErrorMessage - Optional error message to show on import failure.
+ * @returns A Blob URL string for the bootstrap script.
+ */
 function getWorkerBootstrapUrl(label: string, workerScriptUrl: string, workerLoadingFailedErrorMessage: string | undefined): string {
 	if (/^((http:)|(https:)|(file:))/.test(workerScriptUrl) && workerScriptUrl.substring(0, globalThis.origin.length) !== globalThis.origin) {
 		// this is the cross-origin case
@@ -110,6 +182,11 @@ function getWorkerBootstrapUrl(label: string, workerScriptUrl: string, workerLoa
 		typeof (globalThis as Record<string, unknown>).__TAURI_INTERNALS__ !== 'undefined'
 			? `globalThis.__TAURI_INTERNALS__ = globalThis.__TAURI_INTERNALS__ || {};`
 			: '',
+		// On Windows, WebView2 blocks fetch()/import() for custom URI schemes.
+		// Propagate the file server URL so workers can route requests through HTTP.
+		typeof (globalThis as Record<string, unknown>)._VSCODE_FILE_SERVER_URL === 'string'
+			? `globalThis._VSCODE_FILE_SERVER_URL = ${JSON.stringify((globalThis as Record<string, unknown>)._VSCODE_FILE_SERVER_URL)};`
+			: '',
 		`const ttPolicy = globalThis.trustedTypes?.createPolicy('defaultWorkerFactory', { createScriptURL: value => value });`,
 		`globalThis.workerttPolicy = ttPolicy;`,
 
@@ -123,6 +200,15 @@ function getWorkerBootstrapUrl(label: string, workerScriptUrl: string, workerLoa
 	return URL.createObjectURL(blob);
 }
 
+/**
+ * Wait for a Web Worker to signal that it has finished loading.
+ *
+ * Listens for a single `vscode-worker-ready` message from the worker,
+ * then resolves with the worker instance. Rejects on worker error.
+ *
+ * @param worker - The Web Worker to wait for.
+ * @returns A promise resolving to the same `Worker` once it is ready.
+ */
 function whenESMWorkerReady(worker: Worker): Promise<Worker> {
 	return new Promise<Worker>((resolve, reject) => {
 		worker.onmessage = function (e) {
@@ -135,10 +221,23 @@ function whenESMWorkerReady(worker: Worker): Promise<Worker> {
 	});
 }
 
+/**
+ * Type guard that checks whether a value implements the `PromiseLike` interface.
+ *
+ * @typeParam T - The type the promise resolves to.
+ * @param obj - The value to check.
+ * @returns `true` if the value has a callable `then` method.
+ */
 function isPromiseLike<T>(obj: unknown): obj is PromiseLike<T> {
 	return !!obj && typeof (obj as PromiseLike<T>).then === 'function';
 }
 
+/**
+ * Wrapper around a Web Worker that implements the {@link IWebWorker} interface.
+ *
+ * Provides typed message passing via `onMessage` / `postMessage` and automatic
+ * cleanup on disposal (terminates the worker and removes all event listeners).
+ */
 export class WebWorker extends Disposable implements IWebWorker {
 	private readonly id: number;
 	private worker: Promise<Worker> | null;
@@ -149,6 +248,10 @@ export class WebWorker extends Disposable implements IWebWorker {
 	private readonly _onError = this._register(new Emitter<MessageEvent | ErrorEvent>());
 	public readonly onError = this._onError.event;
 
+	/**
+	 * @param worker - A promise resolving to the underlying `Worker` instance.
+	 * @param id - Unique numeric identifier for this worker.
+	 */
 	constructor(worker: Promise<Worker>, id: number) {
 		super();
 		this.id = id;
@@ -179,10 +282,17 @@ export class WebWorker extends Disposable implements IWebWorker {
 		}));
 	}
 
+	/** Returns the unique numeric identifier for this worker. */
 	public getId(): number {
 		return this.id;
 	}
 
+	/**
+	 * Send a message to the worker, optionally transferring ownership of `Transferable` objects.
+	 *
+	 * @param message - The data to send.
+	 * @param transfer - An array of `Transferable` objects (e.g., `ArrayBuffer`, `MessagePort`) to transfer.
+	 */
 	public postMessage(message: unknown, transfer: Transferable[]): void {
 		this.worker?.then(w => {
 			try {

--- a/src/vs/workbench/services/extensions/browser/webWorkerExtensionHost.ts
+++ b/src/vs/workbench/services/extensions/browser/webWorkerExtensionHost.ts
@@ -274,6 +274,7 @@ export class WebWorkerExtensionHost extends Disposable implements IExtensionHost
 					data: {
 						workerUrl: this._webWorkerService.getWorkerUrl(extensionHostWorkerMainDescriptor),
 						fileRoot: globalThis._VSCODE_FILE_ROOT,
+						fileServerUrl: typeof globalThis._VSCODE_FILE_SERVER_URL === 'string' ? globalThis._VSCODE_FILE_SERVER_URL : '',
 						nls: {
 							messages: getNLSMessages(),
 							language: getNLSLanguage()

--- a/src/vs/workbench/services/extensions/browser/webWorkerExtensionHost.ts
+++ b/src/vs/workbench/services/extensions/browser/webWorkerExtensionHost.ts
@@ -274,7 +274,7 @@ export class WebWorkerExtensionHost extends Disposable implements IExtensionHost
 					data: {
 						workerUrl: this._webWorkerService.getWorkerUrl(extensionHostWorkerMainDescriptor),
 						fileRoot: globalThis._VSCODE_FILE_ROOT,
-						fileServerUrl: typeof globalThis._VSCODE_FILE_SERVER_URL === 'string' ? globalThis._VSCODE_FILE_SERVER_URL : '',
+						fileServerUrl: typeof (globalThis as Record<string, unknown>)._VSCODE_FILE_SERVER_URL === 'string' ? (globalThis as Record<string, unknown>)._VSCODE_FILE_SERVER_URL as string : '',
 						nls: {
 							messages: getNLSMessages(),
 							language: getNLSLanguage()

--- a/src/vs/workbench/services/extensions/worker/webWorkerExtensionHostIframe.html
+++ b/src/vs/workbench/services/extensions/worker/webWorkerExtensionHostIframe.html
@@ -20,7 +20,7 @@
 		<meta http-equiv="Content-Security-Policy" content="
 			default-src 'none';
 			child-src 'self' data: blob:;
-			script-src 'self' 'unsafe-eval' 'sha256-Az3P+8se4ZoLKOwSJS4ytf0PiEIeK9E4/VoA1ACCj2w=' https: http://localhost:* blob: vscode-file:;
+			script-src 'self' 'unsafe-eval' 'sha256-txu8MXKpl168uAvxJjqFZhyKAU++U8UoPFz54qGJew8=' https: http://localhost:* blob: vscode-file:;
 			connect-src 'self' https: wss: http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:* vscode-file:;"/>
 	</head>
 	<body>
@@ -108,7 +108,7 @@
 				return;
 			}
 			const { data } = event.data;
-			createWorker(data.workerUrl, data.fileRoot, data.nls.messages, data.nls.language);
+			createWorker(data.workerUrl, data.fileRoot, data.fileServerUrl, data.nls.messages, data.nls.language);
 		};
 
 		window.parent.postMessage({
@@ -132,7 +132,7 @@
 	 * @param {object} nlsMessages - Localized message bundles keyed by message key.
 	 * @param {string} nlsLanguage - The current UI language identifier (e.g. "en", "ja").
 	 */
-	function createWorker(workerUrl, fileRoot, nlsMessages, nlsLanguage) {
+	function createWorker(workerUrl, fileRoot, fileServerUrl, nlsMessages, nlsLanguage) {
 		try {
 			if (globalThis.crossOriginIsolated) {
 				workerUrl += '?vscode-coi=2'; // COEP
@@ -147,6 +147,7 @@
 				`globalThis._VSCODE_NLS_MESSAGES = ${JSON.stringify(nlsMessages)};`,
 				`globalThis._VSCODE_NLS_LANGUAGE = ${JSON.stringify(nlsLanguage)};`,
 				`globalThis._VSCODE_FILE_ROOT = ${JSON.stringify(fileRoot)};`,
+				`globalThis._VSCODE_FILE_SERVER_URL = ${JSON.stringify(fileServerUrl || '')};`,
 				`await import(${JSON.stringify(workerUrl)});`,
 				`/*extensionHostWorker*/`
 			].join('')], { type: 'application/javascript' });


### PR DESCRIPTION
## Summary

WebView2 on Windows blocks `fetch()` and dynamic `import()` for custom URI schemes (`vscode-file://`). This causes critical module loading failures including `vscode-textmate`, `onig.wasm`, `editorWebWorkerMain.js`, and layout contribution scripts.

## Changes

- Add `file_server.rs`: lightweight localhost HTTP server (Windows only, `127.0.0.1:0`) that serves files from registered protocol roots
- Add `FileServerState` to `lib.rs`, start server during Tauri setup
- Pass `fileServerUrl` to frontend via `WindowConfiguration`
- Route `file://` URIs through HTTP in `uriToBrowserUri()` on Windows
- Update CSP in `workbench-tauri.html` to allow `http://127.0.0.1:*` across all directives
- Update Trusted Types policy in `amdX.ts` for file server URLs
- Propagate `_VSCODE_FILE_SERVER_URL` to Web Workers via bootstrap blob
- Propagate to extension host worker via iframe `postMessage`
- Update CSP hash in `webWorkerExtensionHostIframe.html`
- Fix Windows drive letter path handling in protocol URI conversion
- Fix backslash handling in `extract_asset_key` for Windows paths

## How to Test

1. Launch the app on Windows 11 with `cargo tauri dev`
2. Open the browser DevTools console — no `Failed to fetch dynamically imported module` errors
3. Open a file with syntax highlighting — TextMate tokenization works
4. Verify the status bar, editor, and command palette render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)