### PR TITLE
fix: strip Windows UNC path prefix for Bun compatibility

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6617,6 +6617,7 @@ dependencies = [
  "core-foundation-sys",
  "core-text",
  "dirs",
+ "dunce",
  "futures-util",
  "globset",
  "hostname",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -48,6 +48,7 @@ notify-rust = "4"
 keyring = { version = "3", features = ["apple-native", "windows-native", "linux-native"] }
 aes-gcm = "0.10"
 rand = "0.8"
+dunce = "1"
 tokio-tungstenite = "0.24"
 futures-util = { version = "0.3", default-features = false, features = ["sink"] }
 clap = { version = "4", features = ["derive"] }

--- a/src-tauri/src/commands/extensions.rs
+++ b/src-tauri/src/commands/extensions.rs
@@ -66,7 +66,7 @@ fn resolve_extensions_dir(app_handle: &tauri::AppHandle) -> Option<PathBuf> {
     if let Some(dir) = std::env::current_dir()
         .ok()
         .map(|cwd| cwd.join("../extensions"))
-        .and_then(|p| p.canonicalize().ok())
+        .and_then(|p| dunce::canonicalize(&p).ok())
         .filter(|p| p.is_dir())
     {
         return Some(dir);
@@ -76,7 +76,7 @@ fn resolve_extensions_dir(app_handle: &tauri::AppHandle) -> Option<PathBuf> {
     if let Some(dir) = std::env::current_dir()
         .ok()
         .map(|cwd| cwd.join("../.build/extensions"))
-        .and_then(|p| p.canonicalize().ok())
+        .and_then(|p| dunce::canonicalize(&p).ok())
         .filter(|p| p.is_dir())
     {
         return Some(dir);

--- a/src-tauri/src/commands/spawn_exthost.rs
+++ b/src-tauri/src/commands/spawn_exthost.rs
@@ -464,10 +464,12 @@ fn resolve_app_root_and_resource_dir(
 ) -> Result<(PathBuf, PathBuf), String> {
     use tauri::Manager;
 
-    let resource_dir = app_handle
-        .path()
-        .resource_dir()
-        .map_err(|e| format!("Failed to resolve resource dir: {e}"))?;
+    let resource_dir = strip_unc_prefix(
+        &app_handle
+            .path()
+            .resource_dir()
+            .map_err(|e| format!("Failed to resolve resource dir: {e}"))?,
+    );
 
     // Walk up from resource dir to find the repo root
     let mut candidate = resource_dir.as_path();
@@ -484,6 +486,7 @@ fn resolve_app_root_and_resource_dir(
 
     // Fallback: try current working directory
     if let Ok(cwd) = std::env::current_dir() {
+        let cwd = strip_unc_prefix(&cwd);
         if cwd.join("out/bootstrap-fork.js").exists() {
             return Ok((cwd, resource_dir));
         }
@@ -501,4 +504,21 @@ fn resolve_app_root_and_resource_dir(
         "Cannot find repo root with out/bootstrap-fork.js. Searched from: {}",
         resource_dir.display()
     ))
+}
+
+/// Strip the Windows UNC extended-length path prefix (`\\?\`) from a path.
+///
+/// On Windows, `std::fs::canonicalize()` and Tauri's `resource_dir()` may
+/// return paths with the `\\?\` prefix. Node.js handles this transparently,
+/// but Bun does not — it treats the prefix as part of the file name, causing
+/// module resolution failures in the Extension Host.
+///
+/// On non-Windows platforms this is a no-op.
+fn strip_unc_prefix(path: &std::path::Path) -> PathBuf {
+    let s = path.to_string_lossy();
+    if s.starts_with(r"\\?\") {
+        PathBuf::from(&s[4..])
+    } else {
+        path.to_path_buf()
+    }
 }

--- a/src-tauri/src/commands/spawn_exthost.rs
+++ b/src-tauri/src/commands/spawn_exthost.rs
@@ -516,8 +516,8 @@ fn resolve_app_root_and_resource_dir(
 /// On non-Windows platforms this is a no-op.
 fn strip_unc_prefix(path: &std::path::Path) -> PathBuf {
     let s = path.to_string_lossy();
-    if s.starts_with(r"\\?\") {
-        PathBuf::from(&s[4..])
+    if let Some(stripped) = s.strip_prefix(r"\\?\") {
+        PathBuf::from(stripped)
     } else {
         path.to_path_buf()
     }


### PR DESCRIPTION
## Summary
- Windows上でBunランタイムが `\?\` UNCパスプレフィックスを処理できず、全ビルトイン拡張機能のアクティベーションが失敗していた問題を修正
- `dunce` クレートを追加し、`canonicalize()` がUNCプレフィックスなしのパスを返すように変更
- `spawn_exthost.rs` に `strip_unc_prefix()` ヘルパーを追加し、`resource_dir()` と `current_dir()` の結果もクリーンアップ

## Root cause
On Windows, `std::fs::canonicalize()` and Tauri's `resource_dir()` return paths with the `\?\` extended-length path prefix. Node.js handles this transparently, but Bun does not — it treats the prefix as part of the filename, causing all built-in extensions to fail with `Cannot find module '\?\E:\...\extension.js'`.

## Test plan
- [ ] Windows上でアプリを起動し、ビルトイン拡張機能（Git, Emmet, JSON等）が正常にアクティベートされることを確認
- [ ] vscode-neovimのカーソル移動が正常に動作することを確認
- [ ] macOSでリグレッションがないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)