### PR TITLE
fix: sanitize ESM singleton module directory names for Windows compatibility

### DIFF
--- a/src/vs/workbench/api/node/extHostExtensionService.ts
+++ b/src/vs/workbench/api/node/extHostExtensionService.ts
@@ -321,7 +321,12 @@ module.exports = globalThis.__VSCODEEE_ESM_API__ || {};
 		}
 		const g = globalThis as Record<string, unknown>;
 
-		const moduleDir = path.join(shimDir, 'node_modules', moduleName);
+		// Sanitize module name for use as a directory name.
+		// Windows does not allow ':' in paths, so 'node:sqlite' becomes 'node_sqlite'.
+		// The symlink in _createBunESMSymlink uses the original name and has its own
+		// try-catch to handle platforms where ':' is invalid in the junction name.
+		const fsSafeName = moduleName.replace(/:/g, '_');
+		const moduleDir = path.join(shimDir, 'node_modules', fsSafeName);
 		fs.mkdirSync(moduleDir, { recursive: true });
 
 		fs.writeFileSync(path.join(moduleDir, 'package.json'), JSON.stringify({


### PR DESCRIPTION
## Summary

- Fix ENOTDIR crash on Windows caused by `node:sqlite` / `node:sea` directory names containing illegal `:` character
- Sanitize ESM singleton module directory names by replacing `:` with `_` (e.g., `node:sqlite` → `node_sqlite`)
- macOS/Linux: symlink `node:sqlite` → `node_sqlite/` preserves ESM import resolution
- Windows: directory creation succeeds, symlink fails gracefully via existing try-catch

Fixes #490

## Known Limitation

ESM `import('node:sqlite')` on Windows is blocked by Bun's resolver treating `node:*` as built-in-only specifiers. This affects extensions like GitHub Copilot Chat that use `import('node:sqlite')` via ESM. CJS `require('node:sqlite')` works on all platforms. Resolving this requires a Bun upstream change to either add native `node:sqlite` support or fall through to filesystem resolution for unknown `node:*` specifiers.

## Test plan

- [x] Windows 11 Pro: Extension host starts without ENOTDIR crash
- [x] No TypeScript compilation errors
- [x] precommit hook passed
- [ ] macOS/Linux: verify ESM `import('node:sqlite')` still resolves via symlink

🤖 Generated with [Claude Code](https://claude.com/claude-code)