### PR TITLE
fix: strip UNC path prefix from resource_dir extensions path for Bun compatibility

### DIFF
--- a/src-tauri/src/commands/extensions.rs
+++ b/src-tauri/src/commands/extensions.rs
@@ -84,21 +84,25 @@ fn resolve_extensions_dir(app_handle: &tauri::AppHandle) -> Option<PathBuf> {
 
     // Fall back to resource directory for built apps.
     // Tauri maps `../.build/extensions` (from bundle.resources) to `_up_/.build/extensions`.
+    //
+    // On Windows, `resource_dir()` may return a path with the `\\?\` extended-length
+    // prefix. This prefix breaks Bun's `require()` in the Extension Host, so we
+    // canonicalize with `dunce` to strip it — consistent with the CWD-based paths above.
     if let Ok(rd) = app_handle.path().resource_dir() {
         // Primary: packaged extensions in .build/extensions
         let packaged = rd.join("_up_/.build/extensions");
         if packaged.is_dir() {
-            return Some(packaged);
+            return Some(dunce::canonicalize(&packaged).unwrap_or(packaged));
         }
         // Legacy: direct extensions path (from older bundle.resources config)
         let up_dir = rd.join("_up_/extensions");
         if up_dir.is_dir() {
-            return Some(up_dir);
+            return Some(dunce::canonicalize(&up_dir).unwrap_or(up_dir));
         }
         // Also check direct path in case bundled differently
         let direct = rd.join("extensions");
         if direct.is_dir() {
-            return Some(direct);
+            return Some(dunce::canonicalize(&direct).unwrap_or(direct));
         }
     }
 


### PR DESCRIPTION
## Summary

On Windows, Tauri's `resource_dir()` may return paths with the `\\?\` extended-length prefix. This prefix breaks Bun's `require()` in the Extension Host, preventing built-in extensions (`git-base`, `github-authentication`, `Git`, `GitHub`) from activating in production builds.

This is the same class of issue fixed in #494 (commit d65214d6) for CWD-based paths, but the `resource_dir()` fallback paths (used in production/packaged builds) were missed.

## Related Issue

No existing issue — this is a follow-up fix for the partial resolution in #494.

## Changes

- Apply `dunce::canonicalize()` to all three `resource_dir()` fallback paths in `resolve_extensions_dir()`:
  - `_up_/.build/extensions` (packaged extensions)
  - `_up_/extensions` (legacy path)
  - `extensions` (direct path)
- Add documentation comment explaining why the canonicalization is needed

## How to Test

1. Build a production Windows binary (`cargo tauri build`)
2. Install and run the app
3. Verify that built-in extensions (Git, GitHub Authentication) activate successfully
4. Check that `app.log` no longer contains `Cannot find module '\\?\...'` errors