### PR TITLE
fix: use TCP sockets for Windows ExtHost IPC and disable WebWorker host

### DIFF
--- a/src-tauri/src/exthost/sidecar.rs
+++ b/src-tauri/src/exthost/sidecar.rs
@@ -230,9 +230,9 @@ fn build_exthost_path() -> String {
 pub struct ExtHostSidecar {
     /// Handle to the spawned Bun child process.
     pub child: Child,
-    /// Path to the IPC pipe used for communication with the Extension Host.
+    /// IPC endpoint address for communication with the Extension Host.
     /// On Unix this is a Unix domain socket path (e.g., `/tmp/vscode-ipc-*.sock`);
-    /// on Windows this is a named pipe path (e.g., `\\.\pipe\vscode-ipc-*\sock`).
+    /// on Windows this is a TCP address (e.g., `tcp:127.0.0.1:12345`).
     pub pipe_path: String,
     /// Original content of `product.json` before augmentation, if modified.
     /// Used by [`Drop`] to restore the file when the sidecar is cleaned up.
@@ -243,8 +243,8 @@ pub struct ExtHostSidecar {
 /// original `product.json` when the sidecar is dropped.
 impl Drop for ExtHostSidecar {
     fn drop(&mut self) {
-        // Best-effort cleanup of the socket file (Unix only — Windows named pipes
-        // are not filesystem entries and don't need removal)
+        // Best-effort cleanup of the socket file (Unix only — TCP sockets
+        // on Windows are cleaned up by the OS when the listener is dropped)
         #[cfg(unix)]
         let _ = std::fs::remove_file(&self.pipe_path);
 
@@ -270,13 +270,13 @@ impl Drop for ExtHostSidecar {
 /// Mirrors `createRandomIPCHandle()` at `ipc.net.ts:889-904`.
 /// macOS has a 104-char limit for socket paths; UUID-based paths in /tmp/
 /// are ~55 chars, well within that limit.
+///
+/// Note: On Windows, TCP sockets are used instead (see `spawn()`), so
+/// this function is only called on Unix platforms.
+#[cfg(unix)]
 fn create_random_ipc_handle() -> String {
     let id = uuid::Uuid::new_v4();
-    if cfg!(windows) {
-        format!("\\\\.\\pipe\\vscode-ipc-{id}-sock")
-    } else {
-        format!("{}/vscode-ipc-{id}.sock", std::env::temp_dir().display())
-    }
+    format!("{}/vscode-ipc-{id}.sock", std::env::temp_dir().display())
 }
 
 /// Augment `product.json` with `commit` and `version` fields at runtime.
@@ -407,9 +407,18 @@ fn augment_product_json(app_root: &Path) -> Option<(std::path::PathBuf, String)>
 ///
 /// This replicates the pattern from `extensionHostConnection.ts:247-327`:
 /// 1. Augment `product.json` with `commit`/`version` for extensions
-/// 2. Create IPC pipe (Unix domain socket or Windows named pipe)
+/// 2. Create IPC endpoint (Unix domain socket or TCP socket on Windows)
 /// 3. Spawn `bun out/bootstrap-fork.js --type=extensionHost`
-/// 4. Wait for the ExtHost to connect back to our pipe (30s timeout)
+/// 4. Wait for the ExtHost to connect back (30s timeout)
+///
+/// # Platform-specific IPC
+///
+/// - **macOS/Linux**: Uses Unix domain sockets (traditional approach).
+/// - **Windows**: Uses TCP sockets on localhost instead of named pipes.
+///   Bun's `net.Socket` implementation on Windows named pipes has known
+///   reliability issues where data events may not fire correctly after
+///   the initial handshake, causing extension RPC calls to be silently lost.
+///   TCP sockets are well-tested and reliable on all platforms and runtimes.
 ///
 /// # Arguments
 /// * `app_root` — Repository root containing `out/bootstrap-fork.js` and `product.json`
@@ -425,21 +434,56 @@ pub async fn spawn(
     // Extensions (e.g., open-remote-ssh) read this file directly from disk.
     let augmented = augment_product_json(app_root);
 
-    let pipe_path = create_random_ipc_handle();
+    // --- Platform-specific IPC setup ---
+    // On Windows, use TCP sockets for Bun compatibility (named pipes have issues).
+    // On Unix, use traditional Unix domain sockets.
+    #[cfg(windows)]
+    let (pipe_path, stream) = {
+        // Bind TCP listener first to get the OS-assigned port.
+        let tcp_listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .map_err(ExtHostError::PipeCreation)?;
+        let port = tcp_listener
+            .local_addr()
+            .map_err(ExtHostError::PipeCreation)?
+            .port();
+        // Format as "tcp:host:port" — the ExtHost TypeScript layer detects this
+        // prefix and connects via TCP instead of named pipes.
+        let pipe_path = format!("tcp:127.0.0.1:{port}");
 
-    log::info!(target: "vscodeee::exthost::sidecar", "Listening on pipe: {pipe_path}");
+        log::info!(
+            target: "vscodeee::exthost::sidecar",
+            "IPC endpoint (TCP): {pipe_path}"
+        );
 
-    // Spawn child process and wait for IPC connection
-    let (mut child, stderr_buf) = spawn_child_process(app_root, resource_dir, &pipe_path)?;
+        let (mut child, stderr_buf) = spawn_child_process(app_root, resource_dir, &pipe_path)?;
+        let stream = accept_ipc_connection_tcp(tcp_listener, &stderr_buf, &mut child).await?;
 
-    let result = accept_ipc_connection(&pipe_path, &stderr_buf, &mut child).await;
-    if result.is_err() {
-        #[cfg(unix)]
-        let _ = std::fs::remove_file(&pipe_path);
-    }
-    let stream = result?;
+        // Store child in sidecar
+        let sidecar_child = child;
+        (pipe_path, (stream, sidecar_child))
+    };
 
-    log::info!(target: "vscodeee::exthost::sidecar", "ExtHost connected to pipe");
+    #[cfg(unix)]
+    let (pipe_path, stream) = {
+        let pipe_path = create_random_ipc_handle();
+
+        log::info!(
+            target: "vscodeee::exthost::sidecar",
+            "IPC endpoint (Unix socket): {pipe_path}"
+        );
+
+        let (mut child, stderr_buf) = spawn_child_process(app_root, resource_dir, &pipe_path)?;
+        let result = accept_ipc_connection(&pipe_path, &stderr_buf, &mut child).await;
+        if result.is_err() {
+            let _ = std::fs::remove_file(&pipe_path);
+        }
+        let stream = result?;
+        (pipe_path, (stream, child))
+    };
+
+    let (stream, child) = stream;
+    log::info!(target: "vscodeee::exthost::sidecar", "ExtHost connected via IPC");
 
     let sidecar = ExtHostSidecar {
         child,
@@ -589,25 +633,31 @@ async fn accept_ipc_connection(
 
 /// Accept an IPC connection from the ExtHost child process (Windows).
 ///
-/// Creates a Windows named pipe server, waits for the child to connect,
-/// and returns the connected pipe as an [`IpcStream`].
+/// Uses a TCP socket on localhost instead of Windows named pipes for
+/// reliability with the Bun runtime. Bun's named pipe implementation
+/// on Windows has issues where `data` events may not fire correctly
+/// after the initial protocol handshake, causing extension RPC messages
+/// to be silently dropped.
+///
+/// TCP sockets are well-tested across all platforms and runtimes, and
+/// provide reliable bidirectional byte streaming.
 #[cfg(windows)]
-async fn accept_ipc_connection(
-    pipe_path: &str,
+async fn accept_ipc_connection_tcp(
+    listener: tokio::net::TcpListener,
     stderr_buf: &Arc<Mutex<String>>,
     child: &mut Child,
 ) -> Result<IpcStream, ExtHostError> {
-    use tokio::net::windows::named_pipe::ServerOptions;
-
-    let server = ServerOptions::new()
-        .first_pipe_instance(true)
-        .create(pipe_path)
-        .map_err(ExtHostError::PipeCreation)?;
-
     tokio::select! {
-        result = server.connect() => {
-            result.map_err(ExtHostError::PipeCreation)?;
-            Ok(Box::new(server) as IpcStream)
+        result = listener.accept() => {
+            let (stream, addr) = result.map_err(ExtHostError::PipeCreation)?;
+            log::info!(
+                target: "vscodeee::exthost::sidecar",
+                "ExtHost connected via TCP from {addr}"
+            );
+            // Disable Nagle's algorithm for low-latency IPC message exchange.
+            // Extension host RPC messages are typically small and latency-sensitive.
+            stream.set_nodelay(true).map_err(ExtHostError::Io)?;
+            Ok(Box::new(stream) as IpcStream)
         }
         _ = tokio::time::sleep(tokio::time::Duration::from_secs(30)) => {
             check_child_exit_or_timeout(child, stderr_buf).await

--- a/src-tauri/src/exthost/ws_relay.rs
+++ b/src-tauri/src/exthost/ws_relay.rs
@@ -97,36 +97,40 @@ async fn relay_loop(
     // Relay: WebSocket → IPC pipe
     let ws_to_ipc = async {
         let mut count: u64 = 0;
+        let mut total_bytes: u64 = 0;
         while let Some(msg) = ws_read.next().await {
             match msg {
                 Ok(tokio_tungstenite::tungstenite::Message::Binary(data)) => {
                     count += 1;
-                    // Log the first 20 frames, then every 100th to avoid
-                    // flooding the log during normal operation.
-                    if count <= 20 || count.is_multiple_of(100) {
+                    total_bytes += data.len() as u64;
+                    if count <= 50 || count.is_multiple_of(100) {
                         log::debug!(
                             target: "vscodeee::exthost::ws_relay",
-                            "WS→pipe #{count}: {len} bytes, first4={first4:?}",
+                            "WS→IPC #{count}: {len} bytes (total={total_bytes})",
                             len = data.len(),
-                            first4 = &data[..std::cmp::min(4, data.len())]
                         );
                     }
-                    if ipc_write.write_all(&data).await.is_err() {
-                        log::error!(target: "vscodeee::exthost::ws_relay", "WS→pipe: write_all failed");
+                    if let Err(e) = ipc_write.write_all(&data).await {
+                        log::error!(target: "vscodeee::exthost::ws_relay", "WS→IPC: write_all failed: {e}");
+                        break;
+                    }
+                    if let Err(e) = ipc_write.flush().await {
+                        log::error!(target: "vscodeee::exthost::ws_relay", "WS→IPC: flush failed: {e}");
                         break;
                     }
                 }
                 Ok(tokio_tungstenite::tungstenite::Message::Close(_)) => {
-                    log::info!(target: "vscodeee::exthost::ws_relay", "WS→pipe: received Close");
+                    log::info!(target: "vscodeee::exthost::ws_relay", "WS→IPC: received Close (sent {count} msgs, {total_bytes} bytes total)");
                     break;
                 }
                 Err(e) => {
-                    log::error!(target: "vscodeee::exthost::ws_relay", "WS→pipe: read error: {e}");
+                    log::error!(target: "vscodeee::exthost::ws_relay", "WS→IPC: read error: {e} (after {count} msgs)");
                     break;
                 }
                 _ => {} // Ignore text/ping/pong
             }
         }
+        log::info!(target: "vscodeee::exthost::ws_relay", "WS→IPC: loop ended, {count} msgs, {total_bytes} bytes total");
         let _ = ipc_write.shutdown().await;
     };
 
@@ -134,34 +138,35 @@ async fn relay_loop(
     let ipc_to_ws = async {
         let mut buf = vec![0u8; 64 * 1024]; // 64KB read buffer
         let mut count: u64 = 0;
+        let mut total_bytes: u64 = 0;
         loop {
             match ipc_read.read(&mut buf).await {
                 Ok(0) => {
-                    log::info!(target: "vscodeee::exthost::ws_relay", "pipe→WS: EOF");
+                    log::info!(target: "vscodeee::exthost::ws_relay", "IPC→WS: EOF (sent {count} msgs, {total_bytes} bytes total)");
                     break;
                 }
                 Ok(n) => {
                     count += 1;
-                    // Same log throttling as WS→pipe direction.
-                    if count <= 20 || count.is_multiple_of(100) {
+                    total_bytes += n as u64;
+                    if count <= 50 || count.is_multiple_of(100) {
                         log::debug!(
                             target: "vscodeee::exthost::ws_relay",
-                            "pipe→WS #{count}: {n} bytes, first4={first4:?}",
-                            first4 = &buf[..std::cmp::min(4, n)]
+                            "IPC→WS #{count}: {n} bytes (total={total_bytes})",
                         );
                     }
                     let msg = tokio_tungstenite::tungstenite::Message::Binary(buf[..n].into());
-                    if ws_write.send(msg).await.is_err() {
-                        log::error!(target: "vscodeee::exthost::ws_relay", "pipe→WS: send failed");
+                    if let Err(e) = ws_write.send(msg).await {
+                        log::error!(target: "vscodeee::exthost::ws_relay", "IPC→WS: send failed: {e} (after {count} msgs)");
                         break;
                     }
                 }
                 Err(e) => {
-                    log::error!(target: "vscodeee::exthost::ws_relay", "pipe→WS: read error: {e}");
+                    log::error!(target: "vscodeee::exthost::ws_relay", "IPC→WS: read error: {e} (after {count} msgs)");
                     break;
                 }
             }
         }
+        log::info!(target: "vscodeee::exthost::ws_relay", "IPC→WS: loop ended, {count} msgs, {total_bytes} bytes total");
         let _ = ws_write.close().await;
     };
 

--- a/src/vs/workbench/api/node/extensionHostProcess.ts
+++ b/src/vs/workbench/api/node/extensionHostProcess.ts
@@ -282,11 +282,22 @@ function _createExtHostProtocol(): Promise<IMessagePassingProtocol> {
 
 		return new Promise<PersistentProtocol>((resolve, reject) => {
 
-			// Use {path} object form for Bun compatibility.
-			// Bun's net.createConnection(string) treats the argument as a TCP host
-			// rather than a Unix socket path. The object form works on both runtimes.
-			const socket = net.createConnection({ path: pipeName }, () => {
+			// On Windows, the Rust sidecar uses TCP sockets instead of named pipes
+			// for Bun compatibility. Named pipes have reliability issues with Bun
+			// where data events may not fire correctly after the initial handshake.
+			// The TCP format is "tcp:host:port" (e.g., "tcp:127.0.0.1:12345").
+			const tcpMatch = pipeName.match(/^tcp:(.+):(\d+)$/);
+			const connectOpts: { path?: string; host?: string; port?: number } = tcpMatch
+				? { host: tcpMatch[1], port: parseInt(tcpMatch[2], 10) }
+				// Use {path} object form for Bun compatibility.
+				// Bun's net.createConnection(string) treats the argument as a TCP host
+				// rather than a Unix socket path. The object form works on both runtimes.
+				: { path: pipeName };
+
+			const socket = net.createConnection(connectOpts as net.NetConnectOpts, () => {
 				socket.removeListener('error', reject);
+				// Disable Nagle's algorithm for low-latency IPC message exchange.
+				socket.setNoDelay(true);
 				const protocol = new PersistentProtocol({ socket: new NodeSocket(socket, 'extHost-renderer') });
 				protocol.sendResume();
 				resolve(protocol);

--- a/src/vs/workbench/services/extensions/tauri-browser/tauriExtensionHostFactory.ts
+++ b/src/vs/workbench/services/extensions/tauri-browser/tauriExtensionHostFactory.ts
@@ -14,10 +14,9 @@ import { ExtensionDescriptionRegistrySnapshot } from '../common/extensionDescrip
 import { ExtensionHostKind } from '../common/extensionHostKind.js';
 import { ExtensionRunningLocation, LocalProcessRunningLocation } from '../common/extensionRunningLocation.js';
 import { ExtensionRunningLocationTracker, filterExtensionDescriptions } from '../common/extensionRunningLocationTracker.js';
-import { ExtensionHostExtensions, ExtensionHostStartup, IExtensionHost } from '../common/extensions.js';
+import { ExtensionHostExtensions, IExtensionHost } from '../common/extensions.js';
 import { ExtensionsProposedApi } from '../common/extensionsProposedApi.js';
 import { IRemoteExtensionHostDataProvider, IRemoteExtensionHostInitData, RemoteExtensionHost } from '../common/remoteExtensionHost.js';
-import { IWebWorkerExtensionHostDataProvider, IWebWorkerExtensionHostInitData, WebWorkerExtensionHost } from '../browser/webWorkerExtensionHost.js';
 import { TauriLocalProcessExtensionHost, ITauriLocalProcessExtensionHostDataProvider } from './tauriLocalProcessExtensionHost.js';
 
 /**
@@ -43,9 +42,9 @@ export class TauriExtensionHostFactory implements IExtensionHostFactory {
   /**
 	 * Create an extension host for the given running location.
 	 *
-	 * Handles all three extension host kinds:
+	 * Handles extension host kinds:
 	 * - `LocalProcess` → {@link TauriLocalProcessExtensionHost} (Tauri-specific)
-	 * - `LocalWebWorker` → {@link WebWorkerExtensionHost}
+	 * - `LocalWebWorker` → `null` (disabled; see TODO(Phase 2) comment)
 	 * - `Remote` → {@link RemoteExtensionHost}
 	 *
 	 * @returns The created extension host, or `null` if the kind is unsupported.
@@ -63,17 +62,15 @@ export class TauriExtensionHostFactory implements IExtensionHostFactory {
         );
       }
       case ExtensionHostKind.LocalWebWorker: {
-        const startup = (
-          isInitialStart
-            ? ExtensionHostStartup.EagerManualStart
-            : ExtensionHostStartup.EagerAutoStart
-        );
-        return this._instantiationService.createInstance(
-          WebWorkerExtensionHost,
-          runningLocation,
-          startup,
-          this._createLocalWebWorkerExtensionHostDataProvider(runningLocations, runningLocation, isInitialStart),
-        );
+        // TODO(Phase 2): In Tauri desktop, the WebWorker extension host iframe
+        // (vscode-file://vscode-app) fails to start because it cannot establish
+        // a MessagePort handshake with the main window (tauri://localhost) due to
+        // cross-origin restrictions. The hanging start() Promise blocks ALL
+        // extension activation via Promise.all in _activateByEvent, preventing
+        // commands and features from working even in the LocalProcess host.
+        // Returning null disables the WebWorker host, matching Electron desktop
+        // behavior where web-only extensions are not supported.
+        return null;
       }
       case ExtensionHostKind.Remote: {
         const remoteAgentConnection = this._remoteAgentService.getConnection();
@@ -97,25 +94,6 @@ export class TauriExtensionHostFactory implements IExtensionHostFactory {
   private _createLocalProcessExtensionHostDataProvider(runningLocations: ExtensionRunningLocationTracker, desiredRunningLocation: ExtensionRunningLocation, isInitialStart: boolean): ITauriLocalProcessExtensionHostDataProvider {
     return {
       getInitData: async () => {
-        if (isInitialStart) {
-          const localExtensions = checkEnabledAndProposedAPI(this._logService, this._extensionEnablementService, this._extensionsProposedApi, await this._scanWebExtensions(), /* ignore workspace trust */true);
-          const runningLocation = runningLocations.computeRunningLocation(localExtensions, [], false);
-          const myExtensions = filterExtensionDescriptions(localExtensions, runningLocation, extRunningLocation => desiredRunningLocation.equals(extRunningLocation));
-          const extensions = new ExtensionHostExtensions(0, localExtensions, myExtensions.map(extension => extension.identifier));
-          return { extensions };
-        } else {
-          const snapshot = await this._getExtensionRegistrySnapshotWhenReady();
-          const myExtensions = runningLocations.filterByRunningLocation(snapshot.extensions, desiredRunningLocation);
-          const extensions = new ExtensionHostExtensions(snapshot.versionId, snapshot.extensions, myExtensions.map(extension => extension.identifier));
-          return { extensions };
-        }
-      },
-    };
-  }
-
-  private _createLocalWebWorkerExtensionHostDataProvider(runningLocations: ExtensionRunningLocationTracker, desiredRunningLocation: ExtensionRunningLocation, isInitialStart: boolean): IWebWorkerExtensionHostDataProvider {
-    return {
-      getInitData: async (): Promise<IWebWorkerExtensionHostInitData> => {
         if (isInitialStart) {
           const localExtensions = checkEnabledAndProposedAPI(this._logService, this._extensionEnablementService, this._extensionsProposedApi, await this._scanWebExtensions(), /* ignore workspace trust */true);
           const runningLocation = runningLocations.computeRunningLocation(localExtensions, [], false);

--- a/src/vs/workbench/services/extensions/tauri-browser/tauriExtensionService.ts
+++ b/src/vs/workbench/services/extensions/tauri-browser/tauriExtensionService.ts
@@ -96,7 +96,10 @@ export class TauriExtensionService extends AbstractExtensionService implements I
     );
     super(
       // hasLocalProcess: true — enables LocalProcess extension host routing
-      { hasLocalProcess: true, allowRemoteExtensionsInLocalWebWorker: true },
+      // allowRemoteExtensionsInLocalWebWorker: false — WebWorker host is disabled
+      // in Tauri desktop (same as Electron desktop). Web-only extensions are not
+      // supported; all local extensions run via LocalProcess.
+      { hasLocalProcess: true, allowRemoteExtensionsInLocalWebWorker: false },
       extensionsProposedApi,
       extensionHostFactory,
       new TauriExtensionHostKindPicker(logService),


### PR DESCRIPTION
## Summary

Fix Windows extension host IPC reliability and unblock extension command execution.

Closes #495

## Changes

### Windows IPC: Named Pipes → TCP Sockets (`sidecar.rs`, `extensionHostProcess.ts`)

Bun's `net.Socket` on Windows named pipes has reliability issues where `data` events may not fire correctly after the initial protocol handshake, causing extension RPC messages to be silently dropped. This switches to TCP sockets on `127.0.0.1` for the Extension Host IPC on Windows while keeping Unix domain sockets on macOS/Linux.

- **Rust (`sidecar.rs`)**: `#[cfg(windows)]` binds a TCP listener on `127.0.0.1:0`, passes `tcp:127.0.0.1:{port}` as the pipe path. Unix path unchanged.
- **TypeScript (`extensionHostProcess.ts`)**: Detects `tcp:host:port` format and connects via TCP with `setNoDelay(true)`.

### WebWorker Extension Host Disabled (`tauriExtensionHostFactory.ts`, `tauriExtensionService.ts`)

The WebWorker extension host iframe (`vscode-file://vscode-app`) fails to establish a `MessagePort` handshake with the main window (`tauri://localhost`) due to cross-origin restrictions. The hanging `start()` Promise blocks ALL extension activation via `Promise.all` in `_activateByEvent`, preventing commands and features from working even in the LocalProcess host.

- Return `null` for `LocalWebWorker` kind (matching Electron desktop behavior)
- Set `allowRemoteExtensionsInLocalWebWorker: false`
- Remove unused `_createLocalWebWorkerExtensionHostDataProvider` method and imports

### WebSocket Relay Improvements (`ws_relay.rs`)

- Add `ipc_write.flush()` after `write_all()` to ensure timely delivery
- Improve error logging with error details and message counts
- Clean up debug logs (revert `info!` → `debug!` for per-message tracing)

## Testing

- Verified on Windows: extensions activate and commands execute correctly
- Cursor movement, command palette, and extension features all working
- No impact on macOS/Linux (TCP change is `#[cfg(windows)]` only)