### PR TITLE
perf: move ExtHost initialization to LifecyclePhase.Starting

### DIFF
--- a/src/vs/workbench/services/extensions/tauri-browser/tauriExtensionService.ts
+++ b/src/vs/workbench/services/extensions/tauri-browser/tauriExtensionService.ts
@@ -56,7 +56,7 @@ export class TauriExtensionService extends AbstractExtensionService implements I
    * Configures the extension host factory to route extensions through the Tauri
    * LocalProcess extension host (Rust WS relay). Registers fetch-based file
    * system providers for HTTP/HTTPS schemes and schedules initialization on
-   * {@link LifecyclePhase.Ready}.
+   * {@link LifecyclePhase.Starting}.
    */
   constructor(
     @IInstantiationService instantiationService: IInstantiationService,
@@ -122,7 +122,7 @@ export class TauriExtensionService extends AbstractExtensionService implements I
       dialogService,
     );
 
-    lifecycleService.when(LifecyclePhase.Ready).then(async () => {
+    lifecycleService.when(LifecyclePhase.Starting).then(async () => {
       await this._initializeIfNeeded();
     });
 


### PR DESCRIPTION
## Summary

- Move extension host initialization trigger from `LifecyclePhase.Ready` to `LifecyclePhase.Starting` in `TauriExtensionService`
- This allows Bun process spawn, IPC connection, and handshake to overlap with workbench layout creation, reducing perceived startup delay by hundreds of milliseconds
- Update JSDoc comment to reflect the new lifecycle phase

## Context

Previously, ExtHost initialization waited until all eager services were instantiated (`Ready` phase). However, all services needed by the initialization chain (`IUserDataInitializationService`, workspace context, environment service) are available at `Starting` phase — and `IUserDataInitializationService.initializeInstalledExtensions()` is effectively a no-op in the Tauri build (empty initializers array).

The `_createExtHostInitData()` call (which needs `ITelemetryService` and other Ready-phase services) runs after Bun spawn + WebSocket handshake completes (~hundreds of ms), by which point `Ready` has already been reached.

Closes #506

## Test plan

- [ ] Verify extensions load correctly on startup (e.g., Git extension appears in status bar)
- [ ] Verify editors open normally
- [ ] Check console logs for extension-related errors
- [ ] Regression: if issues arise, reverting to `LifecyclePhase.Ready` is a one-line change

🤖 Generated with [Claude Code](https://claude.com/claude-code)