### PR TITLE
perf: cache product.json augmentation to skip redundant I/O on ExtHost spawn

### DIFF
--- a/src-tauri/src/commands/native_host/misc.rs
+++ b/src-tauri/src/commands/native_host/misc.rs
@@ -251,12 +251,10 @@ fn enumerate_fonts_windows() -> Vec<String> {
 /// to produce a clean family name. Empty entries are silently discarded.
 #[cfg(target_os = "windows")]
 fn collect_font_families_from_registry(reg_key: &winreg::RegKey, families: &mut Vec<String>) {
-    for result in reg_key.enum_values() {
-        if let Ok((name, _)) = result {
-            let family = name.split(" (").next().unwrap_or(&name).trim().to_string();
-            if !family.is_empty() {
-                families.push(family);
-            }
+    for (name, _) in reg_key.enum_values().flatten() {
+        let family = name.split(" (").next().unwrap_or(&name).trim().to_string();
+        if !family.is_empty() {
+            families.push(family);
         }
     }
 }

--- a/src-tauri/src/commands/spawn_exthost.rs
+++ b/src-tauri/src/commands/spawn_exthost.rs
@@ -372,9 +372,7 @@ pub async fn spawn_extension_host(
     #[cfg(not(unix))]
     {
         let _ = app_handle;
-        Err(
-            "Extension Host sidecar is only supported on Unix (macOS/Linux) in the PoC.".into(),
-        )
+        Err("Extension Host sidecar is only supported on Unix (macOS/Linux) in the PoC.".into())
     }
 
     #[cfg(unix)]

--- a/src-tauri/src/commands/spawn_exthost.rs
+++ b/src-tauri/src/commands/spawn_exthost.rs
@@ -128,7 +128,7 @@ impl ExtHostState {
     /// Drains all instances from the map and aborts their watchdog/relay tasks,
     /// then kills the child process directly.
     pub fn sync_kill_all(&self) {
-        let drained = match self.instances.try_lock() {
+        let drained: Vec<_> = match self.instances.try_lock() {
             Ok(mut instances) => instances.drain().collect(),
             Err(_) => {
                 log::warn!(
@@ -163,7 +163,7 @@ impl ExtHostState {
                     // /F = force kill, /T = kill child processes too.
                     // CREATE_NO_WINDOW (0x08000000) prevents a console window from flashing.
                     let _ = std::process::Command::new("taskkill")
-                        .args(["/F", "/T", "/PID", &pid.to_string()])
+                        .args(["/F", "/T", "/PID", pid.to_string().as_str()])
                         .creation_flags(0x08000000) // CREATE_NO_WINDOW
                         .stdout(std::process::Stdio::null())
                         .stderr(std::process::Stdio::null())
@@ -372,9 +372,9 @@ pub async fn spawn_extension_host(
     #[cfg(not(unix))]
     {
         let _ = app_handle;
-        return Err(
+        Err(
             "Extension Host sidecar is only supported on Unix (macOS/Linux) in the PoC.".into(),
-        );
+        )
     }
 
     #[cfg(unix)]

--- a/src-tauri/src/commands/spawn_exthost.rs
+++ b/src-tauri/src/commands/spawn_exthost.rs
@@ -128,7 +128,7 @@ impl ExtHostState {
     /// Drains all instances from the map and aborts their watchdog/relay tasks,
     /// then kills the child process directly.
     pub fn sync_kill_all(&self) {
-        let drained: Vec<(u32, ExtHostInstance)> = match self.instances.try_lock() {
+        let drained = match self.instances.try_lock() {
             Ok(mut instances) => instances.drain().collect(),
             Err(_) => {
                 log::warn!(
@@ -192,7 +192,7 @@ pub async fn spawn_exthost_with_relay(
 ) -> Result<ExtHostSpawnResult, String> {
     use crate::exthost;
 
-    let (app_root, resource_dir) = resolve_app_root_and_resource_dir(&app_handle)?;
+    let (app_root, resource_dir, cache_dir) = resolve_app_root_and_resource_dir(&app_handle)?;
     log::info!(target: "vscodeee::commands::spawn_exthost", "Spawning ExtHost with WS relay, app root: {}", app_root.display());
 
     // Verify prerequisites
@@ -208,7 +208,7 @@ pub async fn spawn_exthost_with_relay(
     let instance_id = exthost_state.next_id.fetch_add(1, Ordering::Relaxed);
 
     // Step 1+2: Create pipe + spawn Bun
-    let (sidecar, ipc_stream) = exthost::sidecar::spawn(&app_root, &resource_dir)
+    let (sidecar, ipc_stream) = exthost::sidecar::spawn(&app_root, &resource_dir, &cache_dir)
         .await
         .map_err(|e| format!("ExtHost spawn failed: {e}"))?;
 
@@ -392,7 +392,7 @@ pub async fn spawn_extension_host(
 async fn spawn_extension_host_unix(
     app_handle: tauri::AppHandle,
 ) -> Result<ExtHostHandshakeResult, String> {
-    let (app_root, resource_dir) = resolve_app_root_and_resource_dir(&app_handle)?;
+    let (app_root, resource_dir, cache_dir) = resolve_app_root_and_resource_dir(&app_handle)?;
     log::info!(target: "vscodeee::commands::spawn_exthost", "App root: {}", app_root.display());
 
     // Verify prerequisites
@@ -404,7 +404,7 @@ async fn spawn_extension_host_unix(
         ));
     }
 
-    match spawn_and_handshake(&app_root, &resource_dir).await {
+    match spawn_and_handshake(&app_root, &resource_dir, &cache_dir).await {
         Ok(result) => Ok(result),
         Err(e) => Ok(ExtHostHandshakeResult {
             success: false,
@@ -425,10 +425,12 @@ async fn spawn_extension_host_unix(
 async fn spawn_and_handshake(
     app_root: &std::path::Path,
     resource_dir: &std::path::Path,
+    cache_dir: &std::path::Path,
 ) -> Result<ExtHostHandshakeResult, crate::exthost::ExtHostError> {
     use crate::exthost;
     // Step 1+2: Create pipe + spawn Bun
-    let (mut sidecar, mut stream) = exthost::sidecar::spawn(app_root, resource_dir).await?;
+    let (mut sidecar, mut stream) =
+        exthost::sidecar::spawn(app_root, resource_dir, cache_dir).await?;
 
     let pid = sidecar.child.id().unwrap_or(0);
     let pipe_path = sidecar.pipe_path.clone();
@@ -461,7 +463,7 @@ async fn spawn_and_handshake(
 /// Returns the first directory that contains `out/bootstrap-fork.js`.
 fn resolve_app_root_and_resource_dir(
     app_handle: &tauri::AppHandle,
-) -> Result<(PathBuf, PathBuf), String> {
+) -> Result<(PathBuf, PathBuf, PathBuf), String> {
     use tauri::Manager;
 
     let resource_dir = strip_unc_prefix(
@@ -471,11 +473,16 @@ fn resolve_app_root_and_resource_dir(
             .map_err(|e| format!("Failed to resolve resource dir: {e}"))?,
     );
 
+    let cache_dir = app_handle
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("Failed to resolve app data dir: {e}"))?;
+
     // Walk up from resource dir to find the repo root
     let mut candidate = resource_dir.as_path();
     for _ in 0..5 {
         if candidate.join("out/bootstrap-fork.js").exists() {
-            return Ok((candidate.to_path_buf(), resource_dir.clone()));
+            return Ok((candidate.to_path_buf(), resource_dir.clone(), cache_dir));
         }
         if let Some(parent) = candidate.parent() {
             candidate = parent;
@@ -488,7 +495,7 @@ fn resolve_app_root_and_resource_dir(
     if let Ok(cwd) = std::env::current_dir() {
         let cwd = strip_unc_prefix(&cwd);
         if cwd.join("out/bootstrap-fork.js").exists() {
-            return Ok((cwd, resource_dir));
+            return Ok((cwd, resource_dir, cache_dir));
         }
     }
 
@@ -497,7 +504,7 @@ fn resolve_app_root_and_resource_dir(
     // `{resource_dir}/_up_/` since `out/bootstrap-fork.js` lives under it.
     let up_dir = resource_dir.join("_up_");
     if up_dir.join("out/bootstrap-fork.js").exists() {
-        return Ok((up_dir, resource_dir));
+        return Ok((up_dir, resource_dir, cache_dir));
     }
 
     Err(format!(

--- a/src-tauri/src/exthost/init_data.rs
+++ b/src-tauri/src/exthost/init_data.rs
@@ -25,6 +25,7 @@
 ///
 /// This JSON is sent as the InitData message during the
 /// Ready→InitData→Initialized handshake sequence.
+#[allow(dead_code)]
 pub fn build_minimal_init_data() -> String {
     serde_json::json!({
         "version": "1.115.0",

--- a/src-tauri/src/exthost/mod.rs
+++ b/src-tauri/src/exthost/mod.rs
@@ -74,6 +74,7 @@ pub enum ExtHostError {
     /// Contains the exit status and any captured stderr output.
     ChildExited { status: String, stderr: String },
     /// Protocol error — unexpected message type or format.
+    #[allow(dead_code)]
     Protocol(String),
     /// IO error during communication.
     Io(std::io::Error),

--- a/src-tauri/src/exthost/protocol.rs
+++ b/src-tauri/src/exthost/protocol.rs
@@ -19,6 +19,8 @@
 //! the renderer (TypeScript PersistentProtocol) and the Extension Host.
 //! This module will then be used only for optional debug logging.
 
+#![allow(dead_code)]
+
 use std::io;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 

--- a/src-tauri/src/exthost/sidecar.rs
+++ b/src-tauri/src/exthost/sidecar.rs
@@ -21,6 +21,86 @@ use tokio::sync::Mutex;
 
 use super::{ExtHostError, IpcStream};
 
+// ── product.json augmentation mtime cache ────────────────────────────────
+
+/// Cache record indicating that `product.json` already contains both `commit`
+/// and `version` fields and does not need augmentation.
+///
+/// Stored in `{cache_dir}/product-augment-cache.json` alongside the app data.
+#[derive(serde::Serialize, serde::Deserialize, Default)]
+struct ProductAugmentCache {
+    /// Modification time of `product.json` (seconds since UNIX epoch).
+    product_json_mtime: f64,
+    /// `false` = no augmentation was needed. `true` = augmentation was performed.
+    needed: bool,
+}
+
+/// Check whether `augment_product_json()` can be skipped via the mtime cache.
+///
+/// Returns `true` when the cached mtime matches the file's current mtime and
+/// `needed` is `false`, meaning the file already had both fields last time.
+fn is_augmentation_cached(product_path: &Path, cache_dir: &Path) -> bool {
+    let cache_path = cache_dir.join("product-augment-cache.json");
+
+    let cache: ProductAugmentCache = match std::fs::read_to_string(&cache_path) {
+        Ok(s) => serde_json::from_str(&s).unwrap_or_default(),
+        Err(_) => return false,
+    };
+
+    // If augmentation was needed last time, always re-check
+    if cache.needed {
+        return false;
+    }
+
+    let current_mtime = match std::fs::metadata(product_path)
+        .ok()
+        .and_then(|m| m.modified().ok())
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+    {
+        Some(d) => d.as_secs_f64(),
+        None => return false,
+    };
+
+    let cache_hit = (cache.product_json_mtime - current_mtime).abs() < f64::EPSILON;
+    if cache_hit {
+        log::debug!(
+            target: "vscodeee::exthost::sidecar",
+            "product.json cache hit (mtime={current_mtime}), skipping augmentation"
+        );
+    }
+    cache_hit
+}
+
+/// Persist the augmentation cache after a check completes.
+fn write_augmentation_cache(product_path: &Path, cache_dir: &Path, needed: bool) {
+    let cache_path = cache_dir.join("product-augment-cache.json");
+
+    let current_mtime = match std::fs::metadata(product_path)
+        .ok()
+        .and_then(|m| m.modified().ok())
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+    {
+        Some(d) => d.as_secs_f64(),
+        None => return,
+    };
+
+    let cache = ProductAugmentCache {
+        product_json_mtime: current_mtime,
+        needed,
+    };
+    if let Ok(json) = serde_json::to_string(&cache) {
+        if let Some(parent) = cache_path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        if let Err(e) = std::fs::write(&cache_path, json) {
+            log::warn!(
+                target: "vscodeee::exthost::sidecar",
+                "Failed to write product augment cache: {e}"
+            );
+        }
+    }
+}
+
 /// Resolve the Bun runtime binary path.
 ///
 /// Resolution order:
@@ -41,18 +121,17 @@ fn resolve_runtime_binary() -> String {
     }
 
     // 2. Bundled Bun sidecar (production Tauri build)
-    if let Some(sidecar_path) = std::env::current_exe()
+    let bun_name = if cfg!(target_os = "windows") {
+        "bun.exe"
+    } else {
+        "bun"
+    };
+    if let Some(exe_dir) = std::env::current_exe()
         .ok()
         .as_ref()
         .and_then(|exe| exe.parent())
-        .map(|dir| {
-            dir.join(if cfg!(target_os = "windows") {
-                "bun.exe"
-            } else {
-                "bun"
-            })
-        })
     {
+        let sidecar_path = exe_dir.join(bun_name);
         if sidecar_path.exists() {
             log::info!(
                 target: "vscodeee::exthost::sidecar",
@@ -205,7 +284,7 @@ fn build_exthost_path() -> String {
             "/usr/local/sbin",
         ]
     } else if cfg!(target_os = "windows") {
-        // Windows: Common tool locations that may not be in PATH
+        // Windows: Common tool locations that may not be in PATH.
         // Most tools are found via the system PATH, but some (e.g., Git for Windows)
         // install to non-standard locations.
         &[]
@@ -222,12 +301,11 @@ fn build_exthost_path() -> String {
     }
 
     if parts.is_empty() {
-        current
-    } else {
-        // Prepend extra dirs so they take priority
-        parts.push(&current);
-        parts.join(&separator.to_string())
+        return current;
     }
+    // Prepend extra dirs so they take priority
+    parts.push(&current);
+    parts.join(&separator.to_string())
 }
 
 /// A running Extension Host sidecar process with its named pipe path.
@@ -296,8 +374,15 @@ fn create_random_ipc_handle() -> String {
 ///
 /// Returns `Some((path, original_content))` if the file was modified, or
 /// `None` if no modification was needed.
-fn augment_product_json(app_root: &Path) -> Option<(std::path::PathBuf, String)> {
+fn augment_product_json(app_root: &Path, cache_dir: &Path) -> Option<(std::path::PathBuf, String)> {
     let product_path = app_root.join("product.json");
+
+    // Fast path: skip augmentation if cached mtime matches and no augmentation
+    // was needed last time.
+    if is_augmentation_cached(&product_path, cache_dir) {
+        return None;
+    }
+
     let original = match std::fs::read_to_string(&product_path) {
         Ok(s) => s,
         Err(e) => {
@@ -380,6 +465,9 @@ fn augment_product_json(app_root: &Path) -> Option<(std::path::PathBuf, String)>
     }
 
     if !modified {
+        // product.json already has commit+version — cache the mtime so the
+        // next spawn can skip reading and parsing this file entirely.
+        write_augmentation_cache(&product_path, cache_dir, false);
         return None;
     }
 
@@ -408,6 +496,9 @@ fn augment_product_json(app_root: &Path) -> Option<(std::path::PathBuf, String)>
         target: "vscodeee::exthost::sidecar",
         "Wrote augmented product.json with commit and version"
     );
+    // Cache that augmentation was needed so the next spawn re-checks after
+    // the Drop impl restores the original content (which changes the mtime).
+    write_augmentation_cache(&product_path, cache_dir, true);
     Some((product_path, original))
 }
 
@@ -431,16 +522,18 @@ fn augment_product_json(app_root: &Path) -> Option<(std::path::PathBuf, String)>
 /// # Arguments
 /// * `app_root` — Repository root containing `out/bootstrap-fork.js` and `product.json`
 /// * `resource_dir` — Tauri resource directory containing bundled `node_modules/`
+/// * `cache_dir` — Application data directory for the augmentation mtime cache
 ///
 /// # Returns
 /// A tuple of the sidecar handle and the connected IPC stream.
 pub async fn spawn(
     app_root: &Path,
     resource_dir: &Path,
+    cache_dir: &Path,
 ) -> Result<(ExtHostSidecar, IpcStream), ExtHostError> {
     // Augment product.json with commit/version before spawning the ExtHost.
     // Extensions (e.g., open-remote-ssh) read this file directly from disk.
-    let augmented = augment_product_json(app_root);
+    let augmented = augment_product_json(app_root, cache_dir);
 
     // --- Platform-specific IPC setup ---
     // On Windows, use TCP sockets for Bun compatibility (named pipes have issues).
@@ -467,9 +560,7 @@ pub async fn spawn(
         let (mut child, stderr_buf) = spawn_child_process(app_root, resource_dir, &pipe_path)?;
         let stream = accept_ipc_connection_tcp(tcp_listener, &stderr_buf, &mut child).await?;
 
-        // Store child in sidecar
-        let sidecar_child = child;
-        (pipe_path, (stream, sidecar_child))
+        (pipe_path, (stream, child))
     };
 
     #[cfg(unix)]

--- a/src-tauri/src/file_server.rs
+++ b/src-tauri/src/file_server.rs
@@ -72,6 +72,7 @@ impl FileServer {
     }
 
     /// Returns the port number the server is listening on.
+    #[allow(dead_code)]
     pub fn port(&self) -> u16 {
         self.port
     }
@@ -104,7 +105,7 @@ async fn handle_connection(
     let request = String::from_utf8_lossy(&buf[..n]);
     let path = extract_request_path(&request);
 
-    let (status, content_type, body) = match serve_file_from_roots(roots, &path) {
+    let (status, content_type, body) = match serve_file_from_roots(roots, path) {
         Ok((mime, content)) => (200, mime, content),
         Err(FileServerError::NotFound) => (
             404,


### PR DESCRIPTION
## Summary

- Add mtime-based cache (`product-augment-cache.json` in `app_data_dir`) for `augment_product_json()` to avoid redundant file I/O and `git rev-parse HEAD` subprocess calls on every Extension Host spawn
- Cache records whether augmentation was needed and the file's modification time; skips the entire read/parse/git check when the mtime matches and no augmentation was needed
- Falls back gracefully on any cache error (missing file, corrupt JSON, metadata failure)

Closes #507

## Test plan

- [ ] Verify Extension Host spawns successfully on first launch (cache created)
- [ ] Verify second launch logs `product.json cache hit` and skips augmentation
- [ ] Verify cache invalidation when `product.json` is manually modified
- [ ] Verify cache file appears at `app_data_dir/product-augment-cache.json`
- [ ] Verify extensions (e.g., open-remote-ssh) still read correct `commit` and `version` from `product.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)