### PR TITLE
🚀 Release v0.22.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.1] - 2026-05-10
+
+### Fixed
+
+- Prevent console window from appearing on Windows release builds (#503)
+- Detect Windows shell profiles with absolute paths and support default profile selection
+
 ## [0.22.0] - 2026-05-10
 
 ### Added

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-utils/schema.json",
   "productName": "VS Codeee",
   "mainBinaryName": "codeee",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "identifier": "com.vscodeee.app",
   "build": {
     "frontendDist": "../out",


### PR DESCRIPTION
## Summary

- Bump version from v0.22.0 to v0.22.1
- Prevent console window from appearing on Windows release builds (#503)
- Detect Windows shell profiles with absolute paths and support default profile selection

## Test plan

- [ ] Verify Windows release build does not show console window
- [ ] Verify shell profile detection works with absolute paths
- [ ] Verify default profile selection works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)