### PR TITLE
🚀 Release v0.22.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.2] - 2026-05-10
+
+### Fixed
+
+- Resolve TDZ error and hostname typo in ExtHost WebSocket server (#515)
+- Strip UNC path prefix from resource_dir extensions path for Bun compatibility
+
+### Changed
+
+- Replace Rust WebSocket relay with direct Bun WS server for ExtHost IPC (#513)
+- Cache product.json augmentation to skip redundant I/O on ExtHost spawn (#512)
+- Move ExtHost initialization to LifecyclePhase.Starting (#511)
+
 ## [0.22.1] - 2026-05-10
 
 ### Fixed

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-utils/schema.json",
   "productName": "VS Codeee",
   "mainBinaryName": "codeee",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "identifier": "com.vscodeee.app",
   "build": {
     "frontendDist": "../out",


### PR DESCRIPTION
## Summary

Release v0.22.2 — bug fixes and performance improvements for Extension Host IPC.

## Changes

### Fixed
- Resolve TDZ error and hostname typo in ExtHost WebSocket server (#515)
- Strip UNC path prefix from resource_dir extensions path for Bun compatibility

### Changed
- Replace Rust WebSocket relay with direct Bun WS server for ExtHost IPC (#513)
- Cache product.json augmentation to skip redundant I/O on ExtHost spawn (#512)
- Move ExtHost initialization to LifecyclePhase.Starting (#511)

## How to Test

1. Launch the application
2. Verify extension host starts correctly
3. Confirm no console window appears on Windows
4. Test extension activation and basic functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)